### PR TITLE
IMU example scripts

### DIFF
--- a/examples/sensors/emulate_imu/sim_and_integrate.py
+++ b/examples/sensors/emulate_imu/sim_and_integrate.py
@@ -1,0 +1,78 @@
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from visionsim.dataset import Metadata
+from visionsim.emulate.imu import emulate_imu, imu_integration
+from visionsim.interpolate.pose import pose_interp
+from visionsim.utils.pose import tform_camcoord_gl2bl
+
+""" Coordinate convention for both the 3D world and the image coordinate system:
+        +X: right
+        +Z: up
+        +Y: out of the image plane
+"""
+gravity_vector = np.array([0, 0, -9.8])  # m/s^2
+
+db_path = Path(__file__).parent / "transforms_800Hz.db"
+if not db_path.exists():
+    raise RuntimeError(f"transforms file {db_path} does not exist!")
+
+dataset = Metadata.from_path(db_path)
+true_poses_orig = np.array(dataset.poses)
+true_poses = np.array([tform_camcoord_gl2bl(T) for T in dataset.poses])
+init_pose = true_poses[0]
+
+dt = 1.0 / (dataset.fps * dataset.keyframe_scale)
+print(f"#poses: {len(true_poses)}, dt: {dt}")
+times = np.arange(len(true_poses)) * dt
+pose_spline = pose_interp(true_poses, times)
+_, vel_w = pose_spline(times, order=1)
+init_vel_c = true_poses[0][:3, :3].T @ vel_w[0]
+print(f"initial velocity in camera frame: {str(init_vel_c)}")
+
+num_trajectory_samples = 10
+acc_data, gyro_data = [], []
+noise_mult = 1
+std_acc = 8e-3 * noise_mult
+std_bias_acc = 5.5e-5 * noise_mult
+std_gyro = 1.2e-3 * noise_mult
+std_bias_gyro = 2e-5 * noise_mult
+integrated_trajectories = []
+for _ in range(num_trajectory_samples):
+    imu_data = list(
+        emulate_imu(
+            true_poses_orig,
+            dt=dt,
+            gravity=gravity_vector,
+            std_acc=std_acc,
+            std_bias_acc=std_bias_acc,
+            std_gyro=std_gyro,
+            std_bias_gyro=std_bias_gyro,
+        )
+    )
+    acc_data.append([d["acc_reading"] for d in imu_data])
+    gyro_data.append([d["gyro_reading"] for d in imu_data])
+    integrated_trajectories.append(
+        np.array(
+            list(
+                imu_integration(
+                    acc_pos=acc_data[-1],
+                    vel_ang=gyro_data[-1],
+                    pose_init=init_pose,
+                    vel_init=init_vel_c,
+                    gravity=gravity_vector,
+                    dt=dt,
+                )
+            )
+        )
+    )
+
+# Plot the true and estimated trajectories (on XY plane)
+ax = plt.subplot(1, 1, 1)
+ax.plot(*true_poses[:, :2, -1].T, color="k", label="Ground Truth Trajectory")
+for tr in integrated_trajectories:
+    ax.plot(*tr[:, :2, -1].T)
+ax.legend()
+plt.savefig("integrated_trajectories.pdf")

--- a/examples/sensors/emulate_imu/sim_and_integrate.py
+++ b/examples/sensors/emulate_imu/sim_and_integrate.py
@@ -1,3 +1,5 @@
+import argparse
+import itertools
 from pathlib import Path
 
 import matplotlib.pyplot as plt
@@ -8,71 +10,152 @@ from visionsim.emulate.imu import emulate_imu, imu_integration
 from visionsim.interpolate.pose import pose_interp
 from visionsim.utils.pose import tform_camcoord_gl2bl
 
-""" Coordinate convention for both the 3D world and the image coordinate system:
-        +X: right
-        +Z: up
-        +Y: out of the image plane
-"""
-gravity_vector = np.array([0, 0, -9.8])  # m/s^2
+# Coordinate convention for both the 3D world and the image coordinate system:
+#   +X: right
+#   +Z: up
+#   +Y: out of the image plane
+GRAVITY = np.array([0, 0, -9.8])  # m/s^2
 
-db_path = Path(__file__).parent / "transforms_800Hz.db"
-if not db_path.exists():
-    raise RuntimeError(f"transforms file {db_path} does not exist!")
 
-dataset = Metadata.from_path(db_path)
-true_poses_orig = np.array(dataset.poses)
-true_poses = np.array([tform_camcoord_gl2bl(T) for T in dataset.poses])
-init_pose = true_poses[0]
+AXIS_IDX = {"x": 0, "y": 1, "z": 2}
+AXIS_LABELS = {0: "X", 1: "Y", 2: "Z"}
+VALID_PLANES = ["".join(p) for p in itertools.permutations("xyz", 2)]
 
-dt = 1.0 / (dataset.fps * dataset.keyframe_scale)
-print(f"#poses: {len(true_poses)}, dt: {dt}")
-times = np.arange(len(true_poses)) * dt
-pose_spline = pose_interp(true_poses, times)
-_, vel_w = pose_spline(times, order=1)
-init_vel_c = true_poses[0][:3, :3].T @ vel_w[0]
-print(f"initial velocity in camera frame: {str(init_vel_c)}")
 
-num_trajectory_samples = 10
-acc_data, gyro_data = [], []
-noise_mult = 1
-std_acc = 8e-3 * noise_mult
-std_bias_acc = 5.5e-5 * noise_mult
-std_gyro = 1.2e-3 * noise_mult
-std_bias_gyro = 2e-5 * noise_mult
-integrated_trajectories = []
-for _ in range(num_trajectory_samples):
-    imu_data = list(
-        emulate_imu(
-            true_poses_orig,
-            dt=dt,
-            gravity=gravity_vector,
-            std_acc=std_acc,
-            std_bias_acc=std_bias_acc,
-            std_gyro=std_gyro,
-            std_bias_gyro=std_bias_gyro,
-        )
+def sim_and_integrate(
+    db_path: Path,
+    start: int = 0,
+    end: int | None = None,
+    interp_factor: int = 16,
+    num_samples: int = 10,
+    noise_mult: float = 25.0,
+    plot_path: Path | None = Path("integrated_trajectories.pdf"),
+    plane: str = "xy",
+    save_path: Path | None = None,
+):
+    # Load dataset and get poses
+    dataset = Metadata.from_path(db_path)
+    dt = 1.0 / (dataset.fps * dataset.keyframe_scale)
+    poses_c = np.array(dataset.poses)[start:end]
+    num_poses = len(poses_c)
+
+    # Convert to world coordinate system
+    poses_w = np.array([tform_camcoord_gl2bl(T) for T in poses_c])
+
+    # Interpolate poses to increase temporal resolution, the render might be 100fps, but an IMU can be 1000Hz
+    interp_dt = dt / interp_factor
+    times = np.arange(num_poses) * dt
+    interp_times = np.arange(num_poses * interp_factor) * interp_dt
+    interp_poses_c = pose_interp(poses_c, times)(interp_times)
+    interp_poses_w = pose_interp(poses_w, times)(interp_times)
+    _, interp_velocities_w = pose_interp(poses_w, times)(interp_times, order=1)
+
+    # Get initial velocity in camera frame
+    init_vel_c = interp_poses_w[0][:3, :3].T @ interp_velocities_w[0]
+    print(
+        f"Found {num_poses} poses, which were interpolated by a factor of {interp_factor} (dt: {dt:.4f} -> {interp_dt:.4f})"
     )
-    acc_data.append([d["acc_reading"] for d in imu_data])
-    gyro_data.append([d["gyro_reading"] for d in imu_data])
-    integrated_trajectories.append(
-        np.array(
-            list(
-                imu_integration(
-                    acc_pos=acc_data[-1],
-                    vel_ang=gyro_data[-1],
-                    pose_init=init_pose,
-                    vel_init=init_vel_c,
-                    gravity=gravity_vector,
-                    dt=dt,
+    print(f"Initial velocity in camera frame: {init_vel_c}")
+
+    # IMU noise parameters, scaled by noise_mult from defaults for simplicity
+    std_acc = 8e-3 * noise_mult
+    std_bias_acc = 5.5e-5 * noise_mult
+    std_gyro = 1.2e-3 * noise_mult
+    std_bias_gyro = 2e-5 * noise_mult
+    integrated_trajectories = []
+
+    # Emulate IMU data and integrate trajectories
+    for _ in range(num_samples):
+        imu_data = list(
+            emulate_imu(
+                interp_poses_c,  #  <------- Poses in camera frame!!
+                dt=interp_dt,
+                gravity=GRAVITY,
+                std_acc=std_acc,
+                std_bias_acc=std_bias_acc,
+                std_gyro=std_gyro,
+                std_bias_gyro=std_bias_gyro,
+            )
+        )
+
+        integrated_trajectories.append(
+            np.array(
+                list(
+                    imu_integration(
+                        acc_pos=np.array([d["acc_reading"] for d in imu_data]),
+                        vel_ang=np.array([d["gyro_reading"] for d in imu_data]),
+                        pose_init=interp_poses_w[0],  #  <------- Pose in world frame!!
+                        vel_init=init_vel_c,  #  <------- Velocity in camera frame!!
+                        gravity=GRAVITY,
+                        dt=interp_dt,
+                    )
                 )
             )
         )
-    )
 
-# Plot the true and estimated trajectories (on XY plane)
-ax = plt.subplot(1, 1, 1)
-ax.plot(*true_poses[:, :2, -1].T, color="k", label="Ground Truth Trajectory")
-for tr in integrated_trajectories:
-    ax.plot(*tr[:, :2, -1].T)
-ax.legend()
-plt.savefig("integrated_trajectories.pdf")
+    # Down-interpolate to same number of poses as original
+    trajectories = []
+    for tr in integrated_trajectories:
+        tr_interp = pose_interp(tr, interp_times)(times)
+        trajectories.append(tr_interp)
+    if save_path is not None:
+        np.save(save_path, np.array(trajectories))
+        print(f"Trajectories saved to {save_path}")
+
+    # Plot the true and estimated trajectories
+    if plot_path is not None:
+        i, j = tuple(AXIS_IDX[i] for i in plane.lower())
+        xlabel, ylabel = AXIS_LABELS[i], AXIS_LABELS[j]
+        gt_positions = poses_w[:, :3, -1]  # use original (down-sampled) ground truth
+        fig, ax = plt.subplots(1, 1)
+        ax.plot(gt_positions[:, i], gt_positions[:, j], color="k", label="Ground Truth")
+        for tr in trajectories:
+            positions = tr[:, :3, -1]
+            ax.plot(positions[:, i], positions[:, j])
+        ax.set_xlabel(xlabel)
+        ax.set_ylabel(ylabel)
+        ax.set_title(f"IMU-Integrated vs. Ground Truth Trajectories ({plane.upper()} Plane)")
+        ax.legend()
+        ax.set_aspect("equal")
+        fig.savefig(plot_path)
+        print(f"Plot saved to {plot_path}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Simulate and integrate IMU data.")
+    parser.add_argument(
+        "--db-path",
+        type=Path,
+        default=Path(__file__).parent.parent.parent.parent / "transforms.db",
+        help="Path to transforms.db or json",
+    )
+    parser.add_argument("--start", type=int, default=0, help="Start pose index")
+    parser.add_argument("--end", type=int, default=None, help="End pose index (exclusive)")
+    parser.add_argument("--interp-factor", type=int, default=16, help="Interpolation factor")
+    parser.add_argument("--num-samples", type=int, default=10, help="Number of trajectories to emulate")
+    parser.add_argument("--noise-mult", type=float, default=5.0, help="Noise multiplier for all noise parameters")
+    parser.add_argument(
+        "--plot-path", type=Path, default=Path("integrated_trajectories.pdf"), help="Save plot to this path"
+    )
+    parser.add_argument(
+        "--plane", default="xy", choices=VALID_PLANES, help="Plane to plot trajectories on (e.g. xy, xz, zx)"
+    )
+    parser.add_argument(
+        "--save-path",
+        type=Path,
+        default=None,
+        help="Save down-interpolated trajectories as .npy to this path (omit to skip)",
+    )
+    args = parser.parse_args()
+
+    sim_and_integrate(
+        db_path=args.db_path,
+        start=args.start,
+        end=args.end,
+        interp_factor=args.interp_factor,
+        num_samples=args.num_samples,
+        noise_mult=args.noise_mult,
+        plot_path=args.plot_path,
+        plane=args.plane,
+        save_path=args.save_path,
+    )

--- a/examples/sensors/emulate_imu/sim_and_integrate.py
+++ b/examples/sensors/emulate_imu/sim_and_integrate.py
@@ -51,11 +51,11 @@ def sim_and_integrate(
     _, interp_velocities_w = pose_interp(poses_w, times)(interp_times, order=1)
 
     # Get initial velocity in camera frame
-    init_vel_c = interp_poses_w[0][:3, :3].T @ interp_velocities_w[0]
+    init_vel_w = interp_velocities_w[0]
     print(
         f"Found {num_poses} poses, which were interpolated by a factor of {interp_factor} (dt: {dt:.4f} -> {interp_dt:.4f})"
     )
-    print(f"Initial velocity in camera frame: {init_vel_c}")
+    print(f"Initial velocity in world frame: {init_vel_w}")
 
     # IMU noise parameters, scaled by noise_mult from defaults for simplicity
     std_acc = 8e-3 * noise_mult
@@ -85,7 +85,7 @@ def sim_and_integrate(
                         acc_pos=np.array([d["acc_reading"] for d in imu_data]),
                         vel_ang=np.array([d["gyro_reading"] for d in imu_data]),
                         pose_init=interp_poses_w[0],  #  <------- Pose in world frame!!
-                        vel_init=init_vel_c,  #  <------- Velocity in camera frame!!
+                        vel_init=init_vel_w,  #  <------- Velocity in world frame!!
                         gravity=GRAVITY,
                         dt=interp_dt,
                     )

--- a/examples/sensors/emulate_imu/sim_and_integrate.py
+++ b/examples/sensors/emulate_imu/sim_and_integrate.py
@@ -36,21 +36,20 @@ def sim_and_integrate(
     # Load dataset and get poses
     dataset = Metadata.from_path(db_path)
     dt = 1.0 / (dataset.fps * dataset.keyframe_scale)
-    poses_c = np.array(dataset.poses)[start:end]
-    num_poses = len(poses_c)
+    poses = np.array(dataset.poses)[start:end]
+    num_poses = len(poses)
 
-    # Convert to world coordinate system
-    poses_w = np.array([tform_camcoord_gl2bl(T) for T in poses_c])
+    # Convert to Blender's coordinate convention (+Z up) for both world and camera frames
+    poses = np.array([tform_camcoord_gl2bl(T) for T in poses])
 
     # Interpolate poses to increase temporal resolution, the render might be 100fps, but an IMU can be 1000Hz
     interp_dt = dt / interp_factor
     times = np.arange(num_poses) * dt
     interp_times = np.arange(num_poses * interp_factor) * interp_dt
-    interp_poses_c = pose_interp(poses_c, times)(interp_times)
-    interp_poses_w = pose_interp(poses_w, times)(interp_times)
-    _, interp_velocities_w = pose_interp(poses_w, times)(interp_times, order=1)
+    interp_poses = pose_interp(poses, times)(interp_times)
+    _, interp_velocities_w = pose_interp(poses, times)(interp_times, order=1)
 
-    # Get initial velocity in camera frame
+    # Get initial velocity in world frame
     init_vel_w = interp_velocities_w[0]
     print(
         f"Found {num_poses} poses, which were interpolated by a factor of {interp_factor} (dt: {dt:.4f} -> {interp_dt:.4f})"
@@ -68,7 +67,7 @@ def sim_and_integrate(
     for _ in range(num_samples):
         imu_data = list(
             emulate_imu(
-                interp_poses_c,  #  <------- Poses in camera frame!!
+                interp_poses,
                 dt=interp_dt,
                 gravity=GRAVITY,
                 std_acc=std_acc,
@@ -84,7 +83,7 @@ def sim_and_integrate(
                     imu_integration(
                         acc_pos=np.array([d["acc_reading"] for d in imu_data]),
                         vel_ang=np.array([d["gyro_reading"] for d in imu_data]),
-                        pose_init=interp_poses_w[0],  #  <------- Pose in world frame!!
+                        pose_init=interp_poses[0],
                         vel_init=init_vel_w,  #  <------- Velocity in world frame!!
                         gravity=GRAVITY,
                         dt=interp_dt,
@@ -106,7 +105,7 @@ def sim_and_integrate(
     if plot_path is not None:
         i, j = tuple(AXIS_IDX[i] for i in plane.lower())
         xlabel, ylabel = AXIS_LABELS[i], AXIS_LABELS[j]
-        gt_positions = poses_w[:, :3, -1]  # use original (down-sampled) ground truth
+        gt_positions = poses[:, :3, -1]  # use original (down-sampled) ground truth
         fig, ax = plt.subplots(1, 1)
         ax.plot(gt_positions[:, i], gt_positions[:, j], color="k", label="Ground Truth")
         for tr in trajectories:

--- a/visionsim/cli/emulate.py
+++ b/visionsim/cli/emulate.py
@@ -357,6 +357,7 @@ def imu(
 
     from visionsim.dataset import Metadata
     from visionsim.emulate.imu import emulate_imu
+    from visionsim.utils.pose import tform_camcoord_gl2bl
 
     if output_file and output_file.exists() and not force:
         raise FileExistsError("Output file already exists.")
@@ -369,6 +370,8 @@ def imu(
     init_bias_acc_ = np.array(ast.literal_eval(init_bias_acc))
     init_bias_gyro_ = np.array(ast.literal_eval(init_bias_gyro))
     poses = Metadata.from_path(input_dir).poses
+    # fix coordinate convention in the pose matrices
+    poses = [tform_camcoord_gl2bl(p) for p in poses]
 
     data_gen = emulate_imu(
         poses,

--- a/visionsim/emulate/imu.py
+++ b/visionsim/emulate/imu.py
@@ -7,7 +7,6 @@ import numpy.typing as npt
 from scipy.spatial.transform import Rotation as R
 
 from visionsim.interpolate.pose import pose_interp
-from visionsim.utils.pose import tform_camcoord_gl2bl
 
 
 def imu_integration(
@@ -152,9 +151,6 @@ def emulate_imu(
     std_gyro_discrete = std_gyro / (dt**0.5)
     std_bias_acc_discrete = std_bias_acc * (dt**0.5)
     std_bias_gyro_discrete = std_bias_gyro * (dt**0.5)
-
-    # fix coordinate convention in the pose matrices
-    poses = [tform_camcoord_gl2bl(p) for p in poses]
 
     # get angular velocity (in world coords) and positional acceleration (in camera space)
     times = np.arange(len(poses)) * dt

--- a/visionsim/emulate/imu.py
+++ b/visionsim/emulate/imu.py
@@ -7,42 +7,7 @@ import numpy.typing as npt
 from scipy.spatial.transform import Rotation as R
 
 from visionsim.interpolate.pose import pose_interp
-
-
-def _tform_camcoord_gl2bl(T_bl_gl: npt.NDArray) -> npt.NDArray:
-    """Fix the coordinate convention in the camera pose matrix in transforms.json.
-
-    The coordinate convention for the camera view seems to be the OpenGL one:
-        +x  = right
-        +y  = up
-        +z  = out from the scene,
-    while the coordinate convention in Blender seems to be:
-        +x  = right
-        +y  = into the scene/viewing direction
-        +z  = up,
-    and the matrix in transforms.json appears to directly map from OpenGL
-    coordinate system to Blender's, so we can not treat it as an [R | t] form.
-
-    In turn, we also need to be careful about interpreting the pose
-    "derivatives" we get from directly using that matrix, such as when
-    simulating IMU data.
-
-    To remove this confusion, here we convert the matrix to use Blender's 3D
-    coordinate convention for the camera too.
-
-    Note:
-        For more info, see this `PR <https://github.com/wision-lab/visionsim/pull/24>`_ and also
-        `this one <https://github.com/wision-lab/visionsim/pull/21>`_.
-
-    Args:
-        T_bl_gl (np.NDArray): 4 x 4 matrix representing camera pose, but also mapping directly
-                            from OpenGL coordinate system to Blender
-
-    Returns:
-        T_bl_bl (np.NDArray): also 4 x 4, but represents only pose in Blender's convention
-    """
-    M_gl_bl = np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, -1.0, 0.0, 0.0], [0.0, 0.0, 0.0, 1.0]])
-    return T_bl_gl @ M_gl_bl
+from visionsim.utils.pose import tform_camcoord_gl2bl
 
 
 def imu_integration(
@@ -188,12 +153,12 @@ def emulate_imu(
     std_bias_gyro_discrete = std_bias_gyro * (dt**0.5)
 
     # fix coordinate convention in the pose matrices
-    poses = [_tform_camcoord_gl2bl(p) for p in poses]
+    poses = [tform_camcoord_gl2bl(p) for p in poses]
 
     # get angular velocity (in world coords) and positional acceleration (in camera space)
     times = np.arange(len(poses)) * dt
     pose_spline = pose_interp(poses, times)
-    vel_ang_w, _ = pose_spline(times, order=1)
+    vel_ang_c, _ = pose_spline(times, order=1)
     _, acc_pos_w = pose_spline(times, order=2)
     acc_pos_c = np.array([T_wc[:3, :3].T @ a for T_wc, a in zip(poses, acc_pos_w)])
 
@@ -202,7 +167,7 @@ def emulate_imu(
     bias_gyro = init_bias_gyro
     t = 0.0
 
-    for T_wc, a_pos_c, v_ang_w in zip(poses, acc_pos_c, vel_ang_w):
+    for T_wc, a_pos_c, v_ang_c in zip(poses, acc_pos_c, vel_ang_c):
         a_pos_w = (T_wc[:3, :3] @ a_pos_c).flatten()
         # IMU is assumed collocated with the camera
         a_pos_IMU = T_wc[:3, :3].transpose() @ (a_pos_w - gravity)
@@ -217,7 +182,7 @@ def emulate_imu(
 
         bias_gyro_next = bias_gyro + std_bias_gyro_discrete * rng.standard_normal((3,))
         sim_v_ang = (
-            v_ang_w
+            v_ang_c
             + 0.5 * (bias_gyro + bias_gyro_next)
             + ((((std_gyro_discrete**2) + (1 / 12) * (std_bias_gyro_discrete**2)) ** 0.5) * rng.standard_normal((3,)))
         )

--- a/visionsim/emulate/imu.py
+++ b/visionsim/emulate/imu.py
@@ -38,7 +38,8 @@ def imu_integration(
                 Maximum-a-Posteriori Estimation". <https://www.roboticsproceedings.org/rss11/p06.pdf>`_
     """
     pose = np.eye(4) if pose_init is None else np.array(pose_init)
-    vel_pos = np.zeros((3,)) if vel_init is None else np.array(vel_init)
+    vel_pos_w = np.zeros((3,)) if vel_init is None else np.array(vel_init)
+    vel_pos = pose[:3,:3].T @ vel_pos_w   # convert to camera frame
     gravity = np.array([0, 0, -9.8]) if gravity is None else np.array(gravity)
 
     for ap, va in zip(acc_pos, vel_ang):

--- a/visionsim/utils/pose.py
+++ b/visionsim/utils/pose.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+
+
+def tform_camcoord_gl2bl(T_bl_gl: npt.NDArray) -> npt.NDArray:
+    """Fix the coordinate convention in the camera pose matrix in transforms.json.
+
+    The coordinate convention for the camera view seems to be the OpenGL one:
+        +x  = right
+        +y  = up
+        +z  = out from the scene,
+    while the coordinate convention in Blender seems to be:
+        +x  = right
+        +y  = into the scene/viewing direction
+        +z  = up,
+    and the matrix in transforms.json appears to directly map from OpenGL
+    coordinate system to Blender's, so we can not treat it as an [R | t] form.
+
+    In turn, we also need to be careful about interpreting the pose
+    "derivatives" we get from directly using that matrix, such as when
+    simulating IMU data.
+
+    To remove this confusion, here we convert the matrix to use Blender's 3D
+    coordinate convention for the camera too.
+
+    Note:
+        For more info, see this `PR <https://github.com/wision-lab/visionsim/pull/24>`_ and also
+        `this one <https://github.com/wision-lab/visionsim/pull/21>`_.
+
+    Args:
+        T_bl_gl (np.NDArray): 4 x 4 matrix representing camera pose, but also mapping directly
+                            from OpenGL coordinate system to Blender
+
+    Returns:
+        T_bl_bl (np.NDArray): also 4 x 4, but represents only pose in Blender's convention
+    """
+    M_gl_bl = np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, -1.0, 0.0, 0.0], [0.0, 0.0, 0.0, 1.0]])
+    return T_bl_gl @ M_gl_bl


### PR DESCRIPTION
Example script for IMU simulation. Have tested this with a `transforms.db` file generated for `kitchen2` with keyframe multiplier 16, so effectively an 800 Hz scene. Setting `noise_mult` to a small number (0.001) results in an integrated trajectory very close to the true one.

I can add the `transforms.db` file to this branch too; I wasn't sure if we keep those in the repo (using LFS, perhaps), or separate. Let me know what you prefer.