### PR TITLE
Add thermal modality simulation: FEM heat solver + temperature/radiance render passes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,6 +112,9 @@ TODO.md
 NOTES.md
 *.pkl
 *.DS_store
+# Thermal FEM solve cache (prepare_thermal writes `<blend>.heatsim/` next to the source blend)
+*.heatsim/
+**/*.heatsim/
 scenes/
 data/
 cache/
@@ -122,3 +125,8 @@ examples/quickstart/
 docs/source/_build/
 examples/assets/
 uv.lock
+
+# Local planning / working docs — preserved on the heatsim-devdocs branch, kept out of heatsim
+docs/superpowers/
+docs/thermal_integration/
+.superpowers/

--- a/assets/thermal/bathroom1.thermal.json
+++ b/assets/thermal/bathroom1.thermal.json
@@ -1,0 +1,274 @@
+{
+  "schema_version": 1,
+  "scene": "bathroom1.blend",
+  "generated_by": "drafted with model assistance from a dump of the scene's materials (node graphs, slot areas, emission), then reviewed and corrected against the blend",
+  "defaults": {},
+  "materials": {
+    "Alu bross armoire sdb": {
+      "preset": "aluminium",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.75,
+      "reason": "French 'alu brossé armoire sdb' = brushed aluminium bathroom-cabinet (door object 'porte arm sdb.002'); texture pulido2.jpg ('pulido' = polished); Diffuse/Glossy mix (0.5) with near-white glossy component (roughness 0.45) matches brushed mill-finish aluminium."
+    },
+    "Alu brosse": {
+      "preset": "aluminium",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.8,
+      "reason": "French 'alu brossé' = brushed aluminium; used on 'motif radiateur.001' (radiator grille/motif) and a cylinder; pure Glossy BSDF, near-white (0.92), roughness 0.32 -- matches brushed aluminium bars."
+    },
+    "Bois porte.003": {
+      "preset": "wood",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.55,
+      "reason": "French 'bois porte' = wood door/frame; used on Cube.1120, which also carries 'verre lampe sdb' (glass) -- i.e. a light fixture with a wooden frame and glass shade. No wood texture is present (flat grey 0.8 diffuse), so the name is the main evidence and confidence is moderate."
+    },
+    "CarPaint_flip 1.001": {
+      "preset": "metal_painted",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.4,
+      "reason": "Used on 'robinet.001' (a tap/faucet whose body otherwise uses 'chrome robinet'); this slot is a small pure-Diffuse red patch (0.72,0,0), most likely a painted hot-water indicator accent on the metal tap. 'CarPaint' names a paint/coating, so metal_painted (coated metal) is the closest preset; low confidence since the exact part is not identifiable."
+    },
+    "Cardboard": {
+      "preset": "paper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.85,
+      "reason": "Explicit name 'Cardboard', used on the 'Toilet paper' object (the roll's cardboard core, diffuse brown 0.58/0.43/0.25); the preset library has no dedicated cardboard entry, so 'paper' (paper, card, books...) is the closest match."
+    },
+    "Glass_CG001.003": {
+      "preset": "glass",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.9,
+      "reason": "Name says Glass; Glass BSDF node, IOR 1.45 (matches soda-lime glass), roughness 0.0; used on two cylinder objects (small glass fixture parts)."
+    },
+    "Glass_Head light .001": {
+      "preset": "glass",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.85,
+      "reason": "Name 'Glass_Head light' = glass of a cabinet head-light; Glass BSDF, IOR 1.45; shares object 'porte arm sdb.002' with the brushed-aluminium cabinet door, consistent with a built-in light fixture on the cabinet."
+    },
+    "Metal_Bling chrome": {
+      "preset": "stainless_steel",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.5,
+      "reason": "Name says 'bling chrome' (shiny chrome accessory); Glossy BSDF, near-white (1.0), roughness 0.55 (semi-polished, not a perfect mirror); no dedicated chrome preset so stainless_steel (fittings) is used per guidance; object is a generically-named imported cylinder so the exact part is unclear."
+    },
+    "Metal_brass": {
+      "preset": "copper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.6,
+      "reason": "Name says brass; used on 'motif radiateur.001' (radiator decorative motif) alongside brushed-aluminium bars; Diffuse colour (0.68,0.54,0.44) is brass-toned. No brass preset exists; copper (closest copper-alloy analogue, as used for 'bronce' in kitchen1.thermal.json) is the nearest fit."
+    },
+    "Metal_goldleaf.002": {
+      "preset": "metal_painted",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.45,
+      "reason": "Name says gold leaf (thin decorative gilt coating over a substrate, object 'Plane.008'); Diffuse gold colour (0.8,0.78,0.28) mixed 50/50 with a glossy component. No gold preset exists; treated as a coated/painted metal finish per guidance rather than a solid conductive metal, since gold leaf is a coating, not bulk metal."
+    },
+    "Other_shinyplasti.002": {
+      "preset": "pvc",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.85,
+      "reason": "Name explicitly says 'shiny plastic'; pure Diffuse BSDF, deep blue (0,0,0.85); pvc is the generic rigid-plastic preset."
+    },
+    "Prise electrique": {
+      "preset": "pvc",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.8,
+      "reason": "French 'prise électrique' = electrical outlet; near-white Diffuse (0.95) with a small glossy highlight -- typical of a white plastic wall-outlet cover plate."
+    },
+    "ToilCeramic": {
+      "preset": "porcelain",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.75,
+      "reason": "Used by 'baignoire' (bathtub), 'lavabo.000' (basin) and 'sdb cuvette wc' (toilet bowl) -- the bathroom's vitreous-china sanitaryware. Diffuse near-white with a slight blue tint (0.92,0.91,1.0) plus a glossy glaze component (roughness 0.26). Although the material is literally named 'Ceramic', real bath/sink/toilet fixtures are vitrified porcelain, and the porcelain preset explicitly lists 'basins' -- chosen over the generic ceramic (tile/pottery) preset for that reason."
+    },
+    "armoire wc": {
+      "preset": "pvc",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.45,
+      "reason": "French 'armoire wc' = WC cabinet; used on the cabinet body 'armoire sdb.002' and several small hardware cylinders (shared with 'chrome robinet' on the same objects, i.e. chrome hardware + a painted/laminate body). Near-white Diffuse (0.93) and a fully rough Glossy (roughness 1.0) suggest a matte painted or laminate cabinet surface; pvc used as the generic coated-panel default. Could plausibly be painted wood instead -- genuinely ambiguous."
+    },
+    "black": {
+      "preset": "pvc",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.45,
+      "reason": "Generic pure-black Diffuse BSDF (0,0,0); used on small parts of 'Tube.001' (shared with 'chrome robinet', i.e. a black end-cap/grommet on chrome pipework) and 'thermostat.002' (shared with 'thermostat', i.e. the black dial/knob). No texture or name detail beyond colour; pvc used as the generic small-plastic-part default -- could equally be rubber."
+    },
+    "black radiateur": {
+      "preset": "metal_painted",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.7,
+      "reason": "French 'black radiateur' = black radiator; used on 'Cylinder.190' (radiator body); Glossy BSDF, black (0,0,0), roughness 0.55 -- a painted-steel radiator body, matching the metal_painted preset for coated metal."
+    },
+    "blend-a-med": {
+      "preset": "pvc",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.6,
+      "reason": "Texture 'blend-a-med.jpg' is the label of a real toothpaste brand (Blend-a-med); the tube body is a plastic/laminate cosmetic-product container, matched to the generic pvc preset."
+    },
+    "capuchon tube": {
+      "preset": "pvc",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.9,
+      "reason": "French 'capuchon tube' = tube cap; used on object 'Cone01_Plastic ' whose own name says Plastic; Diffuse/Glossy mix, blue-tinted (0.63,0.64,0.8)."
+    },
+    "carrelage sol": {
+      "preset": "ceramic",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.95,
+      "reason": "French 'carrelage sol' = floor tile; texture 'carrelage sol3.jpg'; glossy glaze layer (roughness 0.26) over the diffuse texture; classic glazed ceramic floor tile, covering ~8.5 m^2 of floor."
+    },
+    "chrome robinet": {
+      "preset": "stainless_steel",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.65,
+      "reason": "French 'chrome robinet' = chrome tap/fitting; used on nearly every chrome hardware part in the scene (taps 'robinet.000/.001/.002', drain 'siphon sdb', shower tray 'bac douche.000', bathtub 'baignoire.000', screws, tubes); pure Glossy BSDF, near-white/blue (0.93,0.95,1.0), roughness 0.0 (mirror finish). No dedicated chrome preset exists; stainless_steel chosen per guidance ('prefer stainless_steel for ... sanitaryware fittings') even though the roughness is closer to a mirror-polished finish."
+    },
+    "couv linge sdb": {
+      "preset": "fabric",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.6,
+      "reason": "French 'couv(re) linge sdb' = bathroom laundry/linen cover; used on 'Plane.013'; a Wave-texture-driven shader mix over brown Diffuse/Glossy colours (0.56/0.46/0.28) suggesting a woven or rippled cloth/wicker cover; fabric is the closest preset."
+    },
+    "lamp ext sdb": {
+      "preset": null,
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.3,
+      "reason": "THIS IS THE SCENE'S SOLE EMISSIVE MATERIAL / LIGHT SOURCE: it is the only material in the file with an Emission shader node (warm-white colour 1.0/0.98/0.82, strength 1.2) and the scene has zero light objects, so all illumination comes from this material. It is applied to a single flat 'Plane' object; measured world-space area is ~100 m^2 (10 m x 10 m, not the ~4 m^2 suggested), consistent with a large offstage backlight/'daylight portal'-style proxy panel (French name = 'exterior bathroom lamp') rather than a real room surface. It is not a physical building material, so no thermal preset honestly applies -- left null rather than guessing. Per the hard constraint, role is still FEM_PARTICIPANT and dirichlet_K is null (no pinned sources), even though this is the light source."
+    },
+    "miroir bord": {
+      "preset": "glass",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.5,
+      "reason": "French 'miroir bord' = mirror edge/border; same object ('miroir sdb') as the 'mirroir' material, i.e. the beveled edge of the bathroom mirror. Glossy BSDF, white, roughness 0.71 (frosted, unlike the perfectly specular main mirror face) -- consistent with an unpolished glass edge; glass chosen as the substrate material."
+    },
+    "mirroir": {
+      "preset": "glass",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.65,
+      "reason": "'Mirroir' (misspelling of French 'miroir' = mirror); object 'miroir sdb', the bathroom mirror explicitly expected per the task brief. Pure Glossy BSDF, white, roughness 0.0 (perfect mirror finish). A mirror's thermal behaviour is dominated by its glass substrate (with a thin metallic backing not separately modelled), so glass is used rather than a metal preset."
+    },
+    "nivea capuchon": {
+      "preset": "pvc",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.75,
+      "reason": "French 'nivea capuchon' = Nivea (real skincare brand) bottle cap, on object 'apres rasage' (aftershave); dark-blue Diffuse (0.03,0.02,0.61) plastic cap; pvc preset."
+    },
+    "nivea decalc": {
+      "preset": "pvc",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.45,
+      "reason": "French 'décalc(omanie)' = decal/label; texture 'nivea2.JPG' is a printed product label on the same 'apres rasage' aftershave bottle; treated as a thin plastic/printed-film label on the bottle, matched to pvc; could plausibly be paper instead."
+    },
+    "nivea flacon": {
+      "preset": "pvc",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.85,
+      "reason": "French 'flacon' = bottle; the main body of the 'apres rasage' aftershave bottle; near-white Diffuse (0.95) plastic bottle, pvc preset."
+    },
+    "paper": {
+      "preset": "paper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.95,
+      "reason": "Explicit name 'paper'; used on the 'Toilet paper' object's sheet (paired with the 'Cardboard' core material); white Diffuse (1.0) plus a slight glossy sheen."
+    },
+    "plastic douche": {
+      "preset": "pvc",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.85,
+      "reason": "French 'plastic douche' = shower plastic, explicit name; cream-coloured Diffuse/Glossy mix on shower-enclosure panel parts (Cube.1149/.1150); pvc preset."
+    },
+    "plastic sanitaire": {
+      "preset": "pvc",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.85,
+      "reason": "French 'plastic sanitaire' = sanitary plastic, explicit name; used across many small sanitaryware plastic parts (toilet seat/fittings: Circle.018, Torus.001/.011, Plane.001/.006/.011); near-white Diffuse/Glossy; pvc preset."
+    },
+    "radiateur": {
+      "preset": "metal_painted",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.75,
+      "reason": "French 'radiateur' = radiator; used on 'motif radiateur.001' alongside the brushed-aluminium bars and brass accents -- this slot is the painted body/frame (cream Diffuse 0.8/0.75/0.64, semi-glossy roughness 0.32); metal_painted preset for the coated-steel radiator body."
+    },
+    "sdb mur": {
+      "preset": "ceramic",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.9,
+      "reason": "French 'sdb mur' = bathroom wall; texture 'carrelage mur4.jpg' = wall tile 4; glazed glossy layer over the tile diffuse texture. This is the single largest material in the scene by area (~48 m^2), consistent with the main wall tiling."
+    },
+    "sdb mur deco": {
+      "preset": "ceramic",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.9,
+      "reason": "French 'sdb mur déco' = bathroom decorative wall (tile); texture 'carrelage sdb deco2.jpg' = decorative bathroom tile; same glazed-tile shader structure as 'sdb mur'."
+    },
+    "sdb verre depoli": {
+      "preset": "glass",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.9,
+      "reason": "French 'verre dépoli' = frosted/ground glass; Glass BSDF, IOR 1.45, roughness 0.32 (frosted, vs. 0.0 for the other clear-glass materials); used on Cube.1121, likely a frosted shower door or window pane."
+    },
+    "serviette wc": {
+      "preset": "fabric",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.9,
+      "reason": "French 'serviette wc' = WC hand towel; explicit name and a single flat plane (Plane.067); purple-blue Diffuse (0.3,0.225,0.62) matches a dyed cotton towel; fabric preset."
+    },
+    "tapis sdb": {
+      "preset": "carpet",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.9,
+      "reason": "French 'tapis sdb' = bathroom rug/bath mat; texture 'tapis sdb3.jpg'; used on two floor planes (Plane.009/.010); carpet is the closest preset for a bath mat."
+    },
+    "thermostat": {
+      "preset": "pvc",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.7,
+      "reason": "Explicit name 'thermostat' (heating control unit, object 'thermostat.002', paired with the 'black' dial material); near-white Diffuse (0.905) housing with a rough glossy sheen (0.71); typical white plastic wall-thermostat housing, pvc preset."
+    },
+    "verre lampe sdb": {
+      "preset": "glass",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.85,
+      "reason": "French 'verre lampe sdb' = bathroom lamp glass; Glass BSDF, IOR 1.45, roughness 0.0; shares object Cube.1120 with the 'Bois porte.003' wood-frame material, i.e. the glass shade of a wood-framed light fixture."
+    }
+  }
+}

--- a/assets/thermal/classroom.thermal.json
+++ b/assets/thermal/classroom.thermal.json
@@ -1,0 +1,304 @@
+{
+  "schema_version": 1,
+  "scene": "classroom.blend",
+  "generated_by": "drafted with model assistance from a dump of the scene's materials (node graphs, slot areas, emission), then reviewed and corrected against the blend; every material is a FEM_PARTICIPANT (no pinned Dirichlet sources)",
+  "defaults": {
+    "preset": "plaster"
+  },
+  "materials": {
+    "beige_paintedPipe": {
+      "preset": "metal_painted",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.6,
+      "reason": "Name says painted pipe; pipes are typically metal, paint coating gives high emissivity."
+    },
+    "plaster": {
+      "preset": "plaster",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.95,
+      "reason": "Explicitly named plaster used on ceiling."
+    },
+    "whiteChalk": {
+      "preset": "plaster",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.7,
+      "reason": "Chalk is calcium-based, thermally similar to gypsum plaster."
+    },
+    "paintedCeiling": {
+      "preset": "plaster",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.7,
+      "reason": "Painted ceiling beams with plaster-wall texture."
+    },
+    "beigeWall": {
+      "preset": "plaster",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.9,
+      "reason": "Interior walls with painted plaster wall texture."
+    },
+    "woodFloor": {
+      "preset": "wood",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.95,
+      "reason": "Name and texture 'base_woodFloor.jpg' clearly indicate wood."
+    },
+    "leatherCoat": {
+      "preset": "leather",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.95,
+      "reason": "Name and texture 'base_leather.jpg' clearly indicate leather."
+    },
+    "woodPlanks": {
+      "preset": "wood",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.95,
+      "reason": "Name and texture 'woodPlanks.jpg' clearly indicate wood."
+    },
+    "yellowLetter": {
+      "preset": "paper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.7,
+      "reason": "Text/letter objects are likely paper-based."
+    },
+    "dayLight_portal": {
+      "preset": "glass",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.4,
+      "reason": "Emissive daylight portal (strength 20) on windows representing strong solar radiation input."
+    },
+    "varnishedWoodDoor": {
+      "preset": "wood",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.9,
+      "reason": "Name and texture 'base_brownWood.jpg' indicate varnished wood door."
+    },
+    "beigePaint": {
+      "preset": "plaster",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.8,
+      "reason": "Painted ceiling moulding with plaster-wall texture."
+    },
+    "whitePaintedWindow": {
+      "preset": "wood",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.7,
+      "reason": "Used by 'woodWindow' objects; painted wooden window frames."
+    },
+    "blackPaintedWood": {
+      "preset": "wood",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.85,
+      "reason": "Name explicitly says painted wood."
+    },
+    "cork": {
+      "preset": "wood",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.5,
+      "reason": "Cork is bark-derived; wood is the closest available preset."
+    },
+    "paintedBlind": {
+      "preset": "metal_painted",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.5,
+      "reason": "Painted blind slats; likely painted metal, ambiguous with PVC."
+    },
+    "ceilingAirVent": {
+      "preset": "metal_painted",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.7,
+      "reason": "Air vents are typically painted metal; prefer metal_painted for coated metal."
+    },
+    "blackBoard": {
+      "preset": "plaster",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.4,
+      "reason": "Blackboard surface; could be slate, plaster, or enameled steel, plaster is closest."
+    },
+    "paper": {
+      "preset": "paper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.95,
+      "reason": "Explicitly named paper used by 'whitePages'."
+    },
+    "worldMap": {
+      "preset": "paper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.9,
+      "reason": "Map texture 'europeMap.png' on paper."
+    },
+    "boardFrame": {
+      "preset": "wood",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.5,
+      "reason": "Board frame is typically wooden; texture is reused plaster wall."
+    },
+    "white_glossPaint": {
+      "preset": "metal_painted",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.5,
+      "reason": "Glossy painted lamp housing and board part; painted metal surface."
+    },
+    "drawing.007": {
+      "preset": "paper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.9,
+      "reason": "Child drawing texture 'childDrawing_08.png' on paper."
+    },
+    "drawing.003": {
+      "preset": "paper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.9,
+      "reason": "Child drawing texture 'childDrawing_07.png' on paper."
+    },
+    "drawing.001": {
+      "preset": "paper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.9,
+      "reason": "Child drawing texture 'childDrawing_01.jpg' on paper."
+    },
+    "greyDiffusePaint": {
+      "preset": "metal_painted",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.6,
+      "reason": "Painted ceiling pipe hangers; painted metal hardware."
+    },
+    "beigePaintedwood": {
+      "preset": "wood",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.8,
+      "reason": "Name explicitly says painted wood."
+    },
+    "drawing.005": {
+      "preset": "paper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.9,
+      "reason": "Child drawing texture 'childDrawing_05.jpg' on paper."
+    },
+    "drawing.006": {
+      "preset": "paper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.9,
+      "reason": "Child drawing texture 'childDrawing_06.jpg' on paper."
+    },
+    "drawing.008": {
+      "preset": "paper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.9,
+      "reason": "Child drawing texture 'childDrawing_04.jpg' on paper."
+    },
+    "porcelainHandle": {
+      "preset": "porcelain",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.9,
+      "reason": "Name explicitly says porcelain handle."
+    },
+    "frostedGlass": {
+      "preset": "glass",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.95,
+      "reason": "Name and texture 'base_frostedGlass.png' clearly indicate glass."
+    },
+    "drawing.002": {
+      "preset": "paper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.9,
+      "reason": "Child drawing texture 'childDrawing_03.jpg' on paper."
+    },
+    "postit": {
+      "preset": "paper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.95,
+      "reason": "Post-it note is paper."
+    },
+    "beigePaintedPlastic": {
+      "preset": "pvc",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.8,
+      "reason": "Name says plastic; wall plugs and switches are typically rigid PVC."
+    },
+    "blackBoardLight": {
+      "preset": "glass",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.7,
+      "reason": "Deliberately NOT pinned as a DIRICHLET_SOURCE, so no object is held at a fixed temperature and every surface solves from the same ambient start. Emissive lamp element (strength 1.0) for blackboard lamp; typical lamp element temperature."
+    },
+    "coloredPlastic": {
+      "preset": "pvc",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.85,
+      "reason": "Name says colored plastic; PVC is the generic rigid plastic preset."
+    },
+    "sc.blade": {
+      "preset": "steel",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.4,
+      "reason": "Possibly scissors blade; bare steel metal, but name is ambiguous."
+    },
+    "drawing": {
+      "preset": "paper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.7,
+      "reason": "Drawing material with checker texture; likely on paper."
+    },
+    "drawing.004": {
+      "preset": "paper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.6,
+      "reason": "Drawing material with no texture info; follows naming pattern of paper drawings."
+    },
+    "dust": {
+      "preset": "pvc",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.3,
+      "reason": "Dust particles; no clear match, using global default PVC."
+    },
+    "override_black": {
+      "preset": "pvc",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.3,
+      "reason": "Rendering override material; no physical basis, using global default PVC."
+    }
+  }
+}

--- a/assets/thermal/diningroom.thermal.json
+++ b/assets/thermal/diningroom.thermal.json
@@ -1,0 +1,330 @@
+{
+  "schema_version": 1,
+  "scene": "diningroom.blend",
+  "generated_by": "drafted with model assistance from a dump of the scene's materials (node graphs, slot areas, emission), then reviewed and corrected against the blend",
+  "defaults": {},
+  "materials": {
+    "BOLA DECORACION": {
+      "preset": "metal_painted",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.45,
+      "reason": "Spanish 'bola decoracion' = decoration ball(s); shader is a 'PBR-Metallic' node group (pure Glossy BSDF, no diffuse term) with a neutral grey base color (~0.30,0.32,0.32); the 3 small orbs sit on the wood shelf (ESTANTERIA) next to 'ceramica negra'. Ambiguous whether raw or coated metal, so following the guidance to prefer metal_painted for ambiguous coated metal."
+    },
+    "BookCover": {
+      "preset": "paper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.6,
+      "reason": "No image texture (generic 0.8-grey Diffuse+Glossy); shares the 'BezierCurve' open-book prop with BookEdge/BookInlet/Page/Page2/Stripy Edge. A book's outer cover is card/paper stock."
+    },
+    "BookCover_Colors": {
+      "preset": "paper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.85,
+      "reason": "Texture 'book_cover_colors.jpg' is a printed book-cover image on a Diffuse+Glossy 'coated card' shader."
+    },
+    "BookCover_Cycles": {
+      "preset": "paper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.85,
+      "reason": "Texture 'introduction to cycles.jpg' is a printed book-cover image (a Blender/Cycles manual)."
+    },
+    "BookCover_Interior": {
+      "preset": "paper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.85,
+      "reason": "Texture 'book_cover_interior.jpg' - the book's inside-cover artwork."
+    },
+    "BookEdge": {
+      "preset": "paper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.9,
+      "reason": "Texture 'Book Edge4.jpg' is a photographed page-edge texture; explicit book part, Diffuse-only shader."
+    },
+    "BookInlet": {
+      "preset": "paper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.55,
+      "reason": "No texture, flat dark-green Diffuse color; likely the book's endpaper/inside-cover lining. Paper is the closest preset though it could instead be a ribbon; noting the uncertainty."
+    },
+    "cantos": {
+      "preset": "wood",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.85,
+      "reason": "Spanish 'cantos' = edges; Cube.007 is a 5m x 1.5cm x 5cm strip at floor level (skirting/edge trim), textured with the same WoodFlooring08_* maps as 'parked. suelo' (the floor)."
+    },
+    "carton": {
+      "preset": "paper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.8,
+      "reason": "Spanish 'carton' = cardboard; used by 216 small (~6x6x5cm) Plane objects stacked in a tall multi-row grid at x=-2.59 - a bookshelf full of book spines. Cardboard/cardstock book covers map to the 'paper' preset (closest available; no dedicated cardboard entry)."
+    },
+    "carton 2": {
+      "preset": "paper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.45,
+      "reason": "Same 'carton'=cardboard name and dark-brown diffuse as 'carton', but geometry is six very thin (4mm diameter, 2.36m tall) cylinders interspersed among the carton bookshelf rows - the shape doesn't look like cardboard sheeting (possibly shelf-support dowels or a modelling leftover). Kept the name-implied preset but lowered confidence for the shape mismatch."
+    },
+    "ceramica": {
+      "preset": "ceramic",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.9,
+      "reason": "Spanish 'ceramica' = ceramic; 'PBR-Dielectric' shader with a light warm-gray color; the 'Circle' object (~30cm diameter, 40cm tall) sits at table height like a tabletop vase/bowl centerpiece."
+    },
+    "ceramica negra": {
+      "preset": "ceramic",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.9,
+      "reason": "Spanish 'ceramica negra' = black ceramic; 'PBR-Dielectric' shader with a near-black color; small pot (~20cm) on the shelf next to the decoration balls."
+    },
+    "chrome": {
+      "preset": "aluminium_polished",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.85,
+      "reason": "Explicit name 'chrome'; a pure mirror Glossy BSDF (roughness 0.0). The 4 Cylinder objects are parented to the chair-seat discs in the 'silla' collection - the chrome pedestal/leg of the dining chairs."
+    },
+    "CRISTAL": {
+      "preset": "glass",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.95,
+      "reason": "Spanish 'cristal' = glass; explicit 'PBR-Glass' node group (Transparent + Refraction BSDF, IOR 2.0). Cube.010 is a large (1.71m x 2.69m x 2.7cm) flat pane co-located with the 'metal 2' frame members - a window pane."
+    },
+    "decoration_twig_wood": {
+      "preset": "wood",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.85,
+      "reason": "Explicit name says wood; dark-brown Diffuse/Glossy shader on a branching hierarchy of 'decoration_twig_branch' objects - a decorative dry-twig arrangement typical of a dining-table centerpiece."
+    },
+    "ESTANTERIA": {
+      "preset": "wood",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.75,
+      "reason": "Spanish 'estanteria' = shelving; Cube.001 is a 1.72m x 13cm x 7cm plank with an amber/honey diffuse tint (0.83,0.78,0.36) under a clear-coat (Refraction IOR 1.45 + Glossy reflection), the varnished-wood shader pattern used elsewhere in this asset pack. The decoration balls sit on it."
+    },
+    "LibroMat_02": {
+      "preset": "paper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.85,
+      "reason": "'Libro' = book (Spanish/Italian); texture 'UVlibro_o2.jpg' is a printed book-cover UV image."
+    },
+    "LibroMat_Aldila": {
+      "preset": "paper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.85,
+      "reason": "'Libro' = book; texture 'UVlibroAldiLa.jpg' is a printed book-cover UV image."
+    },
+    "LibroMat_cripta": {
+      "preset": "paper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.85,
+      "reason": "'Libro' = book; texture 'UVlibro_Cripta.jpg' is a printed book-cover UV image."
+    },
+    "LibroMat_desideri": {
+      "preset": "paper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.85,
+      "reason": "'Libro' = book; texture 'UVlibro_desideri.jpg' is a printed book-cover UV image."
+    },
+    "LibroMat_duenon": {
+      "preset": "paper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.85,
+      "reason": "'Libro' = book; texture 'UVlibro_Duenon.jpg' is a printed book-cover UV image."
+    },
+    "LibroMat_EV": {
+      "preset": "paper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.85,
+      "reason": "'Libro' = book; texture 'UVlibro_EV.jpg' is a printed book-cover UV image."
+    },
+    "LibroMat_Fate": {
+      "preset": "paper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.85,
+      "reason": "'Libro' = book; texture 'UVlibro_FATE.jpg' is a printed book-cover UV image; simple Diffuse-only shader (matte paperback)."
+    },
+    "LibroMat_Gostanza": {
+      "preset": "paper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.85,
+      "reason": "'Libro' = book; texture 'UVlibro_Gostanza.jpg' is a printed book-cover UV image; simple Diffuse-only shader (matte paperback)."
+    },
+    "LibroMat_i4k": {
+      "preset": "paper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.85,
+      "reason": "'Libro' = book; texture 'UVlibro_i4k.jpg' is a printed book-cover UV image."
+    },
+    "LibroMat_Izu": {
+      "preset": "paper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.85,
+      "reason": "'Libro' = book; texture 'UVlibro_Izu.jpg' is a printed book-cover UV image."
+    },
+    "LibroMat_laico": {
+      "preset": "paper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.85,
+      "reason": "'Libro' = book; reuses texture 'UVlibro_o2.jpg' - another book sharing the same cover art."
+    },
+    "LibroMat_Marne": {
+      "preset": "paper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.85,
+      "reason": "'Libro' = book; texture 'UVlibro_marne.jpg' is a printed book-cover UV image."
+    },
+    "LibroMat_paginestrappate": {
+      "preset": "paper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.85,
+      "reason": "'Libro' = book, 'paginestrappate' = torn pages; texture 'UVlibro_paginestrappate.jpg' confirms a worn-paper book cover."
+    },
+    "LibroMat_poihosmesso": {
+      "preset": "paper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.85,
+      "reason": "'Libro' = book; texture 'UVlibro_Poihosmesso.jpg' is a printed book-cover UV image."
+    },
+    "LibroMat_rumore": {
+      "preset": "paper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.85,
+      "reason": "'Libro' = book; texture 'UVlibro_Rumore.jpg' is a printed book-cover UV image."
+    },
+    "LibroMat_Sogni": {
+      "preset": "paper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.85,
+      "reason": "'Libro' = book; texture 'UVlibro_sogni.jpg' is a printed book-cover UV image."
+    },
+    "LibroMat_Uova": {
+      "preset": "paper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.85,
+      "reason": "'Libro' = book; texture 'UVlibro_uova.jpg' is a printed book-cover UV image."
+    },
+    "Material.001": {
+      "preset": null,
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.2,
+      "reason": "Generic default Blender name, no image texture. Shares the 'PBR-Dielectric' node-group family used elsewhere for ceramica/walls (near-black, smooth, roughness 0.05) but carries no name or texture evidence to pin down a specific material; two identical ~65cm low-poly cubes of unclear function (Cube.002/Cube.011). Left unassigned rather than guessed."
+    },
+    "metal": {
+      "preset": "metal_painted",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.55,
+      "reason": "Explicit name 'metal'; anisotropic + glossy layered reflectance (brushed-metal look), neutral gray tint. Cube.003/Cube.004 are co-located with 'PINTURA' (the framed-picture canvas) - the picture's metal frame. Ambiguous coated-vs-bare metal, so using metal_painted per guidance."
+    },
+    "metal 2": {
+      "preset": "metal_painted",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.55,
+      "reason": "Same shader family as 'metal'. Cube.008/Cube.009 are 1.72m x 13cm x 75cm bars co-located with the 'CRISTAL' glass pane - a window's metal frame. Ambiguous coated-vs-bare metal, so using metal_painted per guidance."
+    },
+    "Page": {
+      "preset": "paper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.9,
+      "reason": "Texture 'page1.png', explicit open book-page material on the 'BezierCurve' book prop."
+    },
+    "Page2": {
+      "preset": "paper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.9,
+      "reason": "Texture 'page2.png', explicit open book-page material on the 'BezierCurve' book prop."
+    },
+    "PARED blanca": {
+      "preset": "plaster",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.8,
+      "reason": "Spanish 'pared blanca' = white wall; 'PBR-Dielectric' shader with a light near-white color (~0.84 gray). One of the room-shell object Cube.012's wall material slots."
+    },
+    "PARED VERDE": {
+      "preset": "plaster",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.7,
+      "reason": "Spanish 'pared verde' = green wall; 'PBR-Dielectric' shader with a dark green tint. Same room-shell object (Cube.012) as 'PARED blanca', likely a painted wainscot/accent-wall band."
+    },
+    "parked. suelo": {
+      "preset": "wood",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.9,
+      "reason": "Spanish '(pared.) suelo' = floor; uses the same WoodFlooring08_* texture set as 'cantos' (the matching floor-edge trim). The room-shell object's floor slot."
+    },
+    "PINTURA": {
+      "preset": "paper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.8,
+      "reason": "Spanish 'pintura' = painting; textures are literal artwork images ('PICTURE.png', 'cuadro-abstracto-marron-oxido-y-blanco.jpg' = 'abstract painting brown-rust-and-white'). The printed-canvas insert of a framed picture (Cube.003/Cube.004, alongside the 'metal' frame material)."
+    },
+    "planchas": {
+      "preset": "wood",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.9,
+      "reason": "Spanish 'planchas' = boards/sheets; texture set 'TexturesCom_PlywoodOld0068_*' is literally an old-plywood material."
+    },
+    "plastico blanco": {
+      "preset": "pvc",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.6,
+      "reason": "Spanish 'plastico blanco' = white plastic; used by all 8 chair-seat-shell/disc objects in the 'silla' collection, sitting above the chrome pedestal legs (a molded-plastic shell chair). The shader's exposed base-color default reads near-black, but that input appears fed by an unused Magic-Texture/Hue-Sat chain not reaching the final surface, so the explicit name is treated as authoritative over that one suspicious value."
+    },
+    "Stripy Edge": {
+      "preset": "fabric",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.45,
+      "reason": "Texture 'stripy_book_slip.png' on the 'BezierCurve' book prop alongside BookCover/Page*; a striped 'book slip' most often reads as a silk/fabric ribbon bookmark, though it could instead be a printed paper wrapper band - genuinely uncertain between the two."
+    },
+    "Vildapel Bamboo Planter": {
+      "preset": "wood",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.75,
+      "reason": "Name says 'Bamboo Planter'; texture 'REF Wooden Planter.JPG'. Four planter-pot objects of graduated size (34-65cm), consistent with a set of wood/bamboo planters; no dedicated bamboo preset so using wood."
+    }
+  }
+}

--- a/assets/thermal/kitchen1.thermal.json
+++ b/assets/thermal/kitchen1.thermal.json
@@ -1,0 +1,290 @@
+{
+  "schema_version": 1,
+  "scene": "kitchen1.blend",
+  "generated_by": "drafted with model assistance from a dump of the scene's materials (node graphs, slot areas, emission), then reviewed and corrected against the blend; every material is a FEM_PARTICIPANT (no pinned Dirichlet sources)",
+  "defaults": {
+    "preset": "plaster"
+  },
+  "materials": {
+    "FREGADERO": {
+      "preset": "stainless_steel",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.6,
+      "reason": "Spanish 'fregadero' = sink; kitchen sinks are typically stainless steel; shared 'iron_rusted_rougness.jpg' is a generic roughness map."
+    },
+    "DIC METAL": {
+      "preset": "metal_painted",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.6,
+      "reason": "Metal housing of a dichroic lamp (DICROICA_II); ambiguous metal so prefer metal_painted per guidance."
+    },
+    "PISO MADERA": {
+      "preset": "wood",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.95,
+      "reason": "Spanish 'piso madera' = wood floor; textures WOO PISO.jpg and WOOD PISO BUMP.jpg confirm."
+    },
+    "MUROS": {
+      "preset": "plaster",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.9,
+      "reason": "Spanish 'muros' = walls; texture STUCO BLANCO.jpg indicates plastered/stucco wall."
+    },
+    "PORCELANA": {
+      "preset": "porcelain",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.95,
+      "reason": "Spanish 'porcelana' = porcelain; used by 'mortero' (mortar/pestle)."
+    },
+    "PLATOS": {
+      "preset": "ceramic",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.6,
+      "reason": "Spanish 'platos' = plates/dishes; likely ceramic tableware though also used by cocina gas."
+    },
+    "DIC ILUM": {
+      "preset": "metal_painted",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.7,
+      "reason": "Deliberately NOT pinned as a DIRICHLET_SOURCE (a fixed 350 K would be the obvious choice) so that no object is held at a fixed temperature and every surface solves from the same ambient start. Converted to FEM_PARTICIPANT so no object is pinned and every surface solves from the same ambient start. Emissive element of a dichroic lamp; lamp elements ~340-360 K."
+    },
+    "MADERA ESTANTES": {
+      "preset": "wood",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.95,
+      "reason": "Spanish 'madera estantes' = wood shelves; texture MADERA DIFUSA.jpg confirms."
+    },
+    "CRISTAL LAMPARA.001": {
+      "preset": "glass",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.9,
+      "reason": "Spanish 'cristal lampara' = glass lamp shade; BSDF metallic ignored per guidance."
+    },
+    "jarrones": {
+      "preset": "ceramic",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.7,
+      "reason": "Spanish 'jarrones' = vases; vases are commonly ceramic."
+    },
+    "jarrones.001": {
+      "preset": "ceramic",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.7,
+      "reason": "Spanish 'jarrones' = vases; lighter variant, still likely ceramic."
+    },
+    "agua test": {
+      "preset": "water",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.95,
+      "reason": "Spanish 'agua' = water; transmission=1.0 confirms transparent liquid."
+    },
+    "bronce": {
+      "preset": "copper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.8,
+      "reason": "Spanish 'bronce' = bronze; copper is the closest preset for a copper alloy."
+    },
+    "CRISTAL LAMPARA": {
+      "preset": "glass",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.9,
+      "reason": "Spanish 'cristal lampara' = glass lamp shade."
+    },
+    "CRISTAL LAMPARA.002": {
+      "preset": "glass",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.9,
+      "reason": "Spanish 'cristal lampara' = glass lamp shade; dark variant."
+    },
+    "madera pared": {
+      "preset": "wood",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.95,
+      "reason": "Spanish 'madera pared' = wood wall; texture MADERA DIFUSA.jpg confirms."
+    },
+    "METALBANQUETAS": {
+      "preset": "metal_painted",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.7,
+      "reason": "Spanish 'metal banquetas' = metal stools; furniture metal is typically painted/coated."
+    },
+    "AGUA EXTRANA": {
+      "preset": "water",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.9,
+      "reason": "Spanish 'agua extraña' = strange water; transmission=0.43 indicates liquid."
+    },
+    "ALUMINIO RUGOSO.001": {
+      "preset": "aluminium",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.85,
+      "reason": "Spanish 'aluminio rugoso' = rough aluminium; mill-finish aluminium preset fits."
+    },
+    "CERAMICA NEGRA": {
+      "preset": "ceramic",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.9,
+      "reason": "Spanish 'ceramica negra' = black ceramic."
+    },
+    "metal oscuro": {
+      "preset": "metal_painted",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.6,
+      "reason": "Spanish 'metal oscuro' = dark metal; dark coated/painted metal, prefer metal_painted."
+    },
+    "metal cocina 01": {
+      "preset": "stainless_steel",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.7,
+      "reason": "Spanish 'metal cocina' = kitchen metal; stove/appliance bodies are commonly stainless steel."
+    },
+    "CUADRO": {
+      "preset": "paper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.8,
+      "reason": "Spanish 'cuadro' = painting/picture; texture CUADRO.JPG indicates printed artwork on paper."
+    },
+    "METAL MESA": {
+      "preset": "metal_painted",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.7,
+      "reason": "Spanish 'metal mesa' = table metal; furniture metal is typically painted/coated."
+    },
+    "ALUMINIO RUGOSO": {
+      "preset": "aluminium",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.85,
+      "reason": "Spanish 'aluminio rugoso' = rough aluminium; mill-finish aluminium preset fits."
+    },
+    "CABLE": {
+      "preset": "rubber",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.9,
+      "reason": "Cable sheathing matches the rubber preset description directly."
+    },
+    "hojas.001": {
+      "preset": "foliage",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.95,
+      "reason": "Spanish 'hojas' = leaves; used by IvyLeaf with Leaf textures."
+    },
+    "ilum": {
+      "preset": "metal_painted",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.7,
+      "reason": "Deliberately NOT pinned as a DIRICHLET_SOURCE (a fixed 350 K would be the obvious choice) so that no object is held at a fixed temperature and every surface solves from the same ambient start. Converted to FEM_PARTICIPANT so no object is pinned and every surface solves from the same ambient start. Emissive lamp element (strength=4.0); lamp elements ~340-360 K."
+    },
+    "CERAMICA": {
+      "preset": "ceramic",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.9,
+      "reason": "Spanish 'ceramica' = ceramic."
+    },
+    "METAL pica carnes": {
+      "preset": "iron",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.55,
+      "reason": "Spanish 'pica carnes' = meat grinder; traditional meat grinders are cast iron."
+    },
+    "MADERA BANQUETAS": {
+      "preset": "wood",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.95,
+      "reason": "Spanish 'madera banquetas' = wood stools; texture MADERA DIFUSA.jpg confirms."
+    },
+    "archmodels66_033_1": {
+      "preset": "foliage",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.7,
+      "reason": "Used by 'orquidea' (orchid); archmodel texture likely part of the plant."
+    },
+    "CESPED.000": {
+      "preset": "foliage",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.95,
+      "reason": "Spanish 'cesped' = grass; texture grass_color_V2.JPG confirms."
+    },
+    "metal cubre llamas": {
+      "preset": "steel",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.6,
+      "reason": "Spanish 'cubre llamas' = flame cover; bare steel exposed to flame on gas stove."
+    },
+    "hojas": {
+      "preset": "foliage",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.95,
+      "reason": "Spanish 'hojas' = leaves; used by 'hoja planta' with HOJA DE PLANTA OK.jpg."
+    },
+    "prato": {
+      "preset": "ceramic",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.5,
+      "reason": "Portuguese 'prato' = plate; smooth white surface (roughness=0) suggests ceramic tableware."
+    },
+    "AGUA": {
+      "preset": "water",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.95,
+      "reason": "Spanish 'agua' = water; transmission=1.0 confirms."
+    },
+    "_87": {
+      "preset": "foliage",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.7,
+      "reason": "Used by 'orquidea' (orchid); texture HOJA.jpg = leaf."
+    },
+    "_90": {
+      "preset": "foliage",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.6,
+      "reason": "Used by 'orquidea' (orchid); texture PARA TRANS.jpg suggests translucent flower petal."
+    },
+    "blender_logo": {
+      "preset": "paper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.7,
+      "reason": "Logo/label with printed texture blender_logo.jpg; paper preset for printed labels."
+    }
+  }
+}

--- a/assets/thermal/officebuilding.thermal.json
+++ b/assets/thermal/officebuilding.thermal.json
@@ -1,0 +1,624 @@
+{
+  "schema_version": 1,
+  "scene": "officebuilding.blend",
+  "generated_by": "drafted with model assistance from a dump of the scene's materials (node graphs, slot areas, emission), then reviewed and corrected against the blend",
+  "defaults": {},
+  "materials": {
+    "CAR PAINT": {
+      "preset": "metal_painted",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.5,
+      "reason": "Node group 'UBER CAR PAINT 072616' = car body paint (painted steel/aluminium panel); unused material slot (0 objects in this scene), so name/group is the only evidence."
+    },
+    "CAR PAINT.001": {
+      "preset": "metal_painted",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.6,
+      "reason": "Same 'UBER CAR PAINT' shader, applied to 25 objects (Circle*, Cube.003/.012/...); car paint = painted sheet metal, closest preset is metal_painted."
+    },
+    "CAR PAINT.002": {
+      "preset": "metal_painted",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.6,
+      "reason": "Same UBER CAR PAINT family, used on Cylinder.026."
+    },
+    "CAR PAINT.003": {
+      "preset": "metal_painted",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.6,
+      "reason": "Same UBER CAR PAINT family, used on Cylinder."
+    },
+    "CARBON FIBER": {
+      "preset": "pvc",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.3,
+      "reason": "Node group 'carbon fiber'; unused (0 objects). No carbon-fibre-composite preset exists; approximated as generic rigid plastic (pvc) since the resin matrix dominates surface thermal response. Low confidence: real carbon-fibre laminate diffusivity is not well represented by any preset in the library."
+    },
+    "CLOTH": {
+      "preset": "fabric",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.7,
+      "reason": "Node group named 'CLOTH' (Diffuse+Velvet+Translucent mix, a cloth-sheen shader); unused (0 objects), but the name and shader construction directly indicate fabric."
+    },
+    "CONCRETE": {
+      "preset": "concrete",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.8,
+      "reason": "Node group named 'CON CRETE'; unused (0 objects) but the explicit name matches the concrete preset directly."
+    },
+    "Cracked Glow FX": {
+      "preset": null,
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.1,
+      "reason": "Node group 'Cracked Glow' - a decorative crack/glow FX shader (Voronoi cracks + emission), not applied to any object in this scene (0 objects). No physical surface material maps to a stylised FX shader, so left null rather than guessing."
+    },
+    "DOOR 1": {
+      "preset": "wood",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.55,
+      "reason": "Textures DOOR.jpg/DOOR_NRM.jpg/DOOR_OCC.jpg/DOOR_SPEC.jpg give no colour/species info; generic interior doors in an office building are most commonly solid/veneered wood, so wood is the best-supported guess. Moderate confidence only."
+    },
+    "DOOR 2.001": {
+      "preset": "wood",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.55,
+      "reason": "Textures 'DOUBLE DOOR.jpg' family (used on Cube.010); same reasoning as DOOR 1 - generic interior double door, assumed wood."
+    },
+    "FELT": {
+      "preset": "fabric",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.6,
+      "reason": "Node group named 'FELT' (BMD_FeltShader: diffuse+glossy fabric-style mix); unused (0 objects). No dedicated felt preset exists; fabric is the closest available material."
+    },
+    "FUSE BOX.001": {
+      "preset": "metal_painted",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.45,
+      "reason": "Used on 3 Plane objects (electrical panel faces); no image texture, only a generic PBR2_TEXTURE node group instance. Fuse/breaker boxes are conventionally painted sheet-steel enclosures, so metal_painted is the best guess given the name; low-moderate confidence since there is no texture/colour evidence."
+    },
+    "Fencing_Diamond_Mesh.001": {
+      "preset": "aluminium",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.4,
+      "reason": "Diamond-mesh grille texture 'Fencing_Diamond_Mesh.png.001' on the JBL_Twin speaker prop's grille; a diamond-pattern perforated speaker grille is typically thin metal mesh. Ambiguous versus a fabric acoustic mesh, so only moderate confidence."
+    },
+    "GALVANIZED METAL": {
+      "preset": "steel",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.55,
+      "reason": "Node group named 'galvanized metal'; unused (0 objects). No galvanised-specific preset exists (the zinc coating is thin and doesn't change the bulk thermal mass much); bare steel is the closest preset."
+    },
+    "GLASS": {
+      "preset": "glass",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.9,
+      "reason": "Node group 'Glass - Advanced' (Glass BSDF + Transparent BSDF mix); unused (0 objects) but the name and shader are unambiguous."
+    },
+    "GLASS 2": {
+      "preset": "glass",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.85,
+      "reason": "Used on Cube.015/Cube.046; named GLASS, no further texture evidence needed."
+    },
+    "GLASS 2.001": {
+      "preset": "glass",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.85,
+      "reason": "Used on Plane.028; same GLASS family."
+    },
+    "GLASS.001": {
+      "preset": "glass",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.85,
+      "reason": "Used on Cube.004; same GLASS family."
+    },
+    "GLASS.002": {
+      "preset": "glass",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.85,
+      "reason": "Used on Cube.021; same GLASS family."
+    },
+    "Hologram FX": {
+      "preset": null,
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.1,
+      "reason": "Node group 'Hologram FX 072916' - a stylised holographic-display FX shader (fresnel + wireframe + volume-absorption + emission); unused (0 objects) and has no physical-surface analogue in the preset library, so left null."
+    },
+    "LED": {
+      "preset": "pvc",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.5,
+      "reason": "Node group named 'LED' contains an Emission node (strength 1.7, green) mixed with Glossy/Toon BSDFs - a small indicator-LED lens. LED lenses/encapsulant are typically moulded plastic; unused (0 objects) in this scene."
+    },
+    "LED.001": {
+      "preset": "pvc",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.5,
+      "reason": "Same 'LED' shader, used on Circle.017 (a small indicator light)."
+    },
+    "LIGHT GLOW": {
+      "preset": "glass",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.6,
+      "reason": "Node group 'LIGHT BULB GLOW' (Glass BSDF mixed with a strong warm-orange Emission, strength 18.4) - a light-bulb glass envelope; unused (0 objects)."
+    },
+    "LIGHT GLOW.001": {
+      "preset": "glass",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.7,
+      "reason": "Same LIGHT BULB GLOW shader, used on 3 Cylinder objects (lamp/bulb geometry) alongside a matching 'PBR - GLASS.001' shade material on the same objects."
+    },
+    "LIGHT GLOW.002": {
+      "preset": "glass",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.7,
+      "reason": "Same LIGHT BULB GLOW shader, used on Cylinder.015/.021."
+    },
+    "LIGHT GLOW.003": {
+      "preset": "glass",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.7,
+      "reason": "Same LIGHT BULB GLOW shader, used on Cylinder.017/.022."
+    },
+    "LIGHT GLOW.004": {
+      "preset": "glass",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.7,
+      "reason": "Same LIGHT BULB GLOW shader, used on 3 Cylinder objects."
+    },
+    "LIGHT GLOW.005": {
+      "preset": "glass",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.7,
+      "reason": "Same LIGHT BULB GLOW shader, used on Cylinder.018."
+    },
+    "Leather": {
+      "preset": "leather",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.85,
+      "reason": "Node group named 'LEATHER'; unused (0 objects) but the explicit name matches the leather preset directly."
+    },
+    "MARBLE TEXTURE": {
+      "preset": "marble",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.75,
+      "reason": "Node group 'marbled floor PBR.001'; used on 8 objects (Circle.015/.016, Cube.006/.042/.044/...) - a marble/stone floor or counter finish, matching the marble preset."
+    },
+    "MARBLE TEXTURE.001": {
+      "preset": "marble",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.75,
+      "reason": "Same marbled-floor shader family, used on Cube.005."
+    },
+    "MARBLE TEXTURE.002": {
+      "preset": "marble",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.75,
+      "reason": "Same marbled-floor shader family, used on Plane.004/.005/.006."
+    },
+    "MARBLED FLOOR_PBR": {
+      "preset": "marble",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.75,
+      "reason": "Node group 'marbled floor PBR'; unused (0 objects) but the explicit name matches marble."
+    },
+    "MOSS STONE": {
+      "preset": "marble",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.4,
+      "reason": "Node group named 'MOSS STONE'; unused (0 objects). No moss/weathered-stone preset exists; approximated with the marble/granite/engineered-stone preset as the closest natural-stone analogue. Low confidence given the vegetation (moss) layer isn't represented at all."
+    },
+    "M_0130_Gainsboro.001": {
+      "preset": "pvc",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.5,
+      "reason": "Used on the JBL_Twin speaker prop; Principled BSDF base_color = light grey (0.86, 'Gainsboro'), metallic=0.0, roughness=0.5 - a painted/moulded plastic housing colour option, not bare metal."
+    },
+    "Material.001": {
+      "preset": "pvc",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.3,
+      "reason": "Generic default Blender material name on Cylinder.014 (a small trim/cap on a multi-slot object that also carries PBR GOLD.002). Only evidence is a black Diffuse BSDF colour; guessed as a plain black plastic accent. Low confidence - name gives no information."
+    },
+    "Material.002": {
+      "preset": "pvc",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.3,
+      "reason": "Same generic default-named material pattern (black Diffuse BSDF, no texture), used on Cylinder.003. Low confidence for the same reason as Material.001."
+    },
+    "Material1.001": {
+      "preset": "pvc",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.6,
+      "reason": "Used on the JBL_Twin speaker prop; texture 'TXT_boitier_black.jpg.001' ('boitier' = French for housing/case, black) - the speaker's plastic outer case."
+    },
+    "PBR - BASIC": {
+      "preset": null,
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.15,
+      "reason": "Node group 'PBR2_TEXTURE' - a generic, uninstantiated PBR template with no assigned colour/image and 0 objects using it. No evidence to assign a specific preset."
+    },
+    "PBR - GLASS": {
+      "preset": "glass",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.7,
+      "reason": "Node group named 'PBR - GLASS' (Fresnel + Glass/Refraction BSDF mix); unused (0 objects) but the explicit name matches the glass preset."
+    },
+    "PBR - GLASS.001": {
+      "preset": "glass",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.75,
+      "reason": "Same PBR - GLASS shader; used on 6 objects (Cube.026/.027/.028, Cylinder.016/.019/.020) - paired with 'LIGHT GLOW.001' bulb-glow material on the same lamp objects, i.e. this is the glass shade around the glowing bulb."
+    },
+    "PBR - GLASS.002": {
+      "preset": "glass",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.75,
+      "reason": "Same PBR - GLASS shader, paired with LIGHT GLOW.002 on Cylinder.015/.021 (lamp shade)."
+    },
+    "PBR - GLASS.003": {
+      "preset": "glass",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.75,
+      "reason": "Same PBR - GLASS shader, paired with LIGHT GLOW.003 on Cylinder.017/.022 (lamp shade)."
+    },
+    "PBR - GLASS.004": {
+      "preset": "glass",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.75,
+      "reason": "Same PBR - GLASS shader, paired with LIGHT GLOW.005 on Cylinder.018 (lamp shade)."
+    },
+    "PBR - METAL": {
+      "preset": "metal_painted",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.4,
+      "reason": "Node group 'PBR METAL' - a generic procedural metal template (colour-ramp + noise, no specific finish specified); unused (0 objects). Ambiguous coated/generic metal, so metal_painted per the guidance for ambiguous metals."
+    },
+    "PBR - TEXTURE": {
+      "preset": null,
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.15,
+      "reason": "Node groups 'PBR2_TEXTURE'/'PBR2_TEXTURE INPUT' with no image assigned and 0 objects using it - the un-instantiated base template of the PBR - TEXTURE.* family. No evidence to assign a preset."
+    },
+    "PBR - TEXTURE.001": {
+      "preset": "drywall",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.5,
+      "reason": "Images 'wall texture.jpg'/'_NRM'/'_OCC'/'_SPEC', used on 9 objects (Cube.008/.014/.018/...) - a generic painted interior wall surface; drywall is the commonest office wall/partition material."
+    },
+    "PBR - TEXTURE.002": {
+      "preset": "drywall",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.5,
+      "reason": "Same 'wall texture' image family, used on Cube - generic interior wall surface."
+    },
+    "PBR 2": {
+      "preset": "metal_painted",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.55,
+      "reason": "Images 'GARAGE DOOR.jpg' family, used on Cube.001/Cube.032 - a sectional/roll-up garage door, conventionally painted steel or aluminium panel; metal_painted covers the painted-steel case."
+    },
+    "PBR GOLD": {
+      "preset": "aluminium_polished",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.35,
+      "reason": "Node group 'Gold' (+ 'metal rough normal'); unused (0 objects). No gold preset exists in the library; approximated with aluminium_polished as the closest low-emissivity, reflective decorative-metal-trim preset. Low confidence - composition is not aluminium."
+    },
+    "PBR GOLD.001": {
+      "preset": "aluminium_polished",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.35,
+      "reason": "Same PBR GOLD shader, used on Cube.039 (small decorative trim/hardware accent)."
+    },
+    "PBR GOLD.002": {
+      "preset": "aluminium_polished",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.35,
+      "reason": "Same PBR GOLD shader, used on Cylinder.014."
+    },
+    "PBR GOLD.003": {
+      "preset": "aluminium_polished",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.35,
+      "reason": "Same PBR GOLD shader, used on Cylinder.001."
+    },
+    "PBR GOLD.004": {
+      "preset": "aluminium_polished",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.35,
+      "reason": "Same PBR GOLD shader, used on 3 Cylinder objects (.031/.032/.033)."
+    },
+    "PBR TITANIUM": {
+      "preset": "stainless_steel",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.45,
+      "reason": "Node group 'Titanium' (+ 'metal rough normal'); unused (0 objects). No titanium preset exists; stainless_steel is the closest available low-conductivity structural/trim metal."
+    },
+    "PBR TITANIUM.001": {
+      "preset": "stainless_steel",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.5,
+      "reason": "Same Titanium shader, used on 7 objects (Cube.002/.007/.025, Cylinder.002, Plane, ...) with a generic 'metal_NRM.jpg' normal map confirming bare/brushed metal trim."
+    },
+    "PBR TITANIUM.002": {
+      "preset": "stainless_steel",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.5,
+      "reason": "Same Titanium shader family, used on Cube.041/.043 (metal_NRM.jpg.003 normal map)."
+    },
+    "PBR TITANIUM.003": {
+      "preset": "stainless_steel",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.5,
+      "reason": "Same Titanium shader family, used on Cube.022."
+    },
+    "PBR TITANIUM.004": {
+      "preset": "stainless_steel",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.5,
+      "reason": "Same Titanium shader family, used on Cube.034."
+    },
+    "PBR TITANIUM.005": {
+      "preset": "stainless_steel",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.5,
+      "reason": "Same Titanium shader family, used on Cube.035/.037/.038."
+    },
+    "PBR TITANIUM.006": {
+      "preset": "stainless_steel",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.5,
+      "reason": "Same Titanium shader family, used on Cube.040 (metal_NRM.jpg.001)."
+    },
+    "PBR TITANIUM.007": {
+      "preset": "stainless_steel",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.5,
+      "reason": "Same Titanium shader family, used on Plane.001/.002/.003 (metal_NRM.jpg.002)."
+    },
+    "PICTURE": {
+      "preset": "paper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.75,
+      "reason": "Image texture 'NEW YORK.jpg' on Plane.007 - a framed printed photo; paper is the closest preset for a printed picture/poster."
+    },
+    "PICTURE 2": {
+      "preset": "paper",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.75,
+      "reason": "Image texture 'NEW YORK 2.jpg' on Plane.010 - same framed-photo reasoning as PICTURE."
+    },
+    "PLASTIC_SMOOTH": {
+      "preset": "pvc",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.7,
+      "reason": "Node group 'PBR2_TEXTURE'; unused (0 objects) but the explicit name 'PLASTIC_SMOOTH' matches the generic pvc/plastic preset."
+    },
+    "PLASTIC_SMOOTH.001": {
+      "preset": "pvc",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.7,
+      "reason": "Same PLASTIC_SMOOTH family, used on Circle.014, Cylinder.050/.055."
+    },
+    "PLASTIC_SMOOTH.002": {
+      "preset": "pvc",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.7,
+      "reason": "Same PLASTIC_SMOOTH family, used on the JBL_Twin speaker prop."
+    },
+    "Plastic: Black": {
+      "preset": "pvc",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.75,
+      "reason": "Used on Tube04; Principled BSDF base_color near-black (0.047), metallic=0.0, roughness=0.5 - explicit name and values both confirm a non-metallic black plastic part."
+    },
+    "RUBBER": {
+      "preset": "rubber",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.8,
+      "reason": "Node group named 'RUBBER'; unused (0 objects) but the explicit name matches the rubber preset directly."
+    },
+    "RUBBER TIRE TEXTURE": {
+      "preset": "rubber",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.75,
+      "reason": "Node group 'TIRE' (noise + normal map + mix shader); unused (0 objects); a tire tread is rubber."
+    },
+    "Satin": {
+      "preset": "fabric",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.4,
+      "reason": "Node group 'BMD_SatinShader' (Glossy+Translucent BSDF mix, no diffuse-only term); unused (0 objects). The translucency suggests satin fabric rather than a satin metal finish, but the name is genuinely ambiguous between the two, hence low confidence."
+    },
+    "TINTED WINDOW": {
+      "preset": "glass",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.85,
+      "reason": "Glass BSDF + Transparent BSDF mix, explicitly named 'TINTED WINDOW'; unused (0 objects) but name and shader are unambiguous glass."
+    },
+    "WOOD": {
+      "preset": "wood",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.85,
+      "reason": "Node group named 'WOOD'; unused (0 objects) but the explicit name matches the wood preset directly."
+    },
+    "_0136_Charcoal_1.001": {
+      "preset": "pvc",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.4,
+      "reason": "JBL_Twin speaker prop colour swatch; Diffuse BSDF colour 0.137 (charcoal grey) mixed with a small Glossy term - matches the sibling swatches' painted-plastic-housing pattern (clearcoat-style finish over plastic, not bare metal)."
+    },
+    "_0137_Black_1.001": {
+      "preset": "pvc",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.5,
+      "reason": "JBL_Twin speaker prop colour swatch; Principled BSDF base_color=black, metallic=0.0, roughness=0.5 - confirmed non-metallic plastic housing colour."
+    },
+    "_25DimGray.001": {
+      "preset": "pvc",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.45,
+      "reason": "JBL_Twin speaker prop colour swatch; Principled BSDF base_color=dim grey (0.41), metallic=0.0 - plastic housing colour option, matching sibling swatches."
+    },
+    "_Black_.001": {
+      "preset": "pvc",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.4,
+      "reason": "JBL_Twin speaker prop colour swatch; Diffuse+Glossy mix, colour=black - same painted-plastic pattern as the other named colour swatches on this prop."
+    },
+    "_Charcoal_.001": {
+      "preset": "pvc",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.4,
+      "reason": "JBL_Twin speaker prop colour swatch; Diffuse+Glossy mix, colour=0.137 (charcoal) - same painted-plastic pattern as sibling swatches."
+    },
+    "_DarkGoldenrod_.001": {
+      "preset": "pvc",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.4,
+      "reason": "JBL_Twin speaker prop colour swatch; Principled BSDF base_color=goldenrod (0.72,0.53,0.04), metallic=0.0 - despite the 'gold' colour name, metallic is explicitly 0, i.e. a painted plastic housing colour, not real metal."
+    },
+    "_Silver_.001": {
+      "preset": "aluminium",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.35,
+      "reason": "JBL_Twin speaker prop colour swatch; only evidence is a light-grey (0.75) legacy diffuse colour with no Principled/metallic value captured. Genuinely ambiguous between a painted-plastic 'silver' colour option (like its siblings) and real metal trim; picked aluminium for the metallic name but confidence is low."
+    },
+    "jbl_logo.001": {
+      "preset": "pvc",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.55,
+      "reason": "Logo decal texture 'jbl_logo.jpg.001' on the JBL_Twin speaker's plastic housing."
+    },
+    "jbl_logo1_.001": {
+      "preset": "pvc",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.55,
+      "reason": "Logo decal texture 'jbl_logo1_.jpg.001' on the JBL_Twin speaker's plastic housing."
+    },
+    "light 1": {
+      "preset": "glass",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.5,
+      "reason": "Plain Emission node (strength 3.0, grey 0.8), used on 8 objects (Cube.007/.009/.013/..., Cylinder.052) - a lit ceiling-fixture/diffuser panel. No other node evidence exists; glass is a reasonable guess for a diffuser/bulb envelope; role is forced FEM_PARTICIPANT with no Dirichlet pin per the standing no-pinned-sources instruction."
+    },
+    "light 1.001": {
+      "preset": "glass",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.5,
+      "reason": "Same plain-Emission fixture shader, used on Cube.041/.043."
+    },
+    "light 2": {
+      "preset": "glass",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.5,
+      "reason": "Same plain-Emission fixture shader but stronger (strength 10.0), used on Cube.045 - likely a brighter fixture/spotlight face."
+    },
+    "light switch.001": {
+      "preset": "pvc",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.75,
+      "reason": "Images 'LIGHT SWITCH.jpg'/'LIGHT SWITCH_NRM.jpg', used on 5 LIGHT SWITCH objects - wall switch plates are conventionally moulded plastic."
+    },
+    "socket.001": {
+      "preset": "pvc",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.75,
+      "reason": "Images 'SOCKET.jpg'/'SOCKET_NRM.jpg', used on 11 SOCKET objects - electrical outlet plates are conventionally moulded plastic."
+    },
+    "white cement": {
+      "preset": "concrete",
+      "role": "FEM_PARTICIPANT",
+      "dirichlet_K": null,
+      "confidence": 0.6,
+      "reason": "Used on Cube.011 with image 'wall texture.jpg'; name 'white cement' names a cement-based finish directly, closest preset is concrete."
+    }
+  }
+}

--- a/docs/source/apidocs/visionsim.simulate.heatsim.rst
+++ b/docs/source/apidocs/visionsim.simulate.heatsim.rst
@@ -1,0 +1,157 @@
+visionsim.simulate.heatsim package
+==================================
+
+Submodules
+----------
+
+visionsim.simulate.heatsim.adapter module
+-----------------------------------------
+
+.. automodule:: visionsim.simulate.heatsim.adapter
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+visionsim.simulate.heatsim.atlas module
+---------------------------------------
+
+.. automodule:: visionsim.simulate.heatsim.atlas
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+visionsim.simulate.heatsim.bvh\_backend module
+----------------------------------------------
+
+.. automodule:: visionsim.simulate.heatsim.bvh_backend
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+visionsim.simulate.heatsim.cache module
+---------------------------------------
+
+.. automodule:: visionsim.simulate.heatsim.cache
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+visionsim.simulate.heatsim.constants module
+-------------------------------------------
+
+.. automodule:: visionsim.simulate.heatsim.constants
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+visionsim.simulate.heatsim.irradiance module
+--------------------------------------------
+
+.. automodule:: visionsim.simulate.heatsim.irradiance
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+visionsim.simulate.heatsim.irradiance\_kernel module
+----------------------------------------------------
+
+.. automodule:: visionsim.simulate.heatsim.irradiance_kernel
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+visionsim.simulate.heatsim.laplacian module
+-------------------------------------------
+
+.. automodule:: visionsim.simulate.heatsim.laplacian
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+visionsim.simulate.heatsim.light\_models module
+-----------------------------------------------
+
+.. automodule:: visionsim.simulate.heatsim.light_models
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+visionsim.simulate.heatsim.materials module
+-------------------------------------------
+
+.. automodule:: visionsim.simulate.heatsim.materials
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+visionsim.simulate.heatsim.occluders module
+-------------------------------------------
+
+.. automodule:: visionsim.simulate.heatsim.occluders
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+visionsim.simulate.heatsim.properties module
+--------------------------------------------
+
+.. automodule:: visionsim.simulate.heatsim.properties
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+visionsim.simulate.heatsim.sh9\_sky module
+------------------------------------------
+
+.. automodule:: visionsim.simulate.heatsim.sh9_sky
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+visionsim.simulate.heatsim.sky\_visibility module
+-------------------------------------------------
+
+.. automodule:: visionsim.simulate.heatsim.sky_visibility
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+visionsim.simulate.heatsim.solver module
+----------------------------------------
+
+.. automodule:: visionsim.simulate.heatsim.solver
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+visionsim.simulate.heatsim.temperature\_io module
+-------------------------------------------------
+
+.. automodule:: visionsim.simulate.heatsim.temperature_io
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+visionsim.simulate.heatsim.thermal\_shader module
+-------------------------------------------------
+
+.. automodule:: visionsim.simulate.heatsim.thermal_shader
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+visionsim.simulate.heatsim.uv\_utils module
+-------------------------------------------
+
+.. automodule:: visionsim.simulate.heatsim.uv_utils
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: visionsim.simulate.heatsim
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/source/apidocs/visionsim.simulate.rst
+++ b/docs/source/apidocs/visionsim.simulate.rst
@@ -1,6 +1,14 @@
 visionsim.simulate package
 ==========================
 
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   visionsim.simulate.heatsim
+
 Submodules
 ----------
 

--- a/docs/source/sections/blender/thermal.rst
+++ b/docs/source/sections/blender/thermal.rst
@@ -1,0 +1,819 @@
+Thermal Modality
+================
+
+The thermal modality adds heat-transfer simulation outputs to any render produced by VisionSim.
+When ``--config.include-thermal`` is set, VisionSim runs a finite-element-method (FEM)
+heat-transfer solve on the scene geometry before the main render loop and produces temperature
+and thermal-camera outputs per frame alongside the standard RGB/depth passes.
+
+Enabling thermal
+----------------
+
+Thermal is off by default.  Turn it on with a single flag on any render command:
+
+.. code-block:: bash
+
+    vsim blender.render-animation scene.blend out/ --config.include-thermal
+
+Everything else is optional tuning, exposed under the ``--config.thermal.*`` namespace and
+documented in `Parameters`_ below.
+
+Outputs
+-------
+
+With thermal enabled, three output directories are written per frame in addition to the usual
+passes:
+
+``temperature/``
+    Per-pixel surface temperature in **Kelvin**, saved as a single-channel
+    ``OPEN_EXR`` file.  This is a Cycles value AOV co-rendered with the RGB pass,
+    so it adds no extra render samples.  Meshes that did not participate in the FEM
+    solve report a fallback, so the value is defined everywhere geometry is visible: a
+    ``DIRICHLET_SOURCE`` reports its reservoir temperature; an object whose solved field
+    could not be written back per-vertex (a topology-changing modifier) reports the
+    **mean of its own solved field**; anything else reports ``initial-temperature-K``.
+
+``thermal_radiance/``
+    Gray-body thermal-camera image produced by a **second Blender render** that
+    replaces all scene materials with emission shaders driven by the solved
+    surface temperature.  The 3-channel ``OPEN_EXR`` is proportional to the
+    Stefan-Boltzmann radiated power (``ε × σ × T⁴``), where ``ε`` is a **fixed
+    scene-wide constant of 0.9**, not the per-material emissivity — see the note under
+    ``emissivity`` below.  This is the most expensive part of thermal; disable it with
+    ``--config.thermal.no-radiance`` when you only need the temperature map.
+
+``previews/temperature/``
+    An **inferno-colormap PNG** derived from the temperature map, for quick
+    visual inspection.  The colormap spans the **global temperature range of the
+    solved scene** (its 1st to 99th percentile, so a few outlier-hot texels cannot
+    flatten everything else; the range is also floored at the initial temperature and
+    widened to span at least 1 K), so a scene with only a small
+    temperature rise still uses the full colormap instead of being crushed to one
+    end.  Controlled by ``--config.thermal.preview`` (default ``True``).
+
+.. admonition:: Note
+
+    ``temperature/`` and ``thermal_radiance/`` carry physically meaningful
+    magnitudes (Kelvin and radiated power).  Load them with a library that
+    preserves EXR float precision (e.g. ``OpenEXR``, ``imageio`` with the EXR
+    plugin, or ``cv2``); the ``previews/`` PNGs are for display only and are not
+    quantitative.
+
+Rendering with thermal
+----------------------
+
+Thermal composes with the normal render commands — you can request it alongside any other
+modality.  A few common invocations:
+
+.. code-block:: bash
+
+    # temperature + radiance + preview, GPU solve (defaults)
+    vsim blender.render-animation scene.blend out/ --config.include-thermal
+
+    # temperature map only — skip the (expensive) gray-body radiance render
+    vsim blender.render-animation scene.blend out/ \
+        --config.include-thermal \
+        --config.thermal.no-radiance
+
+    # force a CPU solve (no CUDA required)
+    vsim blender.render-animation scene.blend out/ \
+        --config.include-thermal \
+        --config.thermal.device cpu
+
+    # make the scene heat up more (larger temperature rise)
+    vsim blender.render-animation scene.blend out/ \
+        --config.include-thermal \
+        --config.thermal.irradiance-scale 1000
+
+Animated geometry
+-----------------
+
+Everything above is a **static** solve: one temperature field is computed and held constant for
+every frame of the render. Setting ``--config.thermal.animated`` switches to a **per-frame
+transient solve** instead, so geometry that moves or deforms over the timeline produces a genuine
+thermal *animation* rather than a single frozen field. The motivating example is a hot liquid
+pouring into a cup: frame by frame, the liquid's heat diffuses into the cup and the cup's surface
+visibly warms up over the sequence.
+
+.. code-block:: bash
+
+    vsim blender.render-animation cup_pour.blend out/ \
+        --config.include-thermal \
+        --config.thermal.animated \
+        --config.thermal.substeps-per-frame 4
+
+Animated mode distinguishes two kinds of objects, selected per object via the ``thermal_role``
+material override (see `Per-object material overrides`_):
+
+``FEM_PARTICIPANT`` objects (default) — stable topology
+    Objects whose vertex count never changes across the animation (e.g. the cup itself). Their
+    temperature **evolves**: each frame's solve carries the previous frame's result forward, so
+    heat accumulates and diffuses realistically over time.
+
+``DIRICHLET_SOURCE`` objects — topology-changing sources
+    Objects whose mesh is regenerated every frame with a different vertex count — the standard
+    situation for a fluid simulation's surface as it pours and splashes. A per-vertex temperature
+    history can't be carried forward for a mesh like this, so instead it is treated as a
+    **constant-temperature source**: every frame it drives heat into the nearby FEM-participant
+    objects at its fixed ``dirichlet_temperature_K``, but its own temperature never evolves and is
+    not part of the solve output. Set ``thermal_role = "DIRICHLET_SOURCE"`` on the hot liquid to
+    get this behavior.
+
+.. admonition:: Note
+
+    The fluid (or other topology-changing) mesh must already be **baked** before running an
+    animated thermal solve — e.g. a Mantaflow fluid domain baked to disk. The solver only reads
+    geometry at each frame; it does not run or advance the fluid simulation itself, so the mesh
+    must already exist at every frame the thermal solve visits.
+
+.. admonition:: Note
+
+    Animated mode currently requires ``--config.thermal.domain POINTS``. Requesting
+    ``animated`` together with ``domain MESH`` logs a warning and falls back to the static
+    (M1) solve described above.
+
+.. admonition:: Note
+
+    Because the animated thermal timeline is keyed to unscaled Blender frames at
+    ``dt = (1 / fps) / substeps-per-frame``, combining animated thermal with
+    ``every-n-frames > 1`` or a ``keyframe-multiplier != 1.0`` render stretch is only
+    approximate (and not officially supported) — the simulated timestep doesn't rescale
+    to match either setting.
+
+The four animated-mode parameters are listed in the `Solver`_ table below; they only take effect
+when ``animated`` is ``True``.
+
+Parameters
+----------
+
+All thermal parameters live under ``--config.thermal.*`` and are collected in the
+``ThermalConfig`` dataclass (:mod:`visionsim.simulate.config`).  The tables below list every
+parameter, its default, and the effect of changing it.  Values set here are **global defaults**;
+individual objects can override the material parameters (see `Per-object material overrides`_).
+
+Output control
+~~~~~~~~~~~~~~~
+
+.. list-table::
+    :header-rows: 1
+    :widths: 26 12 62
+
+    * - Parameter
+      - Default
+      - Effect
+    * - ``radiance``
+      - ``True``
+      - Render the gray-body ``thermal_radiance/`` image (a second render pass).
+        Set ``False`` to skip it and render roughly twice as fast.
+    * - ``preview``
+      - ``True``
+      - Save the inferno-colormap ``previews/temperature/`` PNG.  Set ``False`` to
+        skip preview generation.
+
+Material defaults
+~~~~~~~~~~~~~~~~~
+
+These set the physical material used for every mesh that has no per-object override.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 30 12 58
+
+    * - Parameter
+      - Default
+      - Effect
+    * - ``initial-temperature-K``
+      - ``295.0``
+      - Starting temperature (K) of every vertex, and the fallback reported for
+        meshes that do not participate in the solve.  Shifts the whole baseline.
+    * - ``thermal-diffusivity-mm2-s``
+      - ``0.17``
+      - How fast heat spreads through the surface (mm²/s).  Higher values
+        equalize temperature across the object faster (smoother field); lower
+        values keep sharper local hot spots.
+    * - ``density-kg-m3``
+      - ``1330.0``
+      - Material density.  With specific heat it sets the thermal mass: higher
+        density means a slower temperature change for the same heat input.
+    * - ``specific-heat-J-kgK``
+      - ``880.0``
+      - Heat capacity (J/kg·K).  Higher values require more energy to raise the
+        temperature, so the rise is slower and smaller.
+    * - ``emissivity``
+      - ``0.9``
+      - Surface emissivity in ``[0, 1]``.  Drives both halves of the modality: radiative
+        cooling in the solve (higher ε means more radiative loss, so a lower steady-state
+        temperature) and the ``thermal_radiance`` render, where a surface emits
+        ``ε·σ·T⁴`` and reflects ``(1 − ε)`` of the light arriving from its surroundings
+        (see the note below).
+
+.. note::
+
+   **What the radiance pass actually renders.**  Each surface is a gray body:
+
+   .. math::
+
+      L = \varepsilon\,\sigma T^4 \;+\; (1 - \varepsilon)\,L_{\text{incident}}
+
+   It emits :math:`\varepsilon\,\sigma T^4` from its own temperature and reflects the
+   remaining :math:`(1 - \varepsilon)` of whatever light reaches it.  Emissivity is read
+   **per vertex** from the material assignment, so different materials in one scene radiate
+   differently.
+
+   :math:`L_{\text{incident}}` is **not** a constant.  It is path-traced over the
+   hemisphere, so it gathers the radiance of every other surface in view — each of which is
+   emitting its own :math:`\varepsilon\,\sigma T^4` — plus the world background wherever
+   nothing blocks it.  A cool surface facing a hot one therefore picks up that neighbour,
+   weighted by how much of its hemisphere the neighbour covers.  The familiar closed form
+
+   .. math::
+
+      L = \varepsilon\,\sigma T^4 \;+\; (1 - \varepsilon)\,\sigma T_{\text{amb}}^4
+
+   is the special case in which nothing else is in view and the gather reduces to the world
+   term alone.  The world is a blackbody enclosure at ambient, emitting
+   :math:`\sigma T_{\text{amb}}^4`.
+
+   This is the contrast an LWIR camera actually sees, and it is why the preset library's
+   range matters: ``aluminium_polished`` (ε = 0.05) and ``skin`` (ε = 0.98) at the same
+   physical temperature are far apart in the image.  It is also why a low-emissivity surface
+   reads closer to *its surroundings* than to its own temperature — it is mostly mirroring
+   them, which is exactly what makes polished metal hard to measure with a real thermal
+   camera.
+
+   The reflection is **Lambertian, not specular**: the radiance is a cosine-weighted average
+   over the hemisphere, so a low-ε surface picks up the correct amount of energy from a hot
+   neighbour but does not show a mirror image of it.  Bounce counts are inherited from the
+   ``.blend`` rather than set by the thermal pass.
+
+Material presets
+~~~~~~~~~~~~~~~~
+
+The material knobs above are raw physical properties, so any material is a matter of
+supplying the right four numbers.  The **preset library** packages those numbers under a
+short key; a sidecar refers to a material by that key rather than repeating the values
+(see `Automatic material assignment (sidecars)`_).
+
+The table below shows 16 of the 29 presets, with the exact values the
+library uses.  **The full list of keys is the closed vocabulary a sidecar's** ``preset``
+**field accepts** — read it from
+:mod:`visionsim.simulate.heatsim.materials`'s ``_PRESET_TABLE``, or at runtime::
+
+    from visionsim.simulate.heatsim import materials
+    print(materials.preset_keys())
+
+Thermal **diffusivity** is the dominant knob for how heat *spreads* — metals conduct it
+across the whole object quickly, while glass, plastics and textiles keep it localized.
+**Emissivity** is what an LWIR camera sees: note ``aluminium_polished`` at 0.05 against
+``skin`` at 0.98, a 20x range.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 26 20 18 20 16
+
+    * - ``preset`` key
+      - ``thermal-diffusivity-mm2-s``
+      - ``density-kg-m3``
+      - ``specific-heat-J-kgK``
+      - ``emissivity``
+    * - ``aluminium``
+      - ``97``
+      - ``2700``
+      - ``978``
+      - ``0.2``
+    * - ``aluminium_polished``
+      - ``97``
+      - ``2700``
+      - ``978``
+      - ``0.05``
+    * - ``stainless_steel``
+      - ``4``
+      - ``7900``
+      - ``500``
+      - ``0.16``
+    * - ``copper``
+      - ``111``
+      - ``8960``
+      - ``385``
+      - ``0.15``
+    * - ``glass``
+      - ``0.34``
+      - ``2500``
+      - ``840``
+      - ``0.92``
+    * - ``marble``
+      - ``1.2``
+      - ``2700``
+      - ``880``
+      - ``0.94``
+    * - ``concrete``
+      - ``0.5``
+      - ``2300``
+      - ``880``
+      - ``0.92``
+    * - ``plaster``
+      - ``0.4``
+      - ``1200``
+      - ``1090``
+      - ``0.91``
+    * - ``drywall``
+      - ``0.31``
+      - ``800``
+      - ``1090``
+      - ``0.9``
+    * - ``wood``
+      - ``0.082``
+      - ``897``
+      - ``2380``
+      - ``0.9``
+    * - ``pvc``
+      - ``0.17``
+      - ``1330``
+      - ``880``
+      - ``0.93``
+    * - ``fabric``
+      - ``0.09``
+      - ``300``
+      - ``1300``
+      - ``0.95``
+    * - ``carpet``
+      - ``0.06``
+      - ``200``
+      - ``1300``
+      - ``0.9``
+    * - ``water``
+      - ``0.143``
+      - ``997``
+      - ``4182``
+      - ``0.96``
+    * - ``foliage``
+      - ``0.15``
+      - ``700``
+      - ``3000``
+      - ``0.96``
+    * - ``skin``
+      - ``0.11``
+      - ``1050``
+      - ``3470``
+      - ``0.98``
+
+
+Solver
+~~~~~~
+
+.. list-table::
+    :header-rows: 1
+    :widths: 28 14 58
+
+    * - Parameter
+      - Default
+      - Effect
+    * - ``irradiance-scale``
+      - ``100.0``
+      - Scales the absorbed-heat input that drives the temperature rise.  This is
+        the main knob for **how hot the scene gets** — larger values produce a
+        larger temperature rise.  (If the blend file carries authored thermal
+        scene settings, that authored value takes precedence over this flag.)
+    * - ``sim-time-s``
+      - ``1.0``
+      - Total simulated time of the static solve (seconds).  Longer times let the
+        scene heat closer to steady state.
+    * - ``timestep-s``
+      - ``0.05``
+      - Solver timestep (seconds).  Smaller steps are more accurate and stable at
+        higher cost; the solve runs ``sim-time-s / timestep-s`` steps.
+    * - ``domain``
+      - ``POINTS``
+      - FEM domain.  **Leave this on** ``POINTS`` **for scene content.**  It solves on a
+        surface point cloud and does not care about mesh connectivity, so it tolerates
+        the non-manifold, mixed quad/ngon, duplicated-vertex geometry that ordinary
+        archviz assets are full of.  ``MESH`` solves on the mesh connectivity directly,
+        which is only appropriate for clean, **fully triangulated, manifold** meshes —
+        see ``laplacian-backend`` below for why.
+    * - ``laplacian-backend``
+      - ``ROBUST``
+      - Discrete-Laplacian construction.  ``ROBUST`` builds a point-cloud Laplacian that
+        tolerates non-manifold and low-quality meshes.  ``IGL`` uses the libigl
+        **cotangent** Laplacian, which is defined per triangle: on quads or ngons it is
+        either undefined or silently poor, and degenerate (zero-area, sliver) triangles
+        make the cotangent weights blow up.  Prefer ``ROBUST`` unless you know the mesh
+        is triangulated and clean.
+    * - ``irradiance-source``
+      - ``DIRECT_KERNEL``
+      - Where absorbed flux comes from.  ``DIRECT_KERNEL`` is the analytic path: per-light
+        form factors, Embree shadow rays and a 9-coefficient SH sky.  It is fast, but it
+        counts **only objects of type** ``LIGHT`` plus the world sky, and models no
+        indirect bounce.  ``CYCLES_BAKE`` bakes DIFFUSE DIRECT+INDIRECT per object with
+        Cycles instead, so **emissive geometry, indirect bounce, portals and HDRI
+        transport** all contribute.  Prefer it whenever a scene's real light source is not
+        a lamp object — an interior daylit through emissive window planes or light
+        portals, or lit by emissive fixture panels, which is how such scenes are commonly
+        built.  The symptom of using the kernel there is a room that renders flat at its
+        initial temperature while its RGB render is well lit; switching source can change
+        the interior temperature spread by an order of magnitude.
+    * - ``bake-samples``
+      - ``1024``
+      - Cycles samples for the irradiance bake (``CYCLES_BAKE`` only).  Adaptive sampling
+        is **disabled** for the bake, so this is a true per-texel sample count rather than
+        a cap.  It is set here rather than inherited from the blend on purpose: production
+        blends are usually tuned for a *look*, often with a loose adaptive-sampling
+        threshold, and adaptive sampling terminates texels well below the nominal cap.
+        That is fine for a rendered image and not fine for a physical input, because baked
+        irradiance noise propagates into the temperature field.  A steady-state surface
+        sits at ``T ~ (E/(eps*sigma))**0.25``, so a relative error in irradiance appears as
+        roughly a quarter of that in temperature — a bake left noisy at the single-digit
+        percent level shows up as several-Kelvin blotching.  Raising this only helps as
+        ``1/sqrt(N)``, so quadrupling the samples buys a little under half the noise; if a
+        bake is visibly blotchy, check first whether adaptive sampling or a shading-heavy
+        material is the real cause.  Denoising does **not** apply to a bake, so sample
+        count is the only lever here.
+    * - ``irradiance-texture-size``
+      - ``512``
+      - Resolution of the Cycles bakes, in pixels per side.  Governs the albedo bake and,
+        under ``CYCLES_BAKE``, the irradiance bake.  This is the bake's **spatial detail**,
+        as distinct from ``bake-samples``, which is its **noise**: more samples give a
+        smoother bake at the same resolution and cannot recover detail the resolution never
+        captured.  A large surface unwrapped into one 512 px tile gets few texels per square
+        metre however many samples you use, so raise this for scenes with big floors, walls
+        or ceilings.  Cost is quadratic in this value.
+    * - ``device``
+      - ``cuda``
+      - Compute device for the solve.  Falls back to ``cpu`` automatically when
+        CUDA is unavailable.
+    * - ``animated``
+      - ``False``
+      - Enable the per-frame transient solve described in `Animated geometry`_,
+        instead of the static single-shot solve above.  Requires
+        ``domain = POINTS``; with ``domain = MESH`` it logs a warning and falls
+        back to the static solve unchanged.
+    * - ``substeps-per-frame``
+      - ``4``
+      - Solver substeps computed within each rendered Blender frame in animated
+        mode.  More substeps make the per-frame integration more stable and
+        accurate, at extra solve cost; the internal timestep is
+        ``(1 / fps) / substeps-per-frame``.
+    * - ``frame-start`` / ``frame-end``
+      - scene frame range
+      - First/last frame of the animated solve.  Defaults to the blend file's
+        own ``frame_start``/``frame_end``.  Narrowing this range solves (and
+        caches) only the portion of the timeline you actually render.
+    * - ``every-n-frames``
+      - ``1``
+      - Solve every Nth frame instead of every frame, to cut solve cost on long
+        sequences.  Frames that are skipped hold the most recently solved
+        field rather than triggering a fresh solve.
+
+Render domain and the temperature atlas
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The solver produces a temperature per solve node; the render has to turn that into a
+temperature per *pixel*.  ``render-domain`` chooses how.
+
+``VERTEX`` (the default) writes the solved field back as a per-vertex
+``sim_temperature`` attribute and lets Blender interpolate it across faces.  That is
+exact when the mesh is dense, and coarse when it is not: a large floor slab modelled as a
+handful of vertices can only ever show a bilinear ramp, however detailed the underlying
+solve.  Architectural assets are full of such surfaces — big, flat, and cheap in geometry.
+
+``TEXEL`` instead packs every participating object into a shared **temperature atlas** —
+one tile per object in UV space — and the shader samples that image.  Render resolution is
+then set by texel density rather than vertex density, so the same 4-vertex slab can carry
+thousands of independent temperature samples.  This is what makes large flat surfaces
+(floors, walls, ceilings, table tops) render with real spatial structure.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 28 14 58
+
+    * - Parameter
+      - Default
+      - Effect
+    * - ``render-domain``
+      - ``VERTEX``
+      - ``VERTEX`` interpolates the per-vertex field across faces.  ``TEXEL`` builds the
+        atlas described above.  Use ``TEXEL`` for scenes with large, coarsely-tessellated
+        surfaces; it costs an atlas build plus one EXR per solve.
+    * - ``atlas-texel-density``
+      - ``1500.0``
+      - Target texels per m² of surface area.  Tile side is
+        ``ceil(sqrt(area_m2 * density))``, so this sets the effective spatial resolution
+        of the thermal field.  Total texels are ``Σ area × density``, so atlas size
+        grows **linearly** with this value (each object's tile *side* grows as its square
+        root).  Raising it sharpens detail at proportional memory cost.
+    * - ``atlas-tile-min`` / ``atlas-tile-max``
+      - ``16`` / ``512``
+      - Clamp on a single object's tile side in texels.  The minimum keeps tiny objects
+        from collapsing to a single texel; the maximum stops one large object from
+        dominating the atlas.
+    * - ``atlas-texel-soft-max``
+      - ``500000``
+      - Warn-only budget covering atlas texels **plus the vertices of every object that
+        stayed on the per-vertex path** (``Σ side² + retained_vertex_count``).  If the
+        request exceeds it, density is rescaled uniformly downward once and a warning is
+        emitted; a single corrective pass, so it is not an exact bound.
+
+**Which objects join the atlas.**  Membership is automatic, not a per-object switch.  An
+object joins when its own vertex density is below ``atlas-texel-density`` (its vertices are
+too sparse to sample it well), and it joins **unconditionally** when a topology-changing
+modifier — Subdivision, Solidify, Bevel, Geometry Nodes — makes its base and evaluated
+vertex counts differ.  In that case the per-vertex path cannot write a result back onto the
+base mesh at all, so the atlas is the only representation that works.  Objects whose native
+density already exceeds the target keep the vertex path, since atlasing them would throw
+resolution away.
+
+.. note::
+
+   Objects that are demoted from the atlas *and* cannot take a per-vertex write-back fall
+   back to a **constant fill** at the mean of their solved field — the whole object renders
+   as one flat temperature.  If a surface looks uniformly warm where you expect a gradient,
+   that is the cause, and the solve emits a warning naming the object.
+
+Recommended starting point
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For the interior scenes this modality targets:
+
+.. code-block:: shell
+
+    visionsim blender.render-animation scene.blend outdir/ \
+        --config.include-thermal \
+        --config.thermal.assignments assets/thermal/scene.thermal.json \
+        --config.thermal.domain POINTS \
+        --config.thermal.render-domain TEXEL \
+        --config.thermal.irradiance-source CYCLES_BAKE \
+        --config.thermal.bake-samples 1024 \
+        --config.thermal.sim-time-s 500 --config.thermal.timestep-s 1.0
+
+``domain POINTS`` because scene geometry is rarely clean enough for a cotangent operator;
+``render-domain TEXEL`` because such scenes are full of large, coarsely-tessellated
+surfaces; and ``irradiance-source CYCLES_BAKE`` because they are typically lit by emissive
+geometry rather than lamp objects, which the analytic kernel does not see at all.
+
+The shipped defaults (``VERTEX``, ``DIRECT_KERNEL``) are deliberately the *conservative*
+choices, so that turning the modality on changes as little as possible about an arbitrary
+blend.  They are the safe starting point, not the best one for any particular scene — treat
+the block above as the setting to reach for once you know your scene has these properties,
+and the tables above as the reasoning for departing from it.
+
+
+Radiance render and file formats
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+    :header-rows: 1
+    :widths: 24 14 62
+
+    * - Parameter
+      - Default
+      - Effect
+    * - ``radiance-scale``
+      - ``1.0``
+      - Brightness multiplier for the ``thermal_radiance`` image only.  A display
+        scale — it does not change the temperature solve.
+    * - ``exr-codec``
+      - ``DWAA``
+      - EXR compression codec for the ``temperature`` and ``thermal_radiance``
+        files (e.g. ``ZIP``, ``PIZ``, ``DWAA``, ``NONE``).
+    * - ``bit-depth``
+      - ``32``
+      - EXR channel bit depth, ``16`` or ``32``.  Use ``16`` for smaller files
+        where full float precision is not required.
+
+Per-object material overrides
+-----------------------------
+
+The `Material defaults`_ above apply to the whole scene.  To give a specific object a different
+material, add a ``heat_sim_material`` property group to it in the blend file (registered at
+``bpy.types.Object.heat_sim_material``).  Any field that is set overrides the corresponding
+global default **for that object only**; objects without the property group fall back to the
+globals.
+
+The per-object fields are:
+
+``initial_temperature_K``
+    Starting temperature (K) for the object's vertices.
+
+``thermal_diffusivity_mm2_s``
+    Thermal diffusivity in mm²/s.
+
+``density_kg_m3``
+    Material density (kg/m³).
+
+``specific_heat_J_kgK``
+    Specific heat capacity (J/kg·K).
+
+``emissivity``
+    Surface emissivity in ``[0, 1]``, used for the radiation boundary condition in the
+    solve.  It is written to the mesh as a per-vertex attribute but is **not** read by
+    the gray-body radiance shader (see the note below).
+
+``thermal_role``
+    Either ``"FEM_PARTICIPANT"`` (default — full transient solve) or
+    ``"DIRICHLET_SOURCE"`` (vertex temperatures pinned to a constant value every
+    step, i.e. a fixed-temperature heat source or sink).
+
+``dirichlet_temperature_K``
+    Constant temperature applied when ``thermal_role = "DIRICHLET_SOURCE"``.
+    Falls back to ``initial_temperature_K`` when set to 0.
+
+.. admonition:: Animated scenes
+
+    These two fields are the mechanism behind `Animated geometry`_.  Give the
+    topology-changing object — a pouring liquid, or any mesh whose vertex count
+    changes frame to frame — ``thermal_role = "DIRICHLET_SOURCE"`` and a
+    ``dirichlet_temperature_K``; leave stable-topology objects like the cup at
+    the default ``"FEM_PARTICIPANT"`` so their temperature evolves across the
+    animation instead of staying fixed.
+
+Automatic material assignment (sidecars)
+----------------------------------------
+
+`Per-object material overrides`_ are authored inside the blend file, one object at a time.  That
+does not scale to a published dataset of scenes whose objects have no thermal information and whose
+materials are named by artists (often not in English).  For that case VisionSim reads a committed
+**assignment sidecar**: a JSON file that maps each Blender *material name* to a thermal **preset**,
+and per material a role and (for heat sources) a reservoir temperature.  Pass it with:
+
+.. code-block:: bash
+
+    vsim blender.render-animation scene.blend out/ \
+        --config.include-thermal \
+        --config.thermal.assignments assets/thermal/scene.thermal.json
+
+When ``--config.thermal.assignments`` is omitted, behaviour is exactly as documented above
+(scene-wide `Material defaults`_ plus any in-blend `Per-object material overrides`_).  When it is
+supplied, thermal properties are resolved **per material slot**: a stool's metal legs and wooden
+seat get different :math:`\alpha, \rho, c, \varepsilon`, and an emissive lamp element becomes a
+pinned heat source while its glass shade solves normally.  A material the sidecar does not name, or
+names with an unknown preset, falls back to the scene defaults.
+
+Slot-to-vertex resolution
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Blender stores materials on faces; the solver wants one value per vertex.  Almost every vertex is
+interior to a single material, so resolution is a lookup.  At a **seam** — a vertex touching faces
+of two materials — continuous properties (:math:`\alpha, \rho, c, \varepsilon`, initial
+temperature) are the **area-weighted mean** of the incident faces, while categorical facts (is the
+vertex a pinned heat source, and at what temperature) take the **dominant** incident material by
+area.  A vertex cannot be "partly pinned", so the pin is a majority vote, not a blend.
+
+.. note::
+
+    Per-slot resolution needs the object's base-mesh vertex count to match the evaluated geometry.
+    An object carrying a **topology-changing modifier** (Subdivision Surface, Array, …) changes that
+    count, so it falls back to object-level (scene-default or ``heat_sim_material``) properties for
+    the whole object, with a warning naming it.  The static per-slot dataset path does not use such
+    modifiers; this only affects hand-authored scenes that do.
+
+Authoring a sidecar
+~~~~~~~~~~~~~~~~~~~~
+
+A sidecar is a small JSON document.  Author it however suits the scene — by hand for a
+handful of materials, or with a script or a language model for a scene with a hundred
+artist-named ones.  Only the schema below matters; the renderer just reads the committed
+JSON.
+
+.. code-block:: json
+
+    {
+      "schema_version": 1,
+      "scene": "kitchen1.blend",
+      "defaults": { "preset": "plaster" },
+      "materials": {
+        "PARED blanca":  { "preset": "plaster" },
+        "encimera":      { "preset": "marble" },
+        "grifo":         { "preset": "stainless_steel" },
+        "cortina":       { "preset": "fabric" },
+        "madera puerta": { "preset": "wood", "confidence": 0.6,
+                           "reason": "door slab; grain texture, no metal shader" }
+      }
+    }
+
+**Top level**
+
+``schema_version`` (required)
+    Must be ``1``.  A missing or different value is an error, not a warning — the loader
+    refuses a sidecar it cannot interpret rather than guessing.
+
+``scene``
+    The blend file this was authored against.  Informational.
+
+``defaults``
+    Optional scene-wide fallback, e.g. ``{"preset": "plaster"}``.  Used for any material the
+    ``materials`` block does not name.  Omit it (or use ``{}``) to fall back to the
+    scene-wide `Material defaults`_ instead.
+
+``materials``
+    Maps a Blender **material name** (exactly as it appears in the blend) to one entry.
+
+**Per-material entry**
+
+``preset`` (the only field that usually matters)
+    One of the keys in the preset library — see `Material presets`_, or call
+    ``materials.preset_keys()`` for the authoritative list.  Use ``null`` to say
+    "deliberately unassigned", which falls back to ``defaults`` and then to the global
+    knobs.  An unknown key is rejected rather than silently guessed.
+
+``role``
+    ``"FEM_PARTICIPANT"`` (default) — the material solves normally.
+    ``"DIRICHLET_SOURCE"`` — the material is *pinned* at a fixed temperature and acts as a
+    heat source rather than solving.  Use it for a lamp element,
+    a hotplate, a radiator: something whose temperature you are asserting rather than
+    simulating.
+
+``dirichlet_K``
+    The fixed temperature for a ``DIRICHLET_SOURCE``, in Kelvin.  Ignored for a
+    ``FEM_PARTICIPANT``.  Accepted range is 280–500 K; a value outside it is dropped **with
+    a warning**, and the role degrades to ``FEM_PARTICIPANT``.  That degrade is deliberate:
+    keeping the role while dropping the temperature would pin the object at *ambient*,
+    silently turning an intended heat source into a heat **sink**, which is a worse and much
+    harder-to-spot failure than simply letting it solve normally.
+
+``confidence`` / ``reason``
+    Free-form provenance, ignored by the loader.  Useful when a sidecar is reviewed later:
+    they record how sure the author was and why.
+
+.. note::
+
+    The sidecars shipped in ``assets/thermal/`` use no ``DIRICHLET_SOURCE`` entries — every
+    material is a ``FEM_PARTICIPANT``, so no object is held at a fixed temperature and every
+    surface solves from the same ambient start.  Pin a source only when you actually want to
+    assert a temperature.
+
+Optional helper
+^^^^^^^^^^^^^^^
+
+``scripts/thermal_assign.py`` (outside the installed package) is handy for larger scenes.  It
+can inventory a scene's materials — names, slot areas, node graphs, emission — as JSON, and
+render an HTML review sheet for an existing sidecar sorted by surface area:
+
+.. code-block:: bash
+
+    # inventory the scene's materials (runs inside Blender)
+    blender -b scene.blend --python scripts/thermal_assign.py -- dump --output scene.materials.json
+
+    # review an existing sidecar against that inventory
+    python scripts/thermal_assign.py report scene.materials.json \
+        assets/thermal/scene.thermal.json --output scene.review.html
+
+Check the high-coverage materials first — they dominate the result.  Watch for render helpers
+such as a *daylight portal*: they carry an emission node and read as a heat source, which is
+rarely what you want.
+
+Solve caching
+-------------
+
+The FEM solve is **lazy and cached**.  On the first render of a given blend file with a given set
+of solver parameters, VisionSim runs the full solve and writes the per-object temperature
+histories to::
+
+    <blend_file>.heatsim/<cache_key>/temperatures.npz
+
+where ``<cache_key>`` is a 16-character digest derived from the blend file path, its modification
+timestamp, the solver configuration, the sorted list of participating object names, and the
+SHA-256 of the material sidecar (if one is given).  Subsequent renders that use the same blend
+file and the same parameters **skip the solve entirely** and load the cached result.  Changing any
+solver parameter, editing the sidecar, or touching the blend produces a new cache key and triggers
+a fresh solve.
+
+.. note::
+
+   The key includes the blend's modification timestamp, so *any* write to the ``.blend`` — even
+   one that changes nothing relevant to the solve — invalidates every cached solve for it.
+
+To prime the cache ahead of a render run — useful when the solve is expensive and you want
+rendering to start immediately — run the solve on its own:
+
+.. code-block:: bash
+
+    vsim blender.heatsim-solve scene.blend \
+        --config.thermal.device cpu
+
+Because the cache key is anchored to the source blend file, a primed solve is reused by all later
+``vsim blender.render-animation`` calls against the same blend at the same solver settings — even
+in a different output directory.
+
+.. note::
+
+   ``heatsim-solve`` always runs the **static** solve; it accepts ``--config.thermal.animated``
+   but ignores it. The animated path writes a different cache under a different key, so an
+   animated render is not served by a primed static solve. The subcommand also accepts the rest
+   of the render config (``--config.include-*``, ``--config.frames.*`` …) and ignores all of it —
+   only ``--config.thermal.*`` has any effect.
+
+Using thermal from the API
+--------------------------
+
+The same parameters are available when driving VisionSim programmatically.  ``ThermalConfig`` holds
+every setting shown above and is attached to ``RenderConfig.thermal`` (gated by
+``RenderConfig.include_thermal``); the render job forwards it to the two service calls that set up
+thermal on the Blender side:
+
+* :meth:`~visionsim.simulate.blender.BlenderService.exposed_prepare_thermal` — runs (or loads from
+  cache) the FEM solve and prepares the scene for thermal rendering.
+* :meth:`~visionsim.simulate.blender.BlenderService.exposed_include_thermal` — wires the
+  temperature AOV, the inferno preview, and the gray-body radiance pass into the compositor.
+* :meth:`~visionsim.simulate.blender.BlenderService.exposed_heatsim_solve` — the standalone
+  solve-and-cache entry point behind ``vsim blender.heatsim-solve``.
+
+See :mod:`visionsim.simulate.config` for the full ``ThermalConfig`` field reference.

--- a/docs/source/sections/simulation.rst
+++ b/docs/source/sections/simulation.rst
@@ -7,3 +7,4 @@ World Simulation
    blender/groundtruths
    blender/keyframing
    blender/rendering
+   blender/thermal

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,11 +54,67 @@ path = "visionsim/__init__.py"
 
 [tool.ruff]
 line-length = 121
-exclude = ["visionsim/interpolate/rife/*"]
+force-exclude = true
+# The heatsim modules below are vendored near-verbatim from heat-sim-blender @ e5b4afe;
+# linting them would force edits that diverge from upstream. The exemption is
+# provenance-based, and it is applied by measurement, not by intent: each file below is
+# within a few percent of its upstream original (bvh_backend 2%, sky_visibility 4%,
+# sh9_sky 5%, temperature_io 6%). Files that started vendored but have since been
+# substantially rewritten here -- laplacian.py, light_models.py, constants.py,
+# uv_utils.py -- are deliberately NOT listed: they are ours to maintain and are linted
+# and type-checked like the rest. Provenance and per-file drift:
+# docs/devlog/vendoring/ on the heatsim-devdocs branch.
+exclude = [
+    "visionsim/interpolate/rife/*",
+    "visionsim/simulate/heatsim/solver.py",
+    "visionsim/simulate/heatsim/sh9_sky.py",
+    "visionsim/simulate/heatsim/sky_visibility.py",
+    "visionsim/simulate/heatsim/bvh_backend.py",
+    "visionsim/simulate/heatsim/temperature_io.py",
+]
+
+[tool.ruff.lint.per-file-ignores]
+# BLE001 (blind except) and S110 (try-except-pass) are load-bearing in the heatsim
+# modules, not oversights. These call Blender operators (`bpy.ops.*`) which raise
+# undocumented exception types and fail in `--background` for reasons that are not part
+# of Blender's public API -- a poll() failure on one object's UV unwrap, a mode_set that
+# cannot find a valid context. The pipeline solves whole scenes (289 objects for
+# visionsim50/diningroom), and one object's operator failure must degrade that object to
+# a documented fallback rather than abort the scene. Narrowing to a specific exception
+# type would mean guessing at Blender internals, and letting them propagate would trade a
+# per-object degradation for a total loss.
+#
+# KNOWN GAP, tracked in docs/devlog/ on heatsim-devdocs: only 4 of the 40 such handlers
+# currently log anything. Silent degradation has already cost this project real debugging
+# time -- an irradiance array silently dropped for 79% of objects, and 231 objects
+# silently demoted out of the atlas, both of which presented as plausible-looking output.
+# The fix is to log at debug level in these handlers, not to remove them; that is a
+# behavioural change and is deliberately kept out of a lint cleanup.
+"visionsim/simulate/heatsim/*" = ["BLE001", "S110"]
+
+# TRY004 asks that isinstance() guards raise TypeError. materials.py deliberately raises
+# ValueError for *every* malformed-sidecar condition -- schema_version mismatch, preset
+# constraint violations, duplicate keys, and these shape checks alike -- so a caller can
+# catch one exception type for "this sidecar is invalid". Splitting three of them out to
+# TypeError would fragment that contract into `except (ValueError, TypeError)` for no
+# gain: a JSON document's shape is a property of the value, not a Python type error.
+"visionsim/simulate/heatsim/materials.py" = ["BLE001", "S110", "TRY004"]
 
 [tool.mypy]
 exclude = [
     "visionsim/interpolate/rife/*",
+    "visionsim/simulate/heatsim/solver\\.py",
+    "visionsim/simulate/heatsim/laplacian\\.py",
+    "visionsim/simulate/heatsim/constants\\.py",
+    "visionsim/simulate/heatsim/irradiance_kernel\\.py",
+    "visionsim/simulate/heatsim/light_models\\.py",
+    "visionsim/simulate/heatsim/sh9_sky\\.py",
+    "visionsim/simulate/heatsim/sky_visibility\\.py",
+    "visionsim/simulate/heatsim/bvh_backend\\.py",
+    "visionsim/simulate/heatsim/temperature_io\\.py",
+    "visionsim/simulate/heatsim/properties\\.py",
+    "visionsim/simulate/heatsim/irradiance\\.py",
+    "visionsim/simulate/heatsim/uv_utils\\.py",
 ]
 follow_imports="skip"
 

--- a/scripts/thermal_assign.py
+++ b/scripts/thermal_assign.py
@@ -1,0 +1,557 @@
+"""Offline thermal material assignment for VisionSim scenes: dump -> assign -> report.
+
+**Deliberately outside the ``visionsim`` package.** It needs an API key and makes a
+network call, neither of which belongs in a simulator library. It imports from
+``visionsim``; nothing in ``visionsim`` imports it. Run once per scene; the
+committed sidecar is the artifact, and the render path reads only that JSON.
+
+Subcommands::
+
+    # 1. inventory a scene's materials (runs inside Blender)
+    blender -b scene.blend --python scripts/thermal_assign.py -- dump --output scene.materials.json
+
+    # 2. draft a sidecar with an LLM (host python; the only network call)
+    python scripts/thermal_assign.py assign scene.materials.json --output scene.thermal.json
+
+    # 3. render a review contact sheet, then correct the sidecar by hand
+    python scripts/thermal_assign.py report scene.materials.json scene.thermal.json --output review.html
+
+The LLM is provider-neutral: a plain OpenAI-compatible ``/chat/completions`` POST
+over stdlib ``urllib``, so there is no SDK dependency and any compatible backend
+works (OpenAI, a LiteLLM proxy, OpenRouter, vLLM, a local model). Configure with:
+
+* ``LLM_API_KEY``  - required (``OPENAI_API_KEY`` also accepted)
+* ``LLM_BASE_URL`` - default ``https://api.openai.com/v1``
+* ``LLM_MODEL``    - default ``gpt-4o-mini``
+
+Whatever the model returns passes through :func:`apply_guards` before it is
+written, so a hallucinated preset, a skipped material, or a nonsense reservoir
+temperature degrades to "unassigned, use globals" with a warning - never to a
+silent wrong guess. The guards are the contract, not the server's schema support.
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import os
+import sys
+import urllib.request
+import warnings
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from visionsim.simulate.heatsim.materials import (
+    MAX_DIRICHLET_K,
+    MIN_DIRICHLET_K,
+    PRESETS,
+    preset_keys,
+)
+
+DEFAULT_LAMP_K = 345.0
+"""Reservoir temperature for an emissive material with no model-supplied value."""
+
+_ROLES = ("FEM_PARTICIPANT", "DIRICHLET_SOURCE")
+_LOW_CONFIDENCE = 0.5
+
+
+# ---------------------------------------------------------------------------
+# dump
+# ---------------------------------------------------------------------------
+
+
+def _socket(node: Any, name: str) -> Any:
+    inputs = getattr(node, "inputs", None)
+    if inputs is None:
+        return None
+    try:
+        value = getattr(inputs[name], "default_value", None)
+    except (KeyError, TypeError, IndexError):
+        return None
+    if value is None:
+        return None
+    if hasattr(value, "__len__") and not isinstance(value, (str, bytes)):
+        return [float(component) for component in list(value)[:3]]
+    return float(value)
+
+
+def _describe(material: Any) -> dict[str, Any]:
+    """Name, textures, a Principled-BSDF summary, and emission state.
+
+    The BSDF numbers are context for the model, never a decision rule: these scenes
+    are artist-authored for looks, so wood shows up with metallic=0.51 and glass
+    with metallic=1.0. Emission is the one reliable signal.
+    """
+    bsdf: dict[str, Any] = {}
+    emission = {"is_emissive": False, "strength": 0.0}
+    textures: list[str] = []
+    node_types: list[str] = []
+
+    if getattr(material, "use_nodes", False):
+        for node in getattr(getattr(material, "node_tree", None), "nodes", []):
+            node_type = str(getattr(node, "type", ""))
+            node_types.append(node_type)
+            if node_type == "TEX_IMAGE":
+                image = getattr(node, "image", None)
+                name = getattr(image, "name", None) if image is not None else None
+                if name:
+                    textures.append(str(name))
+            elif node_type == "BSDF_PRINCIPLED" and not bsdf:
+                bsdf = {
+                    "base_color": _socket(node, "Base Color"),
+                    "metallic": _socket(node, "Metallic"),
+                    "roughness": _socket(node, "Roughness"),
+                    "transmission": _socket(node, "Transmission Weight"),
+                }
+                strength = _socket(node, "Emission Strength")
+                color = _socket(node, "Emission Color")
+                # Blender 4.x defaults Principled BSDF to Emission Strength=1.0 with a
+                # BLACK emission color, i.e. zero actual emission. Strength alone would
+                # spuriously flag most materials as heat sources on a modern scene. An
+                # absent color socket means an older Blender where strength alone is
+                # the right signal (these are older archviz assets).
+                if strength and (color is None or max(color) > 1e-6):
+                    emission = {"is_emissive": True, "strength": float(strength)}
+            elif node_type == "EMISSION":
+                emission = {"is_emissive": True, "strength": float(_socket(node, "Strength") or 0.0)}
+
+    return {"name": str(material.name), "textures": sorted(set(textures)), "bsdf": bsdf,
+            "emission": emission, "node_types": sorted(set(node_types))}
+
+
+def collect_scene_materials(scene: Any, bpy_data: Any) -> dict[str, Any]:
+    """Build the material inventory for *scene*.
+
+    ``face_area_share`` is what makes review tractable: it ranks materials by how
+    much surface they actually cover, so attention goes to the walls and floor
+    before the 44-vertex logo.
+    """
+    objects = []
+    for obj in getattr(scene, "objects", []):
+        if getattr(obj, "type", None) != "MESH" or getattr(obj, "hide_render", False):
+            continue
+        visible = getattr(obj, "visible_get", None)
+        if visible is not None and not visible():
+            continue
+        objects.append(obj)
+
+    area_by_material: dict[str, float] = {}
+    objects_by_material: dict[str, list[str]] = {}
+    n_vertices = 0
+
+    for obj in objects:
+        mesh = getattr(obj, "data", None)
+        if mesh is None:
+            continue
+        n_vertices += len(getattr(mesh, "vertices", []))
+        slot_names: list[str | None] = []
+        for slot in getattr(obj, "material_slots", []):
+            material = getattr(slot, "material", None)
+            slot_names.append(None if material is None else str(material.name))
+        if not slot_names:
+            continue
+
+        for poly in getattr(mesh, "polygons", []):
+            index = min(max(int(getattr(poly, "material_index", 0)), 0), len(slot_names) - 1)
+            name = slot_names[index]
+            if name is None:
+                continue
+            area_by_material[name] = area_by_material.get(name, 0.0) + float(getattr(poly, "area", 0.0))
+            users = objects_by_material.setdefault(name, [])
+            if obj.name not in users:
+                users.append(obj.name)
+
+    total = sum(area_by_material.values())
+    entries = []
+    for material in getattr(bpy_data, "materials", []):
+        entry = _describe(material)
+        entry["face_area_share"] = (area_by_material.get(entry["name"], 0.0) / total) if total > 0.0 else 0.0
+        entry["objects"] = sorted(objects_by_material.get(entry["name"], []))
+        entries.append(entry)
+    entries.sort(key=lambda m: (-m["face_area_share"], m["name"]))
+
+    return {"schema_version": 1, "n_mesh_objects": len(objects), "n_vertices": n_vertices, "materials": entries}
+
+
+# ---------------------------------------------------------------------------
+# assign
+# ---------------------------------------------------------------------------
+
+
+def build_prompt(dump: dict[str, Any]) -> str:
+    """Render the per-scene prompt: the closed preset menu, then the material inventory."""
+    menu = "\n".join(
+        f"- {key}: alpha={p.alpha_mm2_s} mm2/s, rho={p.density_kg_m3} kg/m3, "
+        f"c={p.specific_heat_J_kgK} J/kgK, emissivity={p.emissivity_ir} - {p.notes}"
+        for key, p in sorted(PRESETS.items())
+    )
+
+    lines = []
+    for material in dump["materials"]:
+        parts = [f"name={material['name']!r}", f"area_share={material['face_area_share']:.4f}"]
+        if material.get("objects"):
+            parts.append(f"used_by={material['objects'][:6]}")
+        if material.get("textures"):
+            parts.append(f"textures={material['textures'][:6]}")
+        if material.get("emission", {}).get("is_emissive"):
+            parts.append(f"EMISSIVE(strength={material['emission']['strength']})")
+        if material.get("bsdf"):
+            parts.append(f"bsdf={material['bsdf']}")
+        lines.append("- " + ", ".join(parts))
+
+    return f"""You are assigning thermal material properties to the materials of a Blender interior scene, \
+so a finite-element heat-transfer simulation can produce physically plausible thermal (LWIR) imagery.
+
+Assign exactly one preset from this closed library to every material listed below:
+
+{menu}
+
+Guidance:
+- The material NAME is your strongest signal. These scenes come from an international asset community, \
+so names may be Spanish, Portuguese, Polish, German or English (e.g. "MADERA" = wood, "CRISTAL" = glass, \
+"MUROS" = walls, "AGUA" = water, "hojas" = leaves, "CESPED" = grass).
+- Texture filenames are the next best signal, especially for opaque names like "_87" or "archmodels66_033_1".
+- The Principled-BSDF numbers are CONTEXT ONLY, never a rule. These scenes were authored for appearance, \
+not physics: wood appears with metallic=0.51 and glass with metallic=1.0. Do not classify from them.
+- Emissivity matters more than diffusivity for how a thermal frame looks. Choose "aluminium_polished" \
+(emissivity 0.05) only for genuinely bare, shiny metal; choose "metal_painted" (emissivity 0.92) for \
+anything coated, painted or powder-coated. When a metal object is ambiguous, prefer "metal_painted".
+- Set role="DIRICHLET_SOURCE" with a plausible dirichlet_K (between {MIN_DIRICHLET_K:.0f} and \
+{MAX_DIRICHLET_K:.0f} K) ONLY for things genuinely warmer than the room: emissive lamp elements \
+(~340-360 K), an active stove or oven surface (~400-450 K), a radiator (~330-340 K), a running TV, \
+monitor or laptop (~305-315 K), a fridge's warm compressor grille (~305 K), human skin (~307 K). \
+Everything else is role="FEM_PARTICIPANT" with dirichlet_K=null.
+- Do NOT mark something a source just because it belongs to a lamp or appliance: a lamp's metal stem and \
+glass shade are FEM participants; only the emissive element is a source.
+- Report a low confidence rather than inventing a specific answer. Confidence is 0.0 to 1.0.
+- Give a one-line reason naming the evidence you used.
+
+Materials in this scene (sorted by the fraction of surface area they cover):
+{chr(10).join(lines)}
+
+Respond with JSON only, in exactly this shape, with one entry for EVERY material above, \
+using the exact name string given:
+
+{{"assignments": [{{"material": "<exact name>", "preset": "<one of the library keys>", \
+"role": "FEM_PARTICIPANT" or "DIRICHLET_SOURCE", "dirichlet_K": <number or null>, \
+"confidence": <0.0-1.0>, "reason": "<one line>"}}]}}
+"""
+
+
+def parse_assignments_content(content: str) -> list[dict[str, Any]]:
+    """Extract the ``assignments`` list from a chat-completion message body.
+
+    Reasoning-capable models (GLM, several others) wrap their answer in a
+    ```json ... ``` markdown fence even when asked for ``response_format:
+    json_object``, so a bare ``json.loads`` fails on the leading fence. Strip an
+    optional fence, then parse. Raises ``ValueError`` with the offending text if
+    the payload still isn't the expected shape, so a bad endpoint fails loudly
+    rather than silently yielding an empty draft.
+    """
+    text = content.strip()
+    if text.startswith("```"):
+        # Drop the opening fence line (``` or ```json) and the closing fence.
+        text = text.split("\n", 1)[1] if "\n" in text else ""
+        if text.rstrip().endswith("```"):
+            text = text.rstrip()[:-3]
+        text = text.strip()
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"model did not return JSON: {content[:200]!r}") from exc
+    if not isinstance(parsed, dict) or "assignments" not in parsed:
+        raise ValueError(f"model JSON lacks an 'assignments' array: {content[:200]!r}")
+    return list(parsed["assignments"])
+
+
+def request_assignments(dump: dict[str, Any]) -> list[dict[str, Any]]:  # pragma: no cover - network
+    """POST the prompt to an OpenAI-compatible ``/chat/completions`` endpoint."""
+    api_key = os.environ.get("LLM_API_KEY") or os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        raise SystemExit(
+            "Set LLM_API_KEY (any OpenAI-compatible endpoint).\n"
+            "  Optional: LLM_BASE_URL (default https://api.openai.com/v1), LLM_MODEL (default gpt-4o-mini)"
+        )
+    base_url = os.environ.get("LLM_BASE_URL", "https://api.openai.com/v1").rstrip("/")
+    body = json.dumps({
+        "model": os.environ.get("LLM_MODEL", "gpt-4o-mini"),
+        "messages": [{"role": "user", "content": build_prompt(dump)}],
+        "response_format": {"type": "json_object"},
+        "temperature": 0,
+    }).encode("utf-8")
+    request = urllib.request.Request(
+        f"{base_url}/chat/completions",
+        data=body,
+        headers={"Content-Type": "application/json", "Authorization": f"Bearer {api_key}"},
+    )
+    with urllib.request.urlopen(request, timeout=600) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+    return parse_assignments_content(payload["choices"][0]["message"]["content"])
+
+
+def apply_guards(dump: dict[str, Any], raw_assignments: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    """Deterministically correct the model's output. Warns on every correction.
+
+    1. An assignment for a material not in the scene is dropped.
+    2. A material the model skipped is added back as unassigned.
+    3. An out-of-enum preset becomes ``None`` rather than a silent guess.
+    4. An unknown role becomes ``FEM_PARTICIPANT``.
+    5. A material with an EMISSION node is **forced** to ``DIRICHLET_SOURCE`` -
+       the node is ground truth and outranks the model's judgement.
+    6. A ``dirichlet_K`` outside the sane band is dropped; if the role was
+       ``DIRICHLET_SOURCE`` (and the material is not itself emissive, which would force
+       it back), the role is also degraded to ``FEM_PARTICIPANT`` -- otherwise the slot
+       would stay pinned at the ambient temperature and silently act as a heat sink.
+    """
+    known = set(preset_keys())
+    scene_materials = {m["name"]: m for m in dump["materials"]}
+    out: dict[str, dict[str, Any]] = {}
+
+    for item in raw_assignments:
+        name = str(item.get("material", ""))
+        if name not in scene_materials:
+            warnings.warn(f"thermal assign: {name!r} is not a material in this scene; dropping it",
+                          UserWarning, stacklevel=2)
+            continue
+
+        preset = str(item["preset"]) if item.get("preset") is not None else None
+        if preset is not None and preset not in known:
+            warnings.warn(f"thermal assign: {name!r} got unknown preset {preset!r}; marking unassigned",
+                          UserWarning, stacklevel=2)
+            preset = None
+
+        role = str(item.get("role") or "FEM_PARTICIPANT").upper()
+        if role not in _ROLES:
+            warnings.warn(f"thermal assign: {name!r} got unknown role {item.get('role')!r}; "
+                          "using FEM_PARTICIPANT", UserWarning, stacklevel=2)
+            role = "FEM_PARTICIPANT"
+
+        dirichlet_K = item.get("dirichlet_K")
+        if dirichlet_K is not None:
+            value = float(dirichlet_K)
+            if MIN_DIRICHLET_K <= value <= MAX_DIRICHLET_K:
+                dirichlet_K = value
+            elif role == "DIRICHLET_SOURCE":
+                # Dropping the temperature but leaving role=DIRICHLET_SOURCE would pin this
+                # slot at the ambient/initial temperature (alpha=0, no incident flux) -- an
+                # intended-but-nonsense-valued heat source silently becomes an ambient heat
+                # SINK. Degrade to FEM_PARTICIPANT instead (mirrors materials.load_assignments'
+                # identical guard). The EMISSION-node check below still overrides this back to
+                # DIRICHLET_SOURCE (with DEFAULT_LAMP_K) when the node is ground truth.
+                warnings.warn(f"thermal assign: {name!r} got dirichlet_K={value} outside "
+                              f"[{MIN_DIRICHLET_K}, {MAX_DIRICHLET_K}] K; dropping it and degrading role "
+                              "DIRICHLET_SOURCE -> FEM_PARTICIPANT (an out-of-band source pinned at "
+                              "ambient would otherwise silently act as a heat sink)",
+                              UserWarning, stacklevel=2)
+                role = "FEM_PARTICIPANT"
+                dirichlet_K = None
+            else:
+                warnings.warn(f"thermal assign: {name!r} got dirichlet_K={value} outside "
+                              f"[{MIN_DIRICHLET_K}, {MAX_DIRICHLET_K}] K; dropping it", UserWarning, stacklevel=2)
+                dirichlet_K = None
+
+        # Ground truth beats judgement: an EMISSION node IS a heat source.
+        if scene_materials[name].get("emission", {}).get("is_emissive"):
+            if role != "DIRICHLET_SOURCE":
+                warnings.warn(f"thermal assign: {name!r} has an EMISSION node; overriding model role "
+                              f"{role!r} to DIRICHLET_SOURCE", UserWarning, stacklevel=2)
+            role = "DIRICHLET_SOURCE"
+            if dirichlet_K is None:
+                dirichlet_K = DEFAULT_LAMP_K
+        if role != "DIRICHLET_SOURCE":
+            dirichlet_K = None
+
+        out[name] = {"preset": preset, "role": role, "dirichlet_K": dirichlet_K,
+                     "confidence": float(item.get("confidence", 0.0)), "reason": str(item.get("reason", ""))}
+
+    for name, entry in scene_materials.items():
+        if name not in out:
+            # Ground truth beats absence: an EMISSION node IS a heat source even if
+            # the model skipped the material entirely. That is a different, more
+            # consequential correction than "unassigned", so it gets its own warning
+            # rather than the generic "marking unassigned" one.
+            if entry.get("emission", {}).get("is_emissive"):
+                warnings.warn(f"thermal assign: no assignment returned for {name!r}, but it has an "
+                              "EMISSION node; forcing DIRICHLET_SOURCE", UserWarning, stacklevel=2)
+                role = "DIRICHLET_SOURCE"
+                dirichlet_K = DEFAULT_LAMP_K
+            else:
+                warnings.warn(f"thermal assign: no assignment returned for {name!r}; marking unassigned",
+                              UserWarning, stacklevel=2)
+                role = "FEM_PARTICIPANT"
+                dirichlet_K = None
+            out[name] = {"preset": None, "role": role, "dirichlet_K": dirichlet_K,
+                         "confidence": 0.0, "reason": "no assignment returned by the model"}
+    return out
+
+
+def to_sidecar(dump: dict[str, Any], guarded: dict[str, dict[str, Any]], scene_name: str) -> dict[str, Any]:
+    """Wrap guarded assignments in the envelope ``materials.load_assignments`` reads."""
+    ordered = [m["name"] for m in dump["materials"]]
+    return {
+        "schema_version": 1,
+        "scene": scene_name,
+        "generated_by": "scripts/thermal_assign.py - REVIEW AND CORRECT BY HAND BEFORE PUBLISHING",
+        "defaults": {"preset": "plaster"},
+        "materials": {name: guarded[name] for name in ordered if name in guarded},
+    }
+
+
+# ---------------------------------------------------------------------------
+# report
+# ---------------------------------------------------------------------------
+
+_CSS = """
+body { font-family: system-ui, sans-serif; margin: 2rem; color: #1a1a1a; background: #fff; }
+h1 { font-size: 1.4rem; margin-bottom: 0.2rem; }
+.sub { color: #666; margin-bottom: 1.5rem; font-size: 0.9rem; }
+table { border-collapse: collapse; width: 100%; font-size: 0.85rem; }
+th, td { border-bottom: 1px solid #e4e4e4; padding: 0.4rem 0.6rem; text-align: left; vertical-align: top; }
+th { background: #fafafa; position: sticky; top: 0; font-weight: 600; }
+td.num { text-align: right; font-variant-numeric: tabular-nums; }
+.swatch { display: inline-block; width: 1rem; height: 1rem; border: 1px solid #bbb; vertical-align: -2px; }
+.bar { display: inline-block; height: 0.55rem; background: #4a7fb5; vertical-align: 1px; }
+.tag { font-size: 0.7rem; font-weight: 700; padding: 0.1rem 0.35rem; border-radius: 3px; }
+.unassigned { background: #ffe0e0; color: #a00; }
+.source { background: #ffeccc; color: #a35200; }
+.lowconf { background: #fff6cc; color: #8a6d00; }
+tr.flagged { background: #fffaf5; }
+"""
+
+
+def _swatch(base_color: Any) -> str:
+    if not base_color or len(base_color) < 3:
+        return '<span class="swatch" style="background:#fff"></span>'
+    r, g, b = (max(0, min(255, round(float(x) ** (1 / 2.2) * 255))) for x in base_color[:3])
+    return f'<span class="swatch" style="background:rgb({r},{g},{b})"></span>'
+
+
+def build_report(dump: dict[str, Any], sidecar: dict[str, Any]) -> str:
+    """Render the review contact sheet, ordered by the surface area each material covers."""
+    entries = dict(sidecar.get("materials", {}))
+    rows: list[str] = []
+    n_unassigned = n_sources = n_low = 0
+
+    for material in dump["materials"]:
+        name = str(material["name"])
+        entry = entries.get(name, {})
+        preset_key = entry.get("preset")
+        preset = PRESETS.get(preset_key) if preset_key else None
+        confidence = float(entry.get("confidence", 0.0))
+        share = float(material.get("face_area_share", 0.0))
+
+        tags = []
+        if preset is None:
+            tags.append('<span class="tag unassigned">UNASSIGNED</span>')
+            n_unassigned += 1
+        if str(entry.get("role", "")) == "DIRICHLET_SOURCE":
+            temp = entry.get("dirichlet_K")
+            label = f"SOURCE {temp:.0f} K" if temp is not None else "SOURCE"
+            tags.append(f'<span class="tag source">{html.escape(label)}</span>')
+            n_sources += 1
+        if preset is not None and confidence < _LOW_CONFIDENCE:
+            tags.append('<span class="tag lowconf">LOW CONF</span>')
+            n_low += 1
+
+        # Precomputed because f-string expressions cannot contain backslashes or
+        # reuse the outer quote character before Python 3.12.
+        row_class = ' class="flagged"' if tags else ""
+        swatch = _swatch((material.get("bsdf") or {}).get("base_color"))
+        preset_cell = html.escape(preset_key) if preset_key else "&mdash;"
+        alpha_cell = f"{preset.alpha_mm2_s:g}" if preset else "&mdash;"
+        eps_cell = f"{preset.emissivity_ir:.2f}" if preset else "&mdash;"
+        bar_px = max(1, int(share * 120))
+        reason = html.escape(str(entry.get("reason", "")))
+        objects = html.escape(", ".join(material.get("objects", [])[:4]))
+
+        rows.append(
+            f"<tr{row_class}>"
+            f"<td>{swatch} <code>{html.escape(name)}</code></td>"
+            f'<td class="num">{share:.1%}<br><span class="bar" style="width:{bar_px}px"></span></td>'
+            f"<td>{preset_cell}</td>"
+            f'<td class="num">{alpha_cell}</td>'
+            f'<td class="num">{eps_cell}</td>'
+            f'<td class="num">{confidence:.2f}</td>'
+            f'<td>{" ".join(tags)}</td>'
+            f"<td>{reason}</td>"
+            f"<td>{objects}</td></tr>"
+        )
+
+    scene = html.escape(str(sidecar.get("scene", "?")))
+    return f"""<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"><title>Thermal assignments &mdash; {scene}</title>
+<style>{_CSS}</style></head><body>
+<h1>Thermal material assignments &mdash; {scene}</h1>
+<div class="sub">{len(dump['materials'])} materials &middot; {dump.get('n_mesh_objects', '?')} mesh objects
+&middot; {dump.get('n_vertices', '?')} vertices &middot; <b>{n_unassigned}</b> unassigned &middot;
+<b>{n_sources}</b> heat sources &middot; <b>{n_low}</b> low confidence &middot;
+sorted by surface area covered</div>
+<table><thead><tr>
+<th>Material</th><th>Area</th><th>Preset</th><th>&alpha; mm&sup2;/s</th><th>&epsilon;</th>
+<th>Conf.</th><th>Flags</th><th>Reason</th><th>Objects</th>
+</tr></thead><tbody>
+{chr(10).join(rows)}
+</tbody></table></body></html>
+"""
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:  # pragma: no cover - CLI
+    argv = sys.argv[sys.argv.index("--") + 1:] if "--" in sys.argv else sys.argv[1:]
+    parser = argparse.ArgumentParser(prog="thermal_assign", description=__doc__.split("\n")[0])
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_dump = sub.add_parser("dump", help="inventory a scene's materials (run inside Blender)")
+    p_dump.add_argument("--output", type=Path, required=True)
+
+    p_assign = sub.add_parser("assign", help="draft a sidecar with an LLM")
+    p_assign.add_argument("dump", type=Path)
+    p_assign.add_argument("--output", type=Path, required=True)
+
+    p_report = sub.add_parser("report", help="render a review contact sheet")
+    p_report.add_argument("dump", type=Path)
+    p_report.add_argument("sidecar", type=Path)
+    p_report.add_argument("--output", type=Path, required=True)
+
+    args = parser.parse_args(argv)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+
+    if args.command == "dump":
+        import bpy  # type: ignore
+
+        result = collect_scene_materials(bpy.context.scene, bpy.data)
+        result["scene"] = str(bpy.path.basename(bpy.data.filepath) or "")
+        args.output.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+        print(f"[thermal_assign] wrote {args.output}: {len(result['materials'])} materials")
+
+    elif args.command == "assign":
+        dump = json.loads(args.dump.read_text(encoding="utf-8"))
+        scene = str(dump.get("scene") or args.dump.name.replace(".materials.json", ".blend"))
+        guarded = apply_guards(dump, request_assignments(dump))
+        args.output.write_text(
+            json.dumps(to_sidecar(dump, guarded, scene), indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+        )
+        unassigned = [n for n, e in guarded.items() if e["preset"] is None]
+        sources = [n for n, e in guarded.items() if e["role"] == "DIRICHLET_SOURCE"]
+        low = [n for n, e in guarded.items() if e["preset"] is not None and e["confidence"] < _LOW_CONFIDENCE]
+        print(f"[thermal_assign] wrote {args.output}: {len(guarded)} materials")
+        print(f"[thermal_assign]   unassigned: {len(unassigned)} {unassigned[:8]}")
+        print(f"[thermal_assign]   heat sources: {len(sources)} {sources[:8]}")
+        print(f"[thermal_assign]   low confidence: {len(low)} {low[:8]}")
+
+    else:
+        dump = json.loads(args.dump.read_text(encoding="utf-8"))
+        sidecar = json.loads(args.sidecar.read_text(encoding="utf-8"))
+        args.output.write_text(build_report(dump, sidecar), encoding="utf-8")
+        print(f"[thermal_assign] wrote {args.output}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import json
 import os
+import shutil
 import sys
 import warnings
 from importlib.metadata import Distribution
@@ -38,13 +39,25 @@ def executable(pytestconfig):
         )
 
     install_dependencies(executable=executable_path, editable=True)
-    return executable_path
+
+    # Resolve to a real path. `--executable` defaults to None, and CI invokes a bare
+    # `pytest`, so tests that interpolate this into an argv (subprocess.run([str(exe), ...]))
+    # would otherwise spawn the literal string "None" and fail with FileNotFoundError.
+    # Tests that pass it to BlenderClient.spawn() tolerate None because that resolves
+    # against $PATH itself; argv-interpolating tests do not.
+    resolved = executable_path or shutil.which("blender")
+    if resolved is None:
+        pytest.skip("No Blender executable: pass --executable=/path/to/blender or put `blender` on PATH.")
+    return resolved
 
 
 @pytest.fixture(scope="session")
 def cube_dataset(tmp_path_factory, executable) -> Path:
     # Note: If this fails and you're using flatpak, it might be because
     #   the application doesn't have read/write access to /tmp!
+    # Note: This fixture also renders the thermal modality (prepare_thermal +
+    #   include_thermal), so a regression in the thermal pipeline will surface
+    #   across all cube_dataset-based tests, not only the thermal-specific ones.
     tmpdir = tmp_path_factory.mktemp("renders")
     log_dir = tmp_path_factory.mktemp("logs")
     scene = Path(__file__).parent / "test_files" / "scenes" / "cube.blend"
@@ -66,6 +79,8 @@ def cube_dataset(tmp_path_factory, executable) -> Path:
         client.include_diffuse_pass()
         client.include_specular_pass()
         client.include_points()
+        client.prepare_thermal(device="cpu", domain="POINTS")
+        client.include_thermal(radiance=True, preview=True)
         client.render_animation()
         client.save_file(tmpdir / "cube_out.blend")
     return tmpdir

--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -43,6 +43,7 @@ def get_public_members(obj, module=None):
         (blender.BlenderService.exposed_include_diffuse_pass, config.DiffusePassConfig),
         (blender.BlenderService.exposed_include_specular_pass, config.SpecularPassConfig),
         (blender.BlenderService.exposed_include_points, config.PointsConfig),
+        (blender.BlenderService.exposed_include_thermal, config.ThermalConfig),
     ],
 )
 def test_output_configs(func, conf):

--- a/tests/test_heatsim_adapter.py
+++ b/tests/test_heatsim_adapter.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import subprocess
+from types import SimpleNamespace
+
+from visionsim.simulate.heatsim import adapter
+
+# Distinctive globals so a leaked PropertyGroup default can never masquerade as a
+# global fallback (the PropertyGroup ships emissivity=0.9, density=1330.0).
+_GLOBAL_DEFAULTS = {
+    "initial_temperature_K": 300.0,
+    "thermal_diffusivity_mm2_s": 0.42,
+    "density_kg_m3": 1234.0,
+    "specific_heat_J_kgK": 777.0,
+    "emissivity": 0.5,
+}
+
+
+class _FakeMat:
+    """Stand-in for ``obj.heat_sim_material`` with a controllable ``is_property_set``.
+
+    ``always_set`` mirrors a PropertyGroup where every field was authored (True) or
+    where every field is still at its registered default (False) - the exact axis
+    that ``resolve_material`` must branch on.
+    """
+
+    def __init__(self, *, always_set: bool, **values):
+        self._always_set = always_set
+        for k, v in values.items():
+            setattr(self, k, v)
+
+    def is_property_set(self, attr):
+        return self._always_set
+
+
+def test_resolve_material_falls_back_to_globals_when_unset():
+    """I1 regression: unset per-object props must defer to the global defaults.
+
+    The PointerProperty is always present and a FloatProperty never returns None,
+    so without ``is_property_set`` gating the (distinctive) per-object values below
+    would shadow the globals and the ``--config.thermal.*`` knobs would be inert.
+    """
+    mat = _FakeMat(
+        always_set=False,
+        initial_temperature_K=295.372,  # PropertyGroup-style defaults that must be ignored
+        thermal_diffusivity_mm2_s=0.17,
+        density_kg_m3=1330.0,
+        specific_heat_J_kgK=880.0,
+        emissivity=0.9,
+        thermal_role="DIRICHLET_SOURCE",
+        dirichlet_temperature_K=400.0,
+    )
+    obj = SimpleNamespace(heat_sim_material=mat)
+
+    out = adapter.resolve_material(obj, _GLOBAL_DEFAULTS)
+
+    assert out["initial_temperature_K"] == 300.0
+    assert out["thermal_diffusivity_mm2_s"] == 0.42
+    assert out["density_kg_m3"] == 1234.0
+    assert out["specific_heat_J_kgK"] == 777.0
+    assert out["emissivity"] == 0.5
+    # thermal_role / dirichlet_temperature_K have no global key -> hard defaults,
+    # NOT the stale group values.
+    assert out["thermal_role"] == "FEM_PARTICIPANT"
+    assert out["dirichlet_temperature_K"] == 0.0
+
+
+def test_resolve_material_uses_per_object_when_set():
+    """Explicitly-set per-object values win over the globals (and are clamped)."""
+    mat = _FakeMat(
+        always_set=True,
+        initial_temperature_K=310.0,
+        thermal_diffusivity_mm2_s=0.99,
+        density_kg_m3=7777.0,
+        specific_heat_J_kgK=500.0,
+        emissivity=2.0,  # out of range -> must clamp to 1.0
+        thermal_role="dirichlet_source",  # lower-case -> upper-cased
+        dirichlet_temperature_K=400.0,
+    )
+    obj = SimpleNamespace(heat_sim_material=mat)
+
+    out = adapter.resolve_material(obj, _GLOBAL_DEFAULTS)
+
+    assert out["initial_temperature_K"] == 310.0
+    assert out["thermal_diffusivity_mm2_s"] == 0.99
+    assert out["density_kg_m3"] == 7777.0
+    assert out["specific_heat_J_kgK"] == 500.0
+    assert out["emissivity"] == 1.0
+    assert out["thermal_role"] == "DIRICHLET_SOURCE"
+    assert out["dirichlet_temperature_K"] == 400.0
+
+
+def test_solve_writes_finite_sim_temperature(executable, tmp_path):
+    """End-to-end adapter smoke test inside a real Blender process.
+
+    Builds a tiny lit scene (subdivided plane + overhead sun + a world with
+    some background light), runs the cached FEM solve via the adapter, writes
+    the last-timestep ``sim_temperature`` attribute, and asserts the result is
+    finite and physical. Also checks that the Direct-Kernel irradiance actually
+    produced non-zero per-vertex flux (so the test cannot pass with a silent
+    zero-flux fallback) and that a second ``solve_scene`` reuses the cache.
+    """
+    code = f"""
+import bpy, numpy as np
+from pathlib import Path
+from visionsim.simulate.heatsim import register, adapter
+
+register()
+
+# --- start from a clean scene -------------------------------------------------
+bpy.ops.object.select_all(action='SELECT')
+bpy.ops.object.delete()
+
+# Subdivided plane (grid) -> enough points for the ROBUST point-cloud Laplacian.
+bpy.ops.mesh.primitive_grid_add(x_subdivisions=15, y_subdivisions=15, size=2.0)
+plane = bpy.context.active_object
+plane.name = 'ThermalPlane'
+plane.heat_simulation_enabled = True
+
+# Overhead sun (default rotation emits along -Z, i.e. straight down).
+bpy.ops.object.light_add(type='SUN')
+sun = bpy.context.active_object
+sun.data.energy = 10.0
+
+# Give the world some light so the sky term is non-zero too.
+world = bpy.context.scene.world
+if world is None:
+    world = bpy.data.worlds.new('World')
+    bpy.context.scene.world = world
+world.use_nodes = True
+bg = world.node_tree.nodes.get('Background')
+if bg is not None:
+    bg.inputs['Color'].default_value = (0.2, 0.2, 0.2, 1.0)
+    bg.inputs['Strength'].default_value = 1.0
+
+defaults = dict(initial_temperature_K=295.0, thermal_diffusivity_mm2_s=0.17,
+                density_kg_m3=1330.0, specific_heat_J_kgK=880.0, emissivity=0.9,
+                irradiance_scale=100.0)
+solver_cfg = dict(sim_time_s=0.15, timestep_s=0.05, domain='POINTS',
+                  laplacian_backend='ROBUST', device='cpu')
+cache_root = Path(r'{tmp_path}')
+
+hist = adapter.solve_scene(bpy.context.scene, defaults=defaults,
+                           solver_cfg=solver_cfg, cache_root=cache_root)
+assert 'ThermalPlane' in hist, list(hist.keys())
+T_hist = np.asarray(hist['ThermalPlane'])
+assert T_hist.ndim == 2 and T_hist.shape[0] >= 2, T_hist.shape
+
+# Second call must come straight from the cache (no re-solve). We assert the
+# cache hit via the RETURN value (cached history equals the first solve), not via
+# captured stdout, so the test does not depend on any debug print side-effect.
+hist2 = adapter.solve_scene(bpy.context.scene, defaults=defaults,
+                            solver_cfg=solver_cfg, cache_root=cache_root)
+assert hist2.keys() == hist.keys(), (list(hist2.keys()), list(hist.keys()))
+assert np.array_equal(T_hist, np.asarray(hist2['ThermalPlane']))
+
+adapter.write_frame_attributes(bpy.context.scene, hist, timestep=-1, defaults=defaults)
+
+# sim_temperature: finite + physical.
+attr = plane.data.attributes['sim_temperature'].data
+vals = np.array([d.value for d in attr])
+assert np.isfinite(vals).all(), 'non-finite temperatures'
+assert vals.min() > 200 and vals.max() < 2000, (float(vals.min()), float(vals.max()))
+
+# emissivity attribute written.
+eps = np.array([d.value for d in plane.data.attributes['emissivity'].data])
+assert np.allclose(eps, 0.9), float(eps.mean())
+
+# The Direct-Kernel irradiance pass produced real (non-zero) flux.
+irr = np.array([d.value for d in plane.data.attributes['sim_irradiance'].data])
+assert np.isfinite(irr).all() and irr.max() > 0.0, float(irr.max())
+
+print('THERMAL_ADAPTER_OK')
+"""
+    out = subprocess.run([str(executable), "-b", "--python-expr", code], capture_output=True, text=True, check=False)
+    assert "THERMAL_ADAPTER_OK" in out.stdout, out.stderr
+
+
+def test_shared_mesh_objects_get_independent_copies(executable, tmp_path):
+    """Fix 3: linked duplicates (multiple objects pointing at one Mesh datablock) share
+    per-vertex attributes AND UV layers on that datablock, so writing sim_temperature for
+    one object overwrites the other -- last write wins. This is the minimal repro: two
+    objects sharing a mesh, given distinct fields (310 K / 350 K), both used to end up at
+    350 K. gather_meshes must un-share each object's mesh (once, idempotently) BEFORE any
+    per-vertex write happens, so each object ends up with -- and keeps -- its own values.
+    """
+    code = """
+import bpy, numpy as np
+from visionsim.simulate.heatsim import register, adapter
+
+register()
+
+bpy.ops.object.select_all(action='SELECT')
+bpy.ops.object.delete()
+
+bpy.ops.mesh.primitive_grid_add(x_subdivisions=6, y_subdivisions=6, size=1.0)
+obj_a = bpy.context.active_object
+obj_a.name = 'SharedA'
+obj_a.heat_simulation_enabled = True
+
+# Linked duplicate: obj_b shares obj_a's mesh datablock (mirrors Blender's Alt-D).
+obj_b = obj_a.copy()
+obj_b.name = 'SharedB'
+obj_b.location.x += 2.0
+bpy.context.collection.objects.link(obj_b)
+obj_b.heat_simulation_enabled = True
+
+assert obj_a.data is obj_b.data, 'objects must start out sharing one mesh datablock'
+assert obj_a.data.users >= 2, obj_a.data.users
+
+sim_objects = adapter.gather_meshes(bpy.context.scene)
+names = {o.name for o in sim_objects}
+assert names == {'SharedA', 'SharedB'}, names
+
+# After gather_meshes, each object must have its own single-user mesh.
+assert obj_a.data is not obj_b.data, 'meshes still shared after gather_meshes'
+assert obj_a.data.users == 1 and obj_b.data.users == 1, (obj_a.data.users, obj_b.data.users)
+
+# Hand-craft distinct histories (skip a full FEM solve -- Fix 3 is about write-back, not
+# the solver) and write them via the same function prepare_thermal uses.
+n = len(obj_a.data.vertices)
+defaults = dict(initial_temperature_K=295.0, thermal_diffusivity_mm2_s=0.17,
+                density_kg_m3=1330.0, specific_heat_J_kgK=880.0, emissivity=0.9)
+history = {'SharedA': np.full((2, n), 310.0), 'SharedB': np.full((2, n), 350.0)}
+adapter.write_frame_attributes(bpy.context.scene, history, timestep=-1, defaults=defaults)
+
+vals_a = np.array([d.value for d in obj_a.data.attributes['sim_temperature'].data])
+vals_b = np.array([d.value for d in obj_b.data.attributes['sim_temperature'].data])
+assert np.allclose(vals_a, 310.0), vals_a  # NOT 350.0 (the old last-write-wins bug)
+assert np.allclose(vals_b, 350.0), vals_b
+
+# Idempotent: a second gather_meshes call must not re-copy (already single-user).
+mesh_a_name, mesh_b_name = obj_a.data.name, obj_b.data.name
+adapter.gather_meshes(bpy.context.scene)
+assert obj_a.data.name == mesh_a_name and obj_b.data.name == mesh_b_name
+
+print('SHARED_MESH_OK')
+"""
+    out = subprocess.run([str(executable), "-b", "--python-expr", code], capture_output=True, text=True, check=False)
+    assert "SHARED_MESH_OK" in out.stdout, out.stderr
+
+
+def test_read_authored_irradiance_scale():
+    from visionsim.simulate.heatsim.adapter import read_authored_irradiance_scale
+
+    class _FakeScene:
+        def __init__(self, data):
+            self._data = data
+        def get(self, key, default=None):
+            return self._data.get(key, default)
+
+    # Authored heat_sim_settings with an irradiance_scale -> returns it.
+    authored = _FakeScene({"heat_sim_settings": {"irradiance_scale": 1000.0}})
+    assert read_authored_irradiance_scale(authored) == 1000.0
+
+    # No heat_sim_settings at all -> None (caller keeps its default).
+    assert read_authored_irradiance_scale(_FakeScene({})) is None
+
+    # heat_sim_settings present but no irradiance_scale key -> None.
+    partial = _FakeScene({"heat_sim_settings": {"fem_domain": "POINTS"}})
+    assert read_authored_irradiance_scale(partial) is None

--- a/tests/test_heatsim_animated.py
+++ b/tests/test_heatsim_animated.py
@@ -1,0 +1,341 @@
+from __future__ import annotations
+
+import subprocess
+
+# ---------------------------------------------------------------------------
+# Shared synthetic-scene builder: a POINTS-domain FEM plate sitting just under
+# a DIRICHLET_SOURCE box. The box's bottom face footprint matches the plate's
+# extent and sits a few mm above it, so cross-object point pairs are *closer*
+# than same-object neighbor spacing -- guaranteeing the point-cloud kNN
+# Laplacian links plate points to the hot reservoir (see adapter._combine /
+# solver._build_matrices POINTS branch: the Laplacian is a spatial graph over
+# ALL combined points, irrespective of which mesh they came from).
+# ---------------------------------------------------------------------------
+_SCENE_SETUP = r"""
+import bpy
+from visionsim.simulate.heatsim import register
+register()
+
+bpy.ops.object.select_all(action='SELECT')
+bpy.ops.object.delete()
+
+# Plate: FEM participant, stable topology, starts at (just under) ambient.
+bpy.ops.mesh.primitive_grid_add(x_subdivisions=6, y_subdivisions=6, size=0.4)
+plate = bpy.context.active_object
+plate.name = 'Plate'
+plate.heat_simulation_enabled = True
+plate.heat_sim_material.initial_temperature_K = 295.0
+plate.heat_sim_material.thermal_diffusivity_mm2_s = 50.0
+
+# Box: Dirichlet reservoir at 369 K, bottom face directly above the plate.
+bpy.ops.mesh.primitive_cube_add(size=0.4, location=(0.0, 0.0, 0.205))
+box = bpy.context.active_object
+box.name = 'Box'
+box.heat_simulation_enabled = True
+box.heat_sim_material.thermal_role = 'DIRICHLET_SOURCE'
+box.heat_sim_material.dirichlet_temperature_K = 369.0
+"""
+
+_DEFAULTS = """
+defaults = dict(initial_temperature_K=295.0, thermal_diffusivity_mm2_s=0.17,
+                density_kg_m3=1330.0, specific_heat_J_kgK=880.0, emissivity=0.9,
+                irradiance_scale=100.0)
+solver_cfg = dict(domain='POINTS', laplacian_backend='ROBUST', device='cpu')
+"""
+
+
+def test_animated_solve_heats_plate_toward_dirichlet_source(executable, tmp_path):
+    code = (
+        _SCENE_SETUP
+        + _DEFAULTS
+        + """
+import numpy as np
+from pathlib import Path
+from visionsim.simulate.heatsim import adapter
+
+bpy.context.scene.frame_start = 1
+bpy.context.scene.frame_end = 5
+
+history, frames = adapter.solve_scene_animated(
+    bpy.context.scene, defaults=defaults, solver_cfg=solver_cfg,
+    cache_root=Path(r'{tmp_path}'),
+    frame_start=1, frame_end=5, every_n=1, substeps_per_frame=4,
+)
+
+assert frames == [1, 2, 3, 4, 5], frames
+assert 'Plate' in history, list(history.keys())
+assert 'Box' not in history, 'Dirichlet source must not be recorded'
+
+plate_hist = np.asarray(history['Plate'])
+n_plate_verts = len(plate.data.vertices)
+assert plate_hist.shape == (5, n_plate_verts), plate_hist.shape
+
+mean_frame1 = float(plate_hist[0].mean())
+mean_frame5 = float(plate_hist[-1].mean())
+assert np.isfinite(plate_hist).all(), 'non-finite temperatures in plate history'
+assert mean_frame5 > mean_frame1, (mean_frame1, mean_frame5)
+
+print('ANIMATED_SOLVE_OK', round(mean_frame1, 4), round(mean_frame5, 4))
+"""
+    ).replace("{tmp_path}", str(tmp_path))
+    out = subprocess.run([str(executable), "-b", "--python-expr", code], capture_output=True, text=True, check=False)
+    assert "ANIMATED_SOLVE_OK" in out.stdout, out.stdout + "\n" + out.stderr
+
+
+def test_animated_solve_survives_dirichlet_vertex_count_change(executable, tmp_path):
+    """The box gains a Subdivision Surface modifier whose level is keyframed to
+    step up mid-run, so its *evaluated* vertex count changes between frames.
+    This must not crash, and the plate's (FEM-participant, stable-topology)
+    history must stay a consistent ``(n_frames, n_plate_verts)`` shape."""
+    code = (
+        _SCENE_SETUP
+        + """
+mod = box.modifiers.new('Subsurf', 'SUBSURF')
+mod.levels = 0
+mod.keyframe_insert(data_path='levels', frame=1)
+mod.levels = 3
+mod.keyframe_insert(data_path='levels', frame=3)
+
+# Finding 6: the whole point of this test is that the box's EVALUATED vertex
+# count actually changes mid-run; assert that directly so the test can't
+# silently pass if the resize never triggered (e.g. the Subsurf modifier
+# didn't evaluate, or the keyframe didn't take effect).
+def _eval_vert_count(obj, frame):
+    bpy.context.scene.frame_set(frame)
+    depsgraph = bpy.context.evaluated_depsgraph_get()
+    return len(obj.evaluated_get(depsgraph).data.vertices)
+
+
+n_box_frame1 = _eval_vert_count(box, 1)
+n_box_frame5 = _eval_vert_count(box, 5)
+assert n_box_frame1 != n_box_frame5, (n_box_frame1, n_box_frame5)
+"""
+        + _DEFAULTS
+        + """
+import numpy as np
+from pathlib import Path
+from visionsim.simulate.heatsim import adapter
+
+bpy.context.scene.frame_start = 1
+bpy.context.scene.frame_end = 5
+
+history, frames = adapter.solve_scene_animated(
+    bpy.context.scene, defaults=defaults, solver_cfg=solver_cfg,
+    cache_root=Path(r'{tmp_path}'),
+    frame_start=1, frame_end=5, every_n=1, substeps_per_frame=4,
+)
+
+n_plate_verts = len(plate.data.vertices)
+plate_hist = np.asarray(history['Plate'])
+assert plate_hist.shape == (5, n_plate_verts), plate_hist.shape
+assert np.isfinite(plate_hist).all(), 'non-finite temperatures after a topology change'
+
+print('ANIMATED_RESIZE_OK', plate_hist.shape)
+"""
+    ).replace("{tmp_path}", str(tmp_path))
+    out = subprocess.run([str(executable), "-b", "--python-expr", code], capture_output=True, text=True, check=False)
+    assert "ANIMATED_RESIZE_OK" in out.stdout, out.stdout + "\n" + out.stderr
+
+
+def test_write_frame_attributes_dirichlet_fallback_uses_reservoir_temperature(executable, tmp_path):
+    """When ``write_frame_attributes`` hits its fallback branch (object absent
+    from ``history``, e.g. a topology-changing Dirichlet liquid whose evaluated
+    vertex count no longer matches), a ``DIRICHLET_SOURCE`` object must stamp
+    its reservoir temperature (``dirichlet_temperature_K``), not the ambient
+    ``initial_temperature_K`` default. A ``FEM_PARTICIPANT`` hitting the same
+    fallback keeps stamping the ambient default (unchanged behavior)."""
+    code = (
+        _SCENE_SETUP
+        + _DEFAULTS
+        + """
+from visionsim.simulate.heatsim import adapter
+
+# Empty history => both Plate (FEM_PARTICIPANT) and Box (DIRICHLET_SOURCE)
+# hit the fallback branch.
+adapter.write_frame_attributes(bpy.context.scene, {}, -1, defaults)
+
+assert box['heatsim_default_temperature'] == 369.0, box['heatsim_default_temperature']
+assert plate['heatsim_default_temperature'] == 295.0, plate['heatsim_default_temperature']
+
+print('DIRICHLET_FALLBACK_OK')
+"""
+    )
+    out = subprocess.run([str(executable), "-b", "--python-expr", code], capture_output=True, text=True, check=False)
+    assert "DIRICHLET_FALLBACK_OK" in out.stdout, out.stdout + "\n" + out.stderr
+
+
+def test_thermal_write_frame_advances_animated_field(executable, tmp_path):
+    """Task 5 integration test: drive the real ``BlenderService`` methods end-to-end.
+
+    After an animated ``exposed_prepare_thermal`` solve, ``exposed_set_current_frame`` +
+    ``_thermal_write_frame`` (the per-frame render hook used by ``exposed_render_frame``)
+    must write an increasingly hot ``sim_temperature`` onto the plate as later frames are
+    requested, since the transient field keeps evolving toward the Dirichlet reservoir.
+    The Dirichlet box itself is absent from the animated history, so it must still hit
+    the Task 4 reservoir-temperature fallback rather than ambient.
+    """
+    code = (
+        _SCENE_SETUP
+        + r"""
+import bpy
+import numpy as np
+from visionsim.simulate.blender import BlenderService
+
+blend_path = r'{tmp_path}/animated_test.blend'
+root_path = r'{tmp_path}'
+bpy.ops.wm.save_as_mainfile(filepath=blend_path)
+
+service = BlenderService()
+service.exposed_initialize(blend_path, root_path)
+
+service.exposed_prepare_thermal(
+    animated=True,
+    domain='POINTS',
+    laplacian_backend='ROBUST',
+    device='cpu',
+    frame_start=1,
+    frame_end=5,
+    substeps_per_frame=4,
+    every_n_frames=1,
+    initial_temperature_K=295.0,
+    thermal_diffusivity_mm2_s=0.17,
+    density_kg_m3=1330.0,
+    specific_heat_J_kgK=880.0,
+    emissivity=0.9,
+    irradiance_scale=100.0,
+)
+
+assert service._thermal_animated_history is not None, 'animated history was not stored on the service'
+assert service._thermal_animated_frames == [1, 2, 3, 4, 5], service._thermal_animated_frames
+assert 'Plate' in service._thermal_animated_history, list(service._thermal_animated_history.keys())
+
+plate_obj = bpy.data.objects['Plate']
+
+
+def plate_mean():
+    attr = plate_obj.data.attributes['sim_temperature']
+    vals = np.zeros(len(attr.data), dtype=np.float32)
+    attr.data.foreach_get('value', vals)
+    return float(vals.mean())
+
+
+service.exposed_set_current_frame(1)
+service._thermal_write_frame(1)
+mean_early = plate_mean()
+
+service.exposed_set_current_frame(5)
+service._thermal_write_frame(5)
+mean_late = plate_mean()
+
+assert mean_late > mean_early, (mean_early, mean_late)
+
+# The Dirichlet box has no per-frame history entry, so the write must fall
+# through to the reservoir-temperature fallback (Task 4), not ambient.
+box_obj = bpy.data.objects['Box']
+assert box_obj['heatsim_default_temperature'] == 369.0, box_obj['heatsim_default_temperature']
+
+print('ANIMATED_RENDER_WRITE_OK', round(mean_early, 4), round(mean_late, 4))
+"""
+    ).replace("{tmp_path}", str(tmp_path))
+    out = subprocess.run([str(executable), "-b", "--python-expr", code], capture_output=True, text=True, check=False)
+    assert "ANIMATED_RENDER_WRITE_OK" in out.stdout, out.stdout + "\n" + out.stderr
+
+
+def test_simulate_for_pose_pins_dirichlet_every_substep(executable, tmp_path):
+    """Finding 1 regression: ``HeatSimFEM.simulate_for_pose`` must re-pin
+    ``dirichlet_indices`` to ``dirichlet_values`` after EVERY substep's CG
+    solve, not just on the initial state or the final returned row. Isolates
+    the pin logic itself (no scene/adapter involved) on a tiny synthetic
+    point cloud so a regression here can't hide behind adapter-level
+    clamping.
+    """
+    code = r"""
+import numpy as np
+from types import SimpleNamespace
+from visionsim.simulate.heatsim.solver import HeatSimFEM
+
+n = 32
+rng = np.random.default_rng(0)
+points = rng.uniform(-10.0, 10.0, size=(n, 3)).astype(np.float64)
+
+gen_params = SimpleNamespace(
+    device='cpu', RHO=1330.0 / 1e9, C=880.0, K=0.17, NUM_FRAME_DELTA=0.05 * 60.0,
+)
+sim_params = SimpleNamespace(
+    sim_radiation=True, sim_convection=False, add_tikhonov_reg=False,
+    sim_time=0.0, record_time=0.0,
+)
+fem = HeatSimFEM(gen_params, sim_params, laplacian_domain='POINTS', laplacian_backend='ROBUST')
+
+u0 = np.full(n, 295.0, dtype=np.float64)
+boundary_mask = np.zeros(n, dtype=bool)
+irradiance = np.zeros(n, dtype=np.float64)
+density = np.full(n, 1330.0 / 1e9, dtype=np.float64)
+specific_heat = np.full(n, 880.0, dtype=np.float64)
+tdiff = np.full(n, 50.0, dtype=np.float64)
+emissivity = np.full(n, 0.9, dtype=np.float64)
+
+dirichlet_indices = [0, 5, 17]
+dirichlet_values = [369.0, 369.0, 369.0]
+
+states = fem.simulate_for_pose(
+    points, None, boundary_mask, u0, irradiance, tdiff, density, specific_heat, emissivity,
+    num_substeps=4, dt=0.05 / 4,
+    dirichlet_indices=dirichlet_indices, dirichlet_values=dirichlet_values,
+)
+
+assert states.shape == (4, n), states.shape
+for s in range(4):
+    row = states[s, dirichlet_indices]
+    assert np.all(row == 369.0), (s, row)
+
+# Sanity: the pin isn't a no-op that happens to match because nothing moved --
+# a non-pinned vertex must actually be free to evolve toward the hot nodes.
+assert states[-1, 1] != 295.0, 'non-pinned vertex did not evolve at all'
+
+print('DIRICHLET_SUBSTEP_PIN_OK')
+"""
+    out = subprocess.run([str(executable), "-b", "--python-expr", code], capture_output=True, text=True, check=False)
+    assert "DIRICHLET_SUBSTEP_PIN_OK" in out.stdout, out.stdout + "\n" + out.stderr
+
+
+def test_animated_solve_more_substeps_does_not_lower_plate_mean(executable, tmp_path):
+    """Finding 1 regression (coarse, end-to-end): pre-fix, the external
+    post-solve Dirichlet clamp only overwrote the RETURNED states array, so
+    the reservoir nodes drifted down *within* a frame across substeps (the
+    Dirichlet<->FEM coupling weight in ``mv`` keeps pulling them toward the
+    FEM neighbors between re-pins) and the plate under-heated -- MORE
+    substeps made this WORSE. With the per-substep pin, raising
+    ``substeps_per_frame`` must not lower the plate's final mean temperature.
+    """
+    code = (
+        _SCENE_SETUP
+        + _DEFAULTS
+        + """
+import numpy as np
+from pathlib import Path
+from visionsim.simulate.heatsim import adapter
+
+bpy.context.scene.frame_start = 1
+bpy.context.scene.frame_end = 5
+
+
+def final_plate_mean(substeps, cache_tag):
+    history, frames = adapter.solve_scene_animated(
+        bpy.context.scene, defaults=defaults, solver_cfg=solver_cfg,
+        cache_root=Path(r'{tmp_path}') / cache_tag,
+        frame_start=1, frame_end=5, every_n=1, substeps_per_frame=substeps,
+    )
+    return float(np.asarray(history['Plate'])[-1].mean())
+
+
+mean_2 = final_plate_mean(2, 'substeps_2')
+mean_8 = final_plate_mean(8, 'substeps_8')
+
+assert mean_8 >= mean_2, (mean_2, mean_8)
+
+print('SUBSTEP_MONOTONIC_OK', round(mean_2, 4), round(mean_8, 4))
+"""
+    ).replace("{tmp_path}", str(tmp_path))
+    out = subprocess.run([str(executable), "-b", "--python-expr", code], capture_output=True, text=True, check=False)
+    assert "SUBSTEP_MONOTONIC_OK" in out.stdout, out.stdout + "\n" + out.stderr

--- a/tests/test_heatsim_assignments_integration.py
+++ b/tests/test_heatsim_assignments_integration.py
@@ -1,0 +1,345 @@
+from __future__ import annotations
+
+import inspect
+import json
+import logging
+from dataclasses import asdict, fields
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from visionsim.simulate.blender import BlenderService
+from visionsim.simulate.config import ThermalConfig
+from visionsim.simulate.heatsim import adapter, materials
+
+_DEFAULTS = {
+    "initial_temperature_K": 300.0,
+    "thermal_diffusivity_mm2_s": 0.42,
+    "density_kg_m3": 1234.0,
+    "specific_heat_J_kgK": 777.0,
+    "emissivity": 0.5,
+    "irradiance_scale": 1.0,
+}
+_SOLVER_CFG = {"domain": "POINTS"}
+
+
+class _Poly:
+    def __init__(self, vertices, material_index, area):
+        self.vertices = list(vertices)
+        self.material_index = material_index
+        self.area = area
+
+
+class _AttrData(list):
+    """Mirrors the bit of bpy's attribute-data collection ``_write_point_float_attr`` uses."""
+
+    def foreach_set(self, prop, values):
+        for elem, value in zip(self, values):
+            setattr(elem, prop, float(value))
+
+
+class _Attr:
+    def __init__(self, n):
+        self.data = _AttrData(type("D", (), {"value": 0.0})() for _ in range(n))
+
+
+class _Attrs(dict):
+    def __init__(self, n):
+        super().__init__()
+        self._n = n
+
+    def new(self, name, type, domain):
+        self[name] = _Attr(self._n)
+        return self[name]
+
+
+class _Mesh:
+    def __init__(self, verts_xyz, polygons):
+        self._xyz = np.asarray(verts_xyz, dtype=np.float64)
+        self.vertices = [object()] * len(self._xyz)
+        self.polygons = list(polygons)
+        self.attributes = _Attrs(len(self._xyz))
+
+    def update(self):
+        pass
+
+
+class _Obj(dict):
+    # dict-backed so ``obj["key"] = value`` mirrors bpy custom properties, but real
+    # bpy.types.Object instances are hashable by identity - restore that here,
+    # since plain ``dict`` (unlike ``object``) sets __hash__ = None.
+    __hash__ = object.__hash__
+    __eq__ = object.__eq__
+
+    def __init__(self, name, mesh, slot_names):
+        super().__init__()
+        self.name = name
+        self.type = "MESH"
+        self.data = mesh
+        self.material_slots = [type("S", (), {"material": type("M", (), {"name": n})()})() for n in slot_names]
+        self.heat_sim_material = None
+
+
+def _square():
+    """4 verts, 2 coplanar tris; tri 0 uses slot 0, tri 1 uses slot 1."""
+    xyz = [(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (1.0, 1.0, 0.0), (0.0, 1.0, 0.0)]
+    return _Obj("square", _Mesh(xyz, [_Poly([0, 1, 2], 0, 0.5), _Poly([0, 2, 3], 1, 0.5)]), ["WOODY", "STEELY"])
+
+
+def _sidecar(tmp_path, block):
+    path = tmp_path / "s.thermal.json"
+    path.write_text(json.dumps({
+        "schema_version": 1, "scene": "s.blend", "defaults": {"preset": None}, "materials": block,
+    }), encoding="utf-8")
+    return materials.load_assignments(path)
+
+
+@pytest.fixture(autouse=True)
+def _stub_geometry(monkeypatch):
+    """_extract_geometry needs bpy/mathutils; feed it straight from the fake mesh."""
+    def fake(obj):
+        verts = np.asarray(obj.data._xyz, dtype=np.float64) * 1000.0  # m -> mm
+        faces = np.asarray([list(p.vertices) for p in obj.data.polygons], dtype=np.int32)
+        return verts, faces, len(verts)
+
+    monkeypatch.setattr(adapter, "_extract_geometry", fake)
+
+
+# --- _combine ---------------------------------------------------------------
+
+
+def test_without_assignment_arrays_stay_constant_per_object():
+    """Backward-compat guard: assignment=None must reproduce today's behaviour exactly."""
+    combined = adapter._combine([_square()], {}, _DEFAULTS, _SOLVER_CFG)
+    assert combined is not None
+    assert np.allclose(combined.alpha, _DEFAULTS["thermal_diffusivity_mm2_s"])
+    assert np.allclose(combined.eps, _DEFAULTS["emissivity"])
+    assert np.allclose(combined.t0, _DEFAULTS["initial_temperature_K"])
+    assert np.all(combined.boundary_mask)
+
+
+def test_with_assignment_alpha_varies_within_one_object(tmp_path):
+    sa = _sidecar(tmp_path, {"WOODY": {"preset": "wood"}, "STEELY": {"preset": "steel"}})
+    combined = adapter._combine([_square()], {}, _DEFAULTS, _SOLVER_CFG, assignment=sa)
+    assert combined is not None
+    # Vert 1 is only in the wood tri; vert 3 only in the steel tri.
+    assert combined.alpha[1] == pytest.approx(materials.PRESETS["wood"].alpha_mm2_s)
+    assert combined.alpha[3] == pytest.approx(materials.PRESETS["steel"].alpha_mm2_s)
+    assert combined.alpha.min() < combined.alpha.max()
+    assert combined.eps[1] == pytest.approx(materials.PRESETS["wood"].emissivity_ir)
+
+
+def test_density_is_converted_to_kg_per_mm3(tmp_path):
+    sa = _sidecar(tmp_path, {"WOODY": {"preset": "wood"}, "STEELY": {"preset": "wood"}})
+    combined = adapter._combine([_square()], {}, _DEFAULTS, _SOLVER_CFG, assignment=sa)
+    assert combined is not None
+    assert combined.density[0] == pytest.approx(materials.PRESETS["wood"].density_kg_m3 / 1.0e9)
+
+
+def test_per_vertex_dirichlet_pins_only_the_source_vertices(tmp_path):
+    sa = _sidecar(tmp_path, {
+        "WOODY": {"preset": "wood"},
+        "STEELY": {"preset": "steel", "role": "DIRICHLET_SOURCE", "dirichlet_K": 350.0},
+    })
+    obj = _square()
+    combined = adapter._combine([obj], {obj: np.full(4, 10.0)}, _DEFAULTS, _SOLVER_CFG, assignment=sa)
+    assert combined is not None
+
+    pinned = ~combined.boundary_mask
+    assert pinned.any() and not pinned.all(), "expected a partially pinned object"
+    assert np.allclose(combined.alpha[pinned], 0.0)
+    assert np.allclose(combined.irradiance[pinned], 0.0)
+    assert np.all(combined.irradiance[~pinned] > 0.0)
+    assert np.allclose(combined.t0[pinned], 350.0)
+    assert np.allclose(combined.t0[~pinned], _DEFAULTS["initial_temperature_K"])
+
+
+def test_object_with_no_slots_keeps_the_object_level_path(tmp_path):
+    sa = _sidecar(tmp_path, {"WOODY": {"preset": "wood"}})
+    obj = _square()
+    obj.material_slots = []
+    combined = adapter._combine([obj], {}, _DEFAULTS, _SOLVER_CFG, assignment=sa)
+    assert combined is not None
+    assert np.allclose(combined.alpha, _DEFAULTS["thermal_diffusivity_mm2_s"])
+
+
+def test_topology_changing_modifier_falls_back_to_object_level(tmp_path, monkeypatch, caplog):
+    """A modifier makes the evaluated geometry a different vertex count than the base mesh.
+
+    resolve_vertex_materials sizes its arrays to the base mesh (4 verts here); _combine
+    operates on the evaluated geometry. When they disagree the per-slot arrays cannot be
+    combined with the (evaluated-sized) flux/mask, so the object must degrade to the
+    object-level path with a warning rather than raise a broadcast error (the real-scene
+    crash on kitchen1's modifier-carrying 'Circle' lamp: dmask (6018,) vs irr (6870,)).
+    """
+    # Evaluated geometry has 6 verts / 2 tris while the base _square() mesh has 4.
+    ev_xyz = np.array([(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (1.0, 1.0, 0.0),
+                       (0.0, 1.0, 0.0), (0.5, 0.5, 0.0), (0.5, 0.0, 0.0)], dtype=np.float64)
+    ev_faces = np.array([[0, 1, 4], [2, 3, 5]], dtype=np.int32)
+    monkeypatch.setattr(adapter, "_extract_geometry", lambda obj: (ev_xyz * 1000.0, ev_faces, 6))
+
+    sa = _sidecar(tmp_path, {"WOODY": {"preset": "wood"}, "STEELY": {"preset": "steel"}})
+    obj = _square()
+    with caplog.at_level("WARNING"):
+        combined = adapter._combine([obj], {}, _DEFAULTS, _SOLVER_CFG, assignment=sa)
+
+    assert combined is not None
+    assert combined.alpha.shape == (6,), "arrays must match the evaluated geometry, not the base mesh"
+    # Fell back to the object-level constant rather than per-slot values.
+    assert np.allclose(combined.alpha, _DEFAULTS["thermal_diffusivity_mm2_s"])
+    assert np.allclose(combined.eps, _DEFAULTS["emissivity"])
+    assert "topology-changing modifier" in caplog.text
+
+
+# --- write_frame_attributes -------------------------------------------------
+
+
+def _emissivity(mesh):
+    return np.array([d.value for d in mesh.attributes["emissivity"].data])
+
+
+def test_without_assignment_emissivity_is_constant():
+    obj = _square()
+    scene = type("S", (), {"objects": [obj]})()
+    adapter.write_frame_attributes(scene, {"square": np.full((2, 4), 305.0)}, -1, _DEFAULTS)
+    assert np.allclose(_emissivity(obj.data), _DEFAULTS["emissivity"])
+
+
+def test_with_assignment_emissivity_varies_per_slot(tmp_path):
+    """The single largest lever on how a thermal frame looks - spec section 4b."""
+    sa = _sidecar(tmp_path, {
+        "WOODY": {"preset": "aluminium_polished"},
+        "STEELY": {"preset": "metal_painted"},
+    })
+    obj = _square()
+    scene = type("S", (), {"objects": [obj]})()
+    adapter.write_frame_attributes(scene, {"square": np.full((2, 4), 305.0)}, -1, _DEFAULTS, assignment=sa)
+
+    eps = _emissivity(obj.data)
+    assert eps[1] == pytest.approx(materials.PRESETS["aluminium_polished"].emissivity_ir, abs=1e-6)
+    assert eps[3] == pytest.approx(materials.PRESETS["metal_painted"].emissivity_ir, abs=1e-6)
+    assert eps.max() - eps.min() > 0.5
+
+
+def test_temperature_attribute_is_still_written(tmp_path):
+    sa = _sidecar(tmp_path, {"WOODY": {"preset": "wood"}, "STEELY": {"preset": "wood"}})
+    obj = _square()
+    scene = type("S", (), {"objects": [obj]})()
+    history = {"square": np.stack([np.full(4, 300.0), np.full(4, 307.0)])}
+    adapter.write_frame_attributes(scene, history, -1, _DEFAULTS, assignment=sa)
+    assert np.allclose([d.value for d in obj.data.attributes["sim_temperature"].data], 307.0)
+
+
+def test_unsimulated_mesh_still_gets_the_fallback_property(tmp_path):
+    sa = _sidecar(tmp_path, {"WOODY": {"preset": "wood"}, "STEELY": {"preset": "wood"}})
+    obj = _square()
+    scene = type("S", (), {"objects": [obj]})()
+    adapter.write_frame_attributes(scene, {}, -1, _DEFAULTS, assignment=sa)
+    assert obj["heatsim_default_temperature"] == pytest.approx(_DEFAULTS["initial_temperature_K"])
+
+
+# --- Finding 1 (fix pass): slot-level Dirichlet in animated mode -----------
+
+
+class _AnimatedScene:
+    """Minimal ``bpy.types.Scene`` stand-in: only what ``solve_scene_animated``
+    (and its ``_scene_fps`` helper) touch directly -- object gathering itself
+    is monkeypatched via ``adapter.gather_meshes``."""
+
+    def __init__(self, objects):
+        self.objects = objects
+        self.frame_current = 1
+        self.render = SimpleNamespace(fps=24.0, fps_base=1.0)
+
+    def frame_set(self, frame):
+        self.frame_current = int(frame)
+
+
+def test_slot_level_dirichlet_mismatch_detector(tmp_path):
+    """Unit-level: the detector flags an object whose material slot is assigned
+    ``DIRICHLET_SOURCE`` in the sidecar while its own ``thermal_role`` stays at
+    the default (``FEM_PARTICIPANT``), and stays silent once the object-level
+    role already declares it."""
+    sa = _sidecar(tmp_path, {
+        "WOODY": {"preset": "wood"},
+        "STEELY": {"preset": "steel", "role": "DIRICHLET_SOURCE", "dirichlet_K": 350.0},
+    })
+    obj = _square()  # heat_sim_material is None -> object-level role defaults FEM_PARTICIPANT
+    assert adapter._slot_level_dirichlet_mismatches([obj], sa, _DEFAULTS) == ["square"]
+
+    # An object-level role that already declares DIRICHLET_SOURCE is not a mismatch --
+    # the whole object is re-pinned wholesale every substep.
+    declared = _square()
+    declared.heat_sim_material = SimpleNamespace(
+        is_property_set=lambda attr: attr == "thermal_role",
+        thermal_role="DIRICHLET_SOURCE",
+    )
+    assert adapter._slot_level_dirichlet_mismatches([declared], sa, _DEFAULTS) == []
+
+    # No slot-level Dirichlet assignment anywhere -> nothing to flag.
+    sa_clean = _sidecar(tmp_path, {"WOODY": {"preset": "wood"}, "STEELY": {"preset": "wood"}})
+    assert adapter._slot_level_dirichlet_mismatches([obj], sa_clean, _DEFAULTS) == []
+
+
+def test_solve_scene_animated_warns_on_slot_level_dirichlet_mismatch(tmp_path, monkeypatch, caplog):
+    """End-to-end (Finding 1): a scene with a slot-level ``DIRICHLET_SOURCE``
+    assignment and an object-level role left at default must warn, in animated
+    mode, that those vertices are not re-pinned per substep. Exercised through
+    the real ``solve_scene_animated`` (not just the detector) with a fake
+    ``bpy``-shaped scene/object, since the rest of the animated test suite
+    needs an actual Blender process for geometry extraction -- here
+    ``adapter._extract_geometry`` and ``adapter.gather_meshes`` are stubbed the
+    same way the rest of this file stubs geometry, so the substep solve itself
+    (pure numpy/scipy/torch, no ``bpy``) can run for real.
+    """
+    sa = _sidecar(tmp_path, {
+        "WOODY": {"preset": "wood"},
+        "STEELY": {"preset": "steel", "role": "DIRICHLET_SOURCE", "dirichlet_K": 350.0},
+    })
+    obj = _square()
+    scene = _AnimatedScene([obj])
+    monkeypatch.setattr(adapter, "gather_meshes", lambda scene: list(scene.objects))
+
+    caplog.set_level(logging.WARNING, logger="rich")
+    history, frames = adapter.solve_scene_animated(
+        scene,
+        defaults=_DEFAULTS,
+        solver_cfg=_SOLVER_CFG,
+        cache_root=Path(tmp_path) / "cache",
+        frame_start=1,
+        frame_end=1,
+        every_n=1,
+        substeps_per_frame=1,
+        assignment=sa,
+    )
+
+    assert frames == [1]
+    assert "square" in history
+
+    messages = [rec.getMessage() for rec in caplog.records]
+    matches = [m for m in messages if "square" in m and "NOT re-pinned per substep" in m]
+    assert matches, messages
+    assert "DIRICHLET_SOURCE" in matches[0]
+    assert "static solve" in matches[0]
+
+
+# Task 3 appends the config/service plumbing tests to this same file.
+
+
+# --- config / service plumbing ----------------------------------------------
+
+
+def test_thermal_config_has_an_assignments_field():
+    assert "assignments" in {f.name for f in fields(ThermalConfig)}
+    assert ThermalConfig().assignments is None
+    assert ThermalConfig(assignments=Path("a.json")).assignments == Path("a.json")
+
+
+def test_asdict_dispatch_matches_both_service_signatures():
+    """job.py and cli/blender.py both call **asdict(config.thermal); every key must land."""
+    keys = set(asdict(ThermalConfig()))
+    for method in (BlenderService.exposed_prepare_thermal, BlenderService.exposed_heatsim_solve):
+        missing = keys - (set(inspect.signature(method).parameters) - {"self"})
+        assert not missing, f"{method.__name__} is missing {sorted(missing)}"

--- a/tests/test_heatsim_atlas.py
+++ b/tests/test_heatsim_atlas.py
@@ -1,0 +1,522 @@
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from visionsim.simulate.heatsim import atlas
+
+# ---------------------------------------------------------------------------
+# surface_area_m2
+# ---------------------------------------------------------------------------
+
+
+def test_surface_area_of_unit_quad():
+    # A 1000mm x 1000mm quad (two triangles) is exactly 1 m^2.
+    verts_mm = np.array(
+        [[0.0, 0.0, 0.0], [1000.0, 0.0, 0.0], [1000.0, 1000.0, 0.0], [0.0, 1000.0, 0.0]]
+    )
+    faces = np.array([[0, 1, 2], [0, 2, 3]])
+    assert atlas.surface_area_m2(verts_mm, faces) == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# select_for_atlas
+# ---------------------------------------------------------------------------
+
+
+def test_selection_excludes_dense_objects():
+    density = 500.0
+    # Orchid-like: 21k verts crammed into 2 m^2 -> ~10500 verts/m^2, already denser than target.
+    assert atlas.select_for_atlas(n_verts=21_000, area_m2=2.0, density=density) is False
+    # Floor-like: 16 verts spanning 80 m^2 -> 0.2 verts/m^2, far under target -> joins the atlas.
+    assert atlas.select_for_atlas(n_verts=16, area_m2=80.0, density=density) is True
+
+
+def test_selection_area_zero_uses_eps_guard():
+    # area_m2=0 must not raise (division guarded by eps); any positive vertex count is "dense".
+    assert atlas.select_for_atlas(n_verts=1, area_m2=0.0, density=500.0) is False
+    # Zero verts and zero area: 0/eps = 0, which is < any positive density -> included.
+    assert atlas.select_for_atlas(n_verts=0, area_m2=0.0, density=500.0) is True
+
+
+def test_select_for_atlas_forces_participation_when_writeback_impossible():
+    """Fix 1: per-vertex write-back can only ever land on the BASE mesh. When a
+    topology-changing modifier (Bevel, Subdivision, Geometry Nodes, ...) makes the base
+    and evaluated vertex counts differ, that path is structurally impossible regardless
+    of density, so the object must join the atlas even if the density rule alone would
+    exclude it."""
+    density = 500.0
+    n_verts, area_m2 = 21_000, 2.0  # orchid-dense: would normally be excluded.
+    assert atlas.select_for_atlas(n_verts, area_m2, density) is False
+    assert atlas.select_for_atlas(n_verts, area_m2, density, writeback_possible=True) is False
+    assert atlas.select_for_atlas(n_verts, area_m2, density, writeback_possible=False) is True
+
+
+# ---------------------------------------------------------------------------
+# allocate: sizing
+# ---------------------------------------------------------------------------
+
+
+def test_tile_size_scales_with_area_and_respects_min_max_and_multiple_of_4():
+    density = 1500.0
+    areas = {
+        "tiny": 0.01,  # K=15,   ceil(sqrt)=4,    mult4=4,    clamped up to tile_min=16
+        "mid": 1.0,  # K=1500, ceil(sqrt)=39,   mult4=40,   no clamp
+        "huge": 1000.0,  # K=1.5e6, ceil(sqrt)=1225, mult4=1228, clamped down to tile_max=512
+    }
+    layout = atlas.allocate(areas, density, tile_min=16, tile_max=512)
+
+    assert layout.tiles["tiny"].size == (16, 16)
+    assert layout.tiles["mid"].size == (40, 40)
+    assert layout.tiles["huge"].size == (512, 512)
+    for spec in layout.tiles.values():
+        w, h = spec.size
+        assert w == h  # tiles are square
+        assert w % 4 == 0
+        assert 16 <= w <= 512
+
+
+def test_big_object_not_power_of_two_overshot():
+    # 81 m^2 @ 1500/m^2: K=121500, ceil(sqrt)=349, rounded up to mult-of-4 = 352.
+    # A naive power-of-two quantizer would jump straight to 512 (a ~2.1x-per-side, ~4.4x-area
+    # overshoot); the spec explicitly forbids that.
+    layout = atlas.allocate({"floor": 81.0}, 1500.0)
+    side = layout.tiles["floor"].size[0]
+    assert side == 352
+    assert side != 512
+
+
+# ---------------------------------------------------------------------------
+# allocate: soft-max rescale
+# ---------------------------------------------------------------------------
+
+
+def test_soft_max_rescales_uniformly_and_warns():
+    # area=100 m^2 @ density=100/m^2 -> K=10000 -> side=100 exactly (already mult of 4, no clamp),
+    # so tiles_total == 10000 exactly, keeping the rescale arithmetic hand-checkable.
+    areas = {"big": 100.0}
+    density = 100.0
+    soft_max = 5000
+
+    with pytest.warns(UserWarning):
+        layout = atlas.allocate(areas, density, soft_max=soft_max)
+
+    assert layout.rescaled is True
+    # ratio = soft_max / tiles_total = 5000/10000 = 0.5 -> effective_density = 50.0
+    assert layout.effective_density == pytest.approx(50.0)
+    assert layout.effective_density < density
+    # New K = 100*50=5000 -> ceil(sqrt)=71 -> rounded up to mult-of-4 = 72.
+    assert layout.tiles["big"].size == (72, 72)
+
+
+def test_soft_max_counts_retained_vertices():
+    areas = {"big": 100.0}  # K=10000 -> side=100 -> tiles_total=10000, same as above
+    density = 100.0
+    soft_max = 15_000
+
+    # Without retained vertices, tiles_total (10000) is under soft_max (15000) -> no rescale.
+    baseline = atlas.allocate(areas, density, soft_max=soft_max, retained_vertex_count=0)
+    assert baseline.rescaled is False
+    assert baseline.effective_density == pytest.approx(density)
+
+    # With 6000 retained vertices, tiles_total+retained = 16000 > 15000 -> rescale must trigger,
+    # even though tiles_total alone was fine. This is the "retained vertices count" contract.
+    with pytest.warns(UserWarning):
+        with_retained = atlas.allocate(areas, density, soft_max=soft_max, retained_vertex_count=6000)
+    assert with_retained.rescaled is True
+    # ratio = (soft_max - retained)/tiles_total = (15000-6000)/10000 = 0.9 -> density=90.0
+    assert with_retained.effective_density == pytest.approx(90.0)
+
+
+# ---------------------------------------------------------------------------
+# allocate: shelf packing
+# ---------------------------------------------------------------------------
+
+
+def _rects_have_padding_gap(r1, r2, padding):
+    x1, y1, w1, h1 = r1
+    x2, y2, w2, h2 = r2
+
+    if x1 + w1 <= x2:
+        xgap = x2 - (x1 + w1)
+    elif x2 + w2 <= x1:
+        xgap = x1 - (x2 + w2)
+    else:
+        xgap = None
+
+    if y1 + h1 <= y2:
+        ygap = y2 - (y1 + h1)
+    elif y2 + h2 <= y1:
+        ygap = y1 - (y2 + h2)
+    else:
+        ygap = None
+
+    return (xgap is not None and xgap >= padding) or (ygap is not None and ygap >= padding)
+
+
+def test_shelf_pack_no_overlap_and_padding():
+    areas = {"a": 0.01, "b": 1.0, "c": 4.0, "d": 0.2, "e": 9.0}
+    padding = 2
+    layout = atlas.allocate(areas, density=1500.0, padding=padding)
+
+    assert set(layout.tiles) == set(areas)
+    rects = {name: (spec.offset[0], spec.offset[1], spec.size[0], spec.size[1]) for name, spec in layout.tiles.items()}
+
+    names = list(rects)
+    for i in range(len(names)):
+        for j in range(i + 1, len(names)):
+            assert _rects_have_padding_gap(rects[names[i]], rects[names[j]], padding), (names[i], names[j])
+
+    # Every tile must actually fit inside the reported atlas bounds.
+    atlas_w, atlas_h = layout.atlas_size
+    assert atlas_w % 4 == 0 and atlas_h % 4 == 0
+    for x, y, w, h in rects.values():
+        assert x >= 0 and y >= 0
+        assert x + w <= atlas_w
+        assert y + h <= atlas_h
+
+
+def test_allocate_empty_areas():
+    layout = atlas.allocate({}, density=500.0)
+    assert layout.tiles == {}
+    assert layout.atlas_size == (0, 0)
+    assert layout.rescaled is False
+    assert layout.effective_density == pytest.approx(500.0)
+
+
+# ---------------------------------------------------------------------------
+# rasterize_tile
+# ---------------------------------------------------------------------------
+
+
+def _quad_mesh(size_mm=80.0):
+    verts_mm = np.array(
+        [[0.0, 0.0, 0.0], [size_mm, 0.0, 0.0], [size_mm, size_mm, 0.0], [0.0, size_mm, 0.0]]
+    )
+    faces = np.array([[0, 1, 2], [0, 2, 3]])
+    loop_uv = np.array(
+        [
+            [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0]],
+            [[0.0, 0.0], [1.0, 1.0], [0.0, 1.0]],
+        ]
+    )
+    return verts_mm, faces, loop_uv
+
+
+def test_rasterize_full_cover_quad():
+    size_mm = 80.0
+    tile = (8, 8)
+    verts_mm, faces, loop_uv = _quad_mesh(size_mm)
+
+    out = atlas.rasterize_tile(verts_mm, faces, loop_uv, tile)
+
+    w, h = tile
+    assert out["xy"].shape[0] == w * h
+    # every texel covered exactly once
+    seen = set(map(tuple, out["xy"].tolist()))
+    assert seen == {(x, y) for x in range(w) for y in range(h)}
+
+    # normals all point +Z (verts are CCW in the XY plane)
+    assert np.allclose(out["normal"], np.array([0.0, 0.0, 1.0]), atol=1e-9)
+
+    # positions interpolate linearly with texel-center UV
+    for xy, pos in zip(out["xy"], out["position_mm"]):
+        x, y = xy
+        expected = np.array([(x + 0.5) / w * size_mm, (y + 0.5) / h * size_mm, 0.0])
+        assert pos == pytest.approx(expected, abs=1e-9)
+
+    assert np.isfinite(out["position_mm"]).all()
+    assert np.isfinite(out["normal"]).all()
+
+
+def test_rasterize_half_tile_triangle():
+    tile = (8, 8)
+    verts_mm = np.array([[0.0, 0.0, 0.0], [80.0, 0.0, 0.0], [0.0, 80.0, 0.0]])
+    faces = np.array([[0, 1, 2]])
+    loop_uv = np.array([[[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]]])
+
+    out = atlas.rasterize_tile(verts_mm, faces, loop_uv, tile)
+
+    w, h = tile
+    n = out["xy"].shape[0]
+    # roughly half the tile, and strictly none of it
+    assert 0 < n < w * h
+    assert 20 <= n <= 44
+    xs, ys = out["xy"][:, 0], out["xy"][:, 1]
+    assert (xs >= 0).all() and (xs < w).all()
+    assert (ys >= 0).all() and (ys < h).all()
+    # no duplicate texels
+    assert len(set(map(tuple, out["xy"].tolist()))) == n
+
+
+def test_rasterize_no_double_claim():
+    # Same abutting-triangle-pair setup as the full-cover test, but the assertion here is
+    # specifically about the shared diagonal edge: no texel may be claimed by both triangles.
+    tile = (16, 16)
+    verts_mm, faces, loop_uv = _quad_mesh(160.0)
+
+    out = atlas.rasterize_tile(verts_mm, faces, loop_uv, tile)
+
+    w, h = tile
+    xy_rows = list(map(tuple, out["xy"].tolist()))
+    assert len(xy_rows) == w * h  # full coverage, no gaps
+    assert len(set(xy_rows)) == len(xy_rows)  # no texel appears twice
+
+    # Confirm both triangles actually contributed (i.e. this is a real two-triangle test, not one
+    # triangle silently covering everything).
+    assert set(out["face"].tolist()) == {0, 1}
+
+
+def test_rasterize_degenerate_triangle_skipped():
+    tile = (8, 8)
+    verts_mm = np.array([[0.0, 0.0, 0.0], [80.0, 0.0, 0.0], [40.0, 0.0, 0.0]])
+    faces = np.array([[0, 1, 2]])
+    # Colinear UVs -> zero UV-space area.
+    loop_uv = np.array([[[0.0, 0.0], [1.0, 0.0], [0.5, 0.0]]])
+
+    out = atlas.rasterize_tile(verts_mm, faces, loop_uv, tile)
+
+    assert out["xy"].shape[0] == 0
+    assert out["position_mm"].shape == (0, 3)
+    assert out["normal"].shape == (0, 3)
+    assert out["face"].shape == (0,)
+    for key in out:
+        assert np.isfinite(out[key]).all() if out[key].size else True
+
+
+def test_rasterize_degenerate_triangle_mixed_with_valid_no_nan():
+    # A degenerate triangle followed by a valid one: the degenerate one must not poison the rest.
+    tile = (8, 8)
+    verts_mm = np.array(
+        [[0.0, 0.0, 0.0], [80.0, 0.0, 0.0], [40.0, 0.0, 0.0], [80.0, 80.0, 0.0], [0.0, 80.0, 0.0]]
+    )
+    faces = np.array([[0, 1, 2], [0, 1, 3], [0, 3, 4]])
+    loop_uv = np.array(
+        [
+            [[0.0, 0.0], [1.0, 0.0], [0.5, 0.0]],  # degenerate
+            [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0]],
+            [[0.0, 0.0], [1.0, 1.0], [0.0, 1.0]],
+        ]
+    )
+
+    out = atlas.rasterize_tile(verts_mm, faces, loop_uv, tile)
+
+    assert out["xy"].shape[0] == 8 * 8
+    assert np.isfinite(out["position_mm"]).all()
+    assert np.isfinite(out["normal"]).all()
+    assert 0 not in out["face"].tolist()  # the degenerate triangle (face 0) claims nothing
+
+
+def test_rasterize_mirrored_uv_triangle_interpolates_correctly():
+    """Mirrored-UV island: face 0's loop_uv corners are authored CW (negative signed UV area),
+    which exercises the `area2 < 0` vertex-swap branch in rasterize_tile. Mesh vertex order in
+    `faces` stays natural/untouched (so the swap only affects the UV<->vertex pairing used for
+    barycentric interpolation, not the mesh winding used for the normal).
+
+    Mesh: same quad as `_quad_mesh` - P0=(0,0,0), P1=(size,0,0), P2=(size,size,0), P3=(0,size,0) -
+    split into faces [0,1,2] and [0,2,3], both CCW in 3D (both normals point +Z).
+
+    Face 0's UV corners are the *same three UV points* as `_quad_mesh`'s face 0 ((0,0),(1,0),(1,1))
+    but with corners 1 and 2 swapped, i.e. mirrored:
+        uv0 = (0, 0)  at vertex i0 = P0
+        uv1 = (1, 1)  at vertex i1 = P1   (P1 normally maps to (1, 0))
+        uv2 = (1, 0)  at vertex i2 = P2   (P2 normally maps to (1, 1))
+    Signed UV area = cross(uv1-uv0, uv2-uv0) = cross((1,1),(1,0)) = 1*0 - 1*1 = -1 < 0, so
+    rasterize_tile takes the `area2 < 0` branch: idx becomes (i0, i2, i1), pts becomes
+    (uv0, uv2, uv1) = ((0,0), (w,0), (w,h)) in tile-pixel space (w, h = tile size). That is the
+    *same triangle footprint* as face 0 in `_quad_mesh` (only relabeled), so coverage/no-double-
+    claim behaves exactly as in `test_rasterize_full_cover_quad` - what differs is which mesh
+    vertex gets which barycentric weight.
+
+    Hand-derived barycentric weights for a=(0,0), b=(w,0), c=(w,h), area2=w*h, texel center
+    (px, py) = (x+0.5, y+0.5):
+        w_a = h*(w-px),  w_b = h*px - w*py,  w_c = w*py
+        wa = 1 - px/w,   wb = px/w - py/h,   wc = py/h
+    and post-swap (ia, ib, ic) = (i0, i2, i1) = (P0, P2, P1), so
+        position = P0*wa + P2*wb + P1*wc = (size*px/w, size*(px/w - py/h), 0)
+    Note the y-component is *not* the naive `(y+0.5)/h*size` shortcut - it is skewed by the
+    mirrored vertex/UV pairing (it depends on px too). A regression that mishandles the swap
+    (e.g. permutes `idx` without permuting `pts` to match, or vice versa) would instead produce
+    either NaNs/garbage or the naive-linear result asserted for face 1 below; this formula is
+    specific to the correct pairing and was cross-checked against the implementation by hand.
+
+    Face 1 is untouched from `_quad_mesh` (ordinary CCW UV, no swap), so it must still interpolate
+    with the naive-linear formula - confirming the mirror on face 0 didn't leak into face 1.
+    """
+    size_mm = 80.0
+    tile = (8, 8)
+    w, h = tile
+    verts_mm = np.array(
+        [[0.0, 0.0, 0.0], [size_mm, 0.0, 0.0], [size_mm, size_mm, 0.0], [0.0, size_mm, 0.0]]
+    )
+    faces = np.array([[0, 1, 2], [0, 2, 3]])
+    loop_uv = np.array(
+        [
+            [[0.0, 0.0], [1.0, 1.0], [1.0, 0.0]],  # CW winding -> area2 < 0 swap branch (mirrored)
+            [[0.0, 0.0], [1.0, 1.0], [0.0, 1.0]],  # ordinary CCW UV, same as _quad_mesh face 1
+        ]
+    )
+
+    # Sanity-check the premise this test depends on, independent of atlas internals: face 0's
+    # loop_uv is authored CW (negative signed area) while face 1's is CCW (positive).
+    uv0, uv1, uv2 = loop_uv[0]
+    signed_area2_face0 = (uv1[0] - uv0[0]) * (uv2[1] - uv0[1]) - (uv1[1] - uv0[1]) * (uv2[0] - uv0[0])
+    assert signed_area2_face0 < 0, "fixture must exercise the area2 < 0 swap branch"
+    uv0, uv1, uv2 = loop_uv[1]
+    signed_area2_face1 = (uv1[0] - uv0[0]) * (uv2[1] - uv0[1]) - (uv1[1] - uv0[1]) * (uv2[0] - uv0[0])
+    assert signed_area2_face1 > 0, "face 1 must stay on the ordinary (no-swap) path"
+
+    out = atlas.rasterize_tile(verts_mm, faces, loop_uv, tile)
+
+    # (a) full coverage, no double-claimed texels, and both triangles actually contributed. The
+    # footprint is identical to test_rasterize_full_cover_quad's quad (see derivation above), so
+    # this should behave exactly the same regardless of the UV mirror on face 0.
+    xy_rows = list(map(tuple, out["xy"].tolist()))
+    assert len(xy_rows) == w * h
+    assert len(set(xy_rows)) == len(xy_rows)
+    assert set(out["face"].tolist()) == {0, 1}
+
+    # (c) normals: computed from `faces`' vertex order (mesh winding), not `loop_uv`, so the UV
+    # mirror on face 0 must NOT affect it. Both faces are CCW in the XY plane -> unit +Z normal.
+    assert np.allclose(out["normal"], np.array([0.0, 0.0, 1.0]), atol=1e-9)
+    assert np.allclose(np.linalg.norm(out["normal"], axis=1), 1.0, atol=1e-9)
+
+    xy = out["xy"]
+    pos = out["position_mm"]
+    face_col = out["face"]
+
+    # (b) face 0 (mirrored): every covered texel must match the skewed barycentric formula above,
+    # not the naive linear one.
+    face0_mask = face_col == 0
+    assert face0_mask.sum() > 0  # the mirrored triangle actually contributed texels
+    for x, y, p in zip(xy[face0_mask, 0], xy[face0_mask, 1], pos[face0_mask]):
+        px, py = float(x) + 0.5, float(y) + 0.5
+        expected = np.array([size_mm * px / w, size_mm * (px / w - py / h), 0.0])
+        assert p == pytest.approx(expected, abs=1e-9)
+
+    # face 1 (ordinary CCW UV): naive-linear formula, unaffected by face 0's mirror.
+    face1_mask = face_col == 1
+    assert face1_mask.sum() > 0
+    for x, y, p in zip(xy[face1_mask, 0], xy[face1_mask, 1], pos[face1_mask]):
+        expected = np.array([(x + 0.5) / w * size_mm, (y + 0.5) / h * size_mm, 0.0])
+        assert p == pytest.approx(expected, abs=1e-9)
+
+    # Explicit named probes (face 0) for diagnosability if the loop-based check above ever fails:
+    # texel (0,0): px=py=0.5 -> wa=1-0.5/8=0.9375, wb=0.5/8-0.5/8=0, wc=0.5/8=0.0625
+    #   position = P0*0.9375 + P2*0 + P1*0.0625 = (80*0.0625, 0, 0) = (5.0, 0.0, 0.0)
+    # texel (7,0): px=7.5, py=0.5 -> position_x=80*7.5/8=75.0, position_y=80*(7.5/8-0.5/8)=70.0
+    # texel (4,2): px=4.5, py=2.5 -> position_x=80*4.5/8=45.0, position_y=80*(4.5/8-2.5/8)=20.0
+    probes = {(0, 0): (5.0, 0.0, 0.0), (7, 0): (75.0, 70.0, 0.0), (4, 2): (45.0, 20.0, 0.0)}
+    for (px_i, py_i), expected in probes.items():
+        m = face0_mask & (xy[:, 0] == px_i) & (xy[:, 1] == py_i)
+        assert m.sum() == 1, f"expected exactly one covered face-0 texel at ({px_i},{py_i})"
+        assert pos[m][0] == pytest.approx(np.array(expected), abs=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# dilate
+# ---------------------------------------------------------------------------
+
+
+def test_dilate_fills_margin_and_preserves_valid():
+    image = np.zeros((5, 5), dtype=np.float64)
+    valid = np.zeros((5, 5), dtype=bool)
+    image[2, 2] = 10.0
+    valid[2, 2] = True
+
+    original = image.copy()
+    out = atlas.dilate(image, valid, iterations=4)
+
+    # The one originally-valid texel is untouched.
+    assert out[2, 2] == pytest.approx(original[2, 2])
+
+    # After one push-out pass, its 8 direct neighbors take the mean of valid 8-neighbors, i.e. 10.
+    for dy, dx in [(-1, -1), (-1, 0), (-1, 1), (0, -1), (0, 1), (1, -1), (1, 0), (1, 1)]:
+        assert out[2 + dy, 2 + dx] == pytest.approx(10.0)
+
+    # With enough iterations (max Chebyshev distance from center on a 5x5 grid is 2), every texel
+    # ends up filled - no leftover zeros from an unfilled/no-valid-neighbor texel.
+    assert np.all(out > 0.0)
+
+    # A corner (Chebyshev distance 2, reached only on the 2nd pass) should also end up close to
+    # 10 given the small, uniform-source geometry here.
+    assert out[0, 0] > 0.0
+
+
+def test_dilate_preserves_valid_and_is_noop_when_all_valid():
+    image = np.arange(9, dtype=np.float64).reshape(3, 3)
+    valid = np.ones((3, 3), dtype=bool)
+    out = atlas.dilate(image, valid, iterations=4)
+    assert np.array_equal(out, image)
+
+
+def test_dilate_rejects_non_2d_valid():
+    # `valid` must be a single 2D validity mask even when `image` is multi-channel
+    # (e.g. an (H, W, 3) RGB atlas) - a caller passing a (H, W, 3) `valid` by mistake
+    # must get a clear error, not a silent shape-broadcast bug.
+    image = np.zeros((4, 4, 3), dtype=np.float64)
+    valid = np.zeros((4, 4, 3), dtype=bool)
+    with pytest.raises(ValueError):
+        atlas.dilate(image, valid, iterations=2)
+
+
+def test_dilate_zero_iterations_is_noop():
+    image = np.array([[1.0, 0.0], [0.0, 0.0]])
+    valid = np.array([[True, False], [False, False]])
+    out = atlas.dilate(image, valid, iterations=0)
+    assert out[0, 0] == pytest.approx(1.0)
+    assert out[0, 1] == pytest.approx(0.0)
+    assert out[1, 0] == pytest.approx(0.0)
+    assert out[1, 1] == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# performance sanity (not a hard requirement of the brief's named tests, but the brief calls out
+# a concrete target: a 352^2 tile with ~2k triangles well under a second)
+# ---------------------------------------------------------------------------
+
+
+def test_rasterize_performance_sanity():
+
+    rng = np.random.default_rng(0)
+    n_tris = 2000
+    tile = (352, 352)
+
+    # Build a grid of small quads (2 triangles each) tiling the UV unit square, so triangles are
+    # spatially local (like real UV islands) rather than degenerate/overlapping garbage.
+    grid_n = math.ceil(math.sqrt(n_tris / 2))
+    step = 1.0 / grid_n
+    verts = []
+    faces = []
+    loop_uv = []
+    for gy in range(grid_n):
+        for gx in range(grid_n):
+            if len(faces) >= n_tris:
+                break
+            u0, v0 = gx * step, gy * step
+            u1, v1 = u0 + step, v0 + step
+            base = len(verts)
+            z = float(rng.uniform(-1.0, 1.0))
+            verts.extend(
+                [
+                    [u0 * 1000, v0 * 1000, z],
+                    [u1 * 1000, v0 * 1000, z],
+                    [u1 * 1000, v1 * 1000, z],
+                    [u0 * 1000, v1 * 1000, z],
+                ]
+            )
+            faces.append([base, base + 1, base + 2])
+            loop_uv.append([[u0, v0], [u1, v0], [u1, v1]])
+            if len(faces) < n_tris:
+                faces.append([base, base + 2, base + 3])
+                loop_uv.append([[u0, v0], [u1, v1], [u0, v1]])
+
+    verts_mm = np.array(verts)
+    faces_arr = np.array(faces[:n_tris])
+    loop_uv_arr = np.array(loop_uv[:n_tris])
+
+    out = atlas.rasterize_tile(verts_mm, faces_arr, loop_uv_arr, tile)
+
+    assert out["xy"].shape[0] > 0

--- a/tests/test_heatsim_atlas_render.py
+++ b/tests/test_heatsim_atlas_render.py
@@ -1,0 +1,652 @@
+"""Tests for Task 3: the atlas EXR writer (``adapter.write_atlas``) and the render-time
+plumbing that loads/packs it. Both node-graph shader tests and the
+``render_domain="TEXEL"`` config-dispatch parity tests live in sibling files
+(``tests/test_heatsim_shader.py``, ``tests/test_heatsim_config.py``); this file covers
+the writer itself and the ``write_frame_attributes``/``global_temperature_range`` TEXEL
+behavior specified in the Task 3 brief.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import Imath
+import numpy as np
+import OpenEXR
+import pytest
+
+from visionsim.simulate.heatsim import adapter, atlas
+
+
+def _tile_layout(atlas_size, tiles):
+    return atlas.AtlasLayout(atlas_size=atlas_size, tiles=tiles, effective_density=500.0, rescaled=False)
+
+
+def _plan(atlas_size, tiles, texels, digest="testdigest"):
+    return adapter.AtlasPlan(layout=_tile_layout(atlas_size, tiles), texels=texels, digest=digest)
+
+
+# ---------------------------------------------------------------------------
+# write_atlas: needs bpy (image creation/save), run inside Blender.
+# ---------------------------------------------------------------------------
+
+
+def test_write_atlas_scatters_dilates_and_marks_alpha(executable, tmp_path):
+    code = f"""
+import numpy as np
+from pathlib import Path
+from visionsim.simulate.heatsim import adapter, atlas
+
+# One object, one 6x6 tile at atlas offset (0,0). Two solved texels at (1,1) and (4,4)
+# (far apart so their dilation margins don't overlap and mask each other's zeros).
+# Size the tile from the dilation count so an unwritten region provably survives: the
+# margin grows by one texel per pass, so a corner further than that from every solved
+# texel must stay alpha=0. Hardcoding a 6x6 tile silently stopped testing anything when
+# _ATLAS_DILATE_ITERATIONS was raised from 1 to 8 -- the margin then covered the whole tile.
+_D = adapter._ATLAS_DILATE_ITERATIONS
+_N = 2 * _D + 6          # room for two solved texels and an untouched corner
+tile = atlas.TileSpec(obj_name='obj', size=(_N, _N), offset=(0, 0))
+layout = atlas.AtlasLayout(atlas_size=(_N, _N), tiles={{'obj': tile}}, effective_density=500.0, rescaled=False)
+texels = {{'obj': {{'xy': np.array([[1, 1], [_N - 2, _N - 2]], dtype=np.int64)}}}}
+plan = adapter.AtlasPlan(layout=layout, texels=texels, digest='rt')
+
+history = {{'obj': np.array([[300.0, 300.0], [310.0, 320.0]])}}  # (T=2, K=2); final row used
+
+out_path = adapter.write_atlas(history, plan, Path(r'{tmp_path}'))
+assert out_path.exists(), out_path
+assert out_path.name == 'atlas_temperature.exr'
+assert 'rt' in str(out_path.parent.name)
+
+import bpy
+img = bpy.data.images.load(str(out_path))
+w, h = img.size
+assert (w, h) == (_N, _N), (w, h)
+px = np.array(img.pixels[:], dtype=np.float64).reshape(h, w, 4)
+
+# Scattered texels: match (within EXR write/load round-trip precision -- Blender's
+# Image.save() has no exposed lossless-compression knob for a plain generated
+# image, so a few mK of drift is expected and harmless for a Kelvin-scale field)
+# at (x=1,y=1) -> 310.0 and (x=4,y=4) -> 320.0, alpha=1.
+assert abs(px[1, 1, 0] - 310.0) < 0.05, px[1, 1]
+assert abs(px[_N - 2, _N - 2, 0] - 320.0) < 0.05, px[_N - 2, _N - 2]
+assert px[1, 1, 3] == 1.0
+assert px[_N - 2, _N - 2, 3] == 1.0
+
+# A direct 8-neighbor of a solved texel is inside the dilation margin: alpha=1 (valid
+# coverage per the dilated mask) and a nonzero temperature pulled from that neighbor
+# (never the raw zero an un-dilated scatter would leave).
+assert px[1, 2, 3] == 1.0, px[1, 2]
+assert px[1, 2, 0] > 0.0, px[1, 2]
+
+# Far corner, well outside the (small, capped) dilation margin from either solved texel:
+# still unwritten -> alpha=0, temperature left at the initialized zero.
+unwritten = np.argwhere(px[:, :, 3] == 0.0)
+assert unwritten.size > 0, 'dilation covered the whole tile; margin is not bounded'
+_r, _c = unwritten[0]
+assert px[_r, _c, 3] == 0.0, px[_r, _c]
+assert px[_r, _c, 0] == 0.0, ('unwritten texel carries a temperature', px[_r, _c])
+
+print('WRITE_ATLAS_OK')
+"""
+    out = subprocess.run([str(executable), "-b", "--python-expr", code], capture_output=True, text=True, check=False)
+    assert "WRITE_ATLAS_OK" in out.stdout, out.stdout + "\n" + out.stderr
+
+    # Absolute-value check: read the EXR with the standalone OpenEXR package (never bpy --
+    # bpy's load applies the same colorspace-tagged decode as the write's encode, so a
+    # write->bpy-load round trip only proves symmetry, not that the file holds the true
+    # Kelvin values). This is the assertion that catches a Non-Color tag regression: an
+    # untagged write would land here as ~11.2 (sRGB-OETF-encoded 310.0), not 310.0.
+    exr_path = tmp_path / "atlas_rt" / "atlas_temperature.exr"
+    assert exr_path.exists(), exr_path
+    exr = OpenEXR.InputFile(str(exr_path))
+    dw = exr.header()["dataWindow"]
+    w = dw.max.x - dw.min.x + 1
+    h = dw.max.y - dw.min.y + 1
+    float_t = Imath.PixelType(Imath.PixelType.FLOAT)
+    r_raw = np.frombuffer(exr.channel("R", float_t), dtype=np.float32).reshape(h, w)
+    # OpenEXR rows are top-down while Blender's Image.pixels buffer (and the (x, y) texel
+    # coordinates used above) are bottom-up, so the on-disk row is (h - 1 - y).
+    # Same geometry the Blender-side half used: tile side derived from the dilation count,
+    # with the second solved texel at (_N - 2, _N - 2).
+    _n = 2 * adapter._ATLAS_DILATE_ITERATIONS + 6
+    assert (w, h) == (_n, _n), (w, h)
+    assert abs(float(r_raw[h - 1 - 1, 1]) - 310.0) < 1e-2, r_raw[h - 1 - 1, 1]
+    assert abs(float(r_raw[h - 1 - (_n - 2), _n - 2]) - 320.0) < 1e-2, r_raw[h - 1 - (_n - 2), _n - 2]
+
+
+def test_write_atlas_no_texels_writes_empty_placeholder(executable, tmp_path):
+    """No atlas objects this solve (render_domain=TEXEL requested but nothing qualified,
+    or atlas_plan built from an empty scene) -> write_atlas must still return a stable,
+    loadable, all-invalid path rather than raising."""
+    code = f"""
+from pathlib import Path
+from visionsim.simulate.heatsim import adapter, atlas
+
+layout = atlas.AtlasLayout(atlas_size=(0, 0), tiles={{}}, effective_density=500.0, rescaled=False)
+plan = adapter.AtlasPlan(layout=layout, texels={{}}, digest='empty')
+
+out_path = adapter.write_atlas({{}}, plan, Path(r'{tmp_path}'))
+assert out_path.exists(), out_path
+
+import bpy
+img = bpy.data.images.load(str(out_path))
+import numpy as np
+px = np.array(img.pixels[:], dtype=np.float64)
+assert np.all(px[3::4] == 0.0)  # every alpha channel is 0 (nothing valid)
+
+print('WRITE_ATLAS_EMPTY_OK')
+"""
+    out = subprocess.run([str(executable), "-b", "--python-expr", code], capture_output=True, text=True, check=False)
+    assert "WRITE_ATLAS_EMPTY_OK" in out.stdout, out.stdout + "\n" + out.stderr
+
+
+# ---------------------------------------------------------------------------
+# F3: dilation must not bridge the inter-tile packing padding (pure numpy, no bpy).
+# ---------------------------------------------------------------------------
+
+
+def test_scatter_atlas_arrays_dilation_does_not_bridge_inter_tile_padding():
+    """Two adjacent tiles, solved at the edges nearest each other with different
+    temperatures. The dilation margin from each tile must not reach far enough to pull
+    its neighbour's temperature into the other tile's region (or the padding gap right
+    next to it) -- this is only true while `_ATLAS_DILATE_ITERATIONS` (grows the valid
+    region by 1 texel/pass) stays strictly less than the packing `_ATLAS_PACKING_PADDING`
+    gap between tiles."""
+    pad = adapter._ATLAS_PACKING_PADDING
+    # Tiles must be wider than the dilation margin, or the margin swallows the tile and
+    # the test stops distinguishing "did not bridge" from "filled everything".
+    side = 2 * adapter._ATLAS_DILATE_ITERATIONS + 2
+    tile_a = atlas.TileSpec("tile_a", (side, side), (0, 0))
+    tile_b = atlas.TileSpec("tile_b", (side, side), (side + pad, 0))
+    atlas_size = (side + pad + side, side)
+    layout = atlas.AtlasLayout(atlas_size=atlas_size, tiles={"tile_a": tile_a, "tile_b": tile_b},
+                                effective_density=500.0, rescaled=False)
+    # Solved texel at each tile's edge closest to the other tile, so any bleed shows up
+    # as fast as possible.
+    texels = {
+        "tile_a": {"xy": np.array([[side - 1, 0]], dtype=np.int64)},
+        "tile_b": {"xy": np.array([[0, 0]], dtype=np.int64)},
+    }
+    plan = adapter.AtlasPlan(layout=layout, texels=texels, digest="bleedtest")
+    history = {"tile_a": np.array([[400.0]]), "tile_b": np.array([[300.0]])}
+
+    temp, _alpha = adapter._scatter_atlas_arrays(history, plan)
+
+    b_start = side + pad
+    tile_b_region = temp[:, b_start : b_start + side]
+    tile_a_region = temp[:, 0:side]
+    # The gap's near-A column may legitimately carry tile A's dilated value (and the
+    # near-B column may legitimately carry tile B's) -- that's the single-texel push-out
+    # margin working as intended. What must never happen is A's temperature reaching
+    # tile B's region or the gap column immediately adjacent to B (and symmetrically for
+    # B's temperature reaching tile A's side).
+    gap_near_b = temp[:, b_start - 1 : b_start]
+    gap_near_a = temp[:, side : side + 1]
+    assert not np.any(np.isclose(tile_b_region, 400.0)), tile_b_region
+    assert not np.any(np.isclose(gap_near_b, 400.0)), gap_near_b
+    assert not np.any(np.isclose(tile_a_region, 300.0)), tile_a_region
+    assert not np.any(np.isclose(gap_near_a, 300.0)), gap_near_a
+    # The middle gap column must stay untouched (0.0). With 2*iterations <= padding the
+    # two tiles' push-outs can never meet; if a future bump violated that invariant, the
+    # meeting texels would hold the MEAN of both tiles (e.g. 350.0 here) - catch it.
+    gap_middle = temp[:, 5:6]
+    assert np.all(gap_middle == 0.0), gap_middle
+
+
+# ---------------------------------------------------------------------------
+# write_frame_attributes TEXEL behavior (no bpy needed via a minimal fake scene/mesh).
+# ---------------------------------------------------------------------------
+
+
+class _FakeAttrData(list):
+    def foreach_set(self, prop, values):
+        for elem, value in zip(self, values):
+            setattr(elem, prop, float(value))
+
+
+class _FakeAttr:
+    def __init__(self, n):
+        self.data = _FakeAttrData(type("D", (), {"value": 0.0})() for _ in range(n))
+
+
+class _FakeAttrs(dict):
+    def __init__(self, n):
+        super().__init__()
+        self._n = n
+
+    def new(self, name, type, domain):
+        self[name] = _FakeAttr(self._n)
+        return self[name]
+
+    def remove(self, attr):
+        for key, value in list(self.items()):
+            if value is attr:
+                del self[key]
+                return
+
+
+class _FakeMesh:
+    def __init__(self, n_verts):
+        self.vertices = [object()] * n_verts
+        self.attributes = _FakeAttrs(n_verts)
+
+    def update(self):
+        pass
+
+
+class _FakeObj:
+    def __init__(self, name, n_verts):
+        self.name = name
+        self.type = "MESH"
+        self.data = _FakeMesh(n_verts)
+        self.heat_sim_material = None
+        self._props = {}
+
+    def __setitem__(self, key, value):
+        self._props[key] = value
+
+    def __getitem__(self, key):
+        return self._props[key]
+
+    def __contains__(self, key):
+        return key in self._props
+
+    def __delitem__(self, key):
+        del self._props[key]
+
+
+class _FakeScene:
+    def __init__(self, objects):
+        self.objects = objects
+
+
+_DEFAULTS = {
+    "initial_temperature_K": 295.0,
+    "thermal_diffusivity_mm2_s": 0.17,
+    "density_kg_m3": 1330.0,
+    "specific_heat_J_kgK": 880.0,
+    "emissivity": 0.9,
+}
+
+
+def test_write_frame_attributes_texel_objects_get_fallback_only():
+    vertex_obj = _FakeObj("vertex_mesh", n_verts=3)
+    atlas_obj = _FakeObj("atlas_mesh", n_verts=3)  # same vertex count as its texel count on purpose
+
+    # atlas_mesh's "history" has K=3 texels -- deliberately the SAME as its vertex count, so a
+    # shape-coincidence could otherwise slip through the old (implicit) shape-mismatch fallback.
+    history = {
+        "vertex_mesh": np.array([[295.0, 295.0, 295.0], [300.0, 301.0, 302.0]]),
+        "atlas_mesh": np.array([[295.0, 295.0, 295.0], [350.0, 360.0, 370.0]]),
+    }
+    plan = _plan((8, 8), {"atlas_mesh": atlas.TileSpec("atlas_mesh", (8, 8), (0, 0))}, {"atlas_mesh": {"xy": np.zeros((3, 2), dtype=np.int64)}})
+
+    scene = _FakeScene([vertex_obj, atlas_obj])
+    adapter.write_frame_attributes(scene, history, -1, _DEFAULTS, atlas_plan=plan)
+
+    # Vertex-path object: unchanged, per-vertex sim_temperature written from the final row.
+    vals = [d.value for d in vertex_obj.data.attributes["sim_temperature"].data]
+    assert vals == pytest.approx([300.0, 301.0, 302.0])
+    assert "heatsim_default_temperature" not in vertex_obj._props
+
+    # Atlas object: NO per-vertex sim_temperature attribute written (even though the shapes
+    # would have "matched" under the old implicit-mismatch fallback) -- only the OBJECT-level
+    # fallback, at the ambient default (FEM participant).
+    assert "sim_temperature" not in atlas_obj.data.attributes
+    assert "emissivity" not in atlas_obj.data.attributes
+    assert atlas_obj["heatsim_default_temperature"] == pytest.approx(295.0)
+
+    # Coverage gate: 1.0 for the atlas participant, 0.0 for the vertex-path object.
+    assert atlas_obj["heatsim_atlas_coverage"] == pytest.approx(1.0)
+    assert vertex_obj["heatsim_atlas_coverage"] == pytest.approx(0.0)
+
+
+def test_write_frame_attributes_vertex_mode_unaffected_by_atlas_plan_none():
+    """atlas_plan=None (or omitted) reproduces exactly today's VERTEX-only behavior --
+    no coverage-gate property is stamped anywhere."""
+    obj = _FakeObj("mesh", n_verts=2)
+    history = {"mesh": np.array([[295.0, 295.0], [305.0, 306.0]])}
+
+    scene = _FakeScene([obj])
+    adapter.write_frame_attributes(scene, history, -1, _DEFAULTS)
+
+    vals = [d.value for d in obj.data.attributes["sim_temperature"].data]
+    assert vals == pytest.approx([305.0, 306.0])
+    assert "heatsim_atlas_coverage" not in obj._props
+
+
+def test_write_frame_attributes_atlas_participant_clears_stale_vertex_attrs():
+    """F1: a VERTEX->TEXEL mode switch on a long-lived service must not let a
+    pre-existing (stale) per-vertex sim_temperature/emissivity attribute bleed through
+    atlas holes -- the shader's vertex-path fallback treats sim_temperature > 1.0 as
+    valid, so a leftover attribute would win over the fresh OBJECT-level fallback."""
+    atlas_obj = _FakeObj("atlas_mesh", n_verts=3)
+    # Simulate a prior VERTEX-mode run: stale per-vertex attributes already present.
+    atlas_obj.data.attributes.new(name="sim_temperature", type="FLOAT", domain="POINT")
+    atlas_obj.data.attributes.new(name="emissivity", type="FLOAT", domain="POINT")
+    for d in atlas_obj.data.attributes["sim_temperature"].data:
+        d.value = 999.0
+
+    plan = _plan(
+        (8, 8),
+        {"atlas_mesh": atlas.TileSpec("atlas_mesh", (8, 8), (0, 0))},
+        {"atlas_mesh": {"xy": np.zeros((3, 2), dtype=np.int64)}},
+    )
+    scene = _FakeScene([atlas_obj])
+    adapter.write_frame_attributes(scene, {}, -1, _DEFAULTS, atlas_plan=plan)
+
+    assert "sim_temperature" not in atlas_obj.data.attributes
+    assert "emissivity" not in atlas_obj.data.attributes
+    assert atlas_obj["heatsim_default_temperature"] == pytest.approx(295.0)
+
+
+def test_write_frame_attributes_vertex_mode_clears_stale_atlas_coverage_gate():
+    """F4: a TEXEL->VERTEX mode switch must clear a stale heatsim_atlas_coverage=1.0
+    object property left by a prior TEXEL run -- otherwise the shader's atlas mix gate
+    (stale alpha * stale coverage) can stay open and select stale atlas texels over the
+    fresh per-vertex temperatures written this call."""
+    obj = _FakeObj("mesh", n_verts=2)
+    obj["heatsim_atlas_coverage"] = 1.0  # left over from a prior TEXEL run
+    history = {"mesh": np.array([[295.0, 295.0], [305.0, 306.0]])}
+
+    scene = _FakeScene([obj])
+    adapter.write_frame_attributes(scene, history, -1, _DEFAULTS, atlas_plan=None)
+
+    assert "heatsim_atlas_coverage" not in obj._props
+
+
+# ---------------------------------------------------------------------------
+# write_frame_attributes constant-fill on impossible write-back (Fix 2: the 0-K
+# regression guard). Same no-bpy fake scene/mesh as above.
+# ---------------------------------------------------------------------------
+
+
+class _FakeMat:
+    """Stand-in for ``obj.heat_sim_material`` (mirrors test_heatsim_adapter.py's)."""
+
+    def __init__(self, *, always_set: bool, **values):
+        self._always_set = always_set
+        for k, v in values.items():
+            setattr(self, k, v)
+
+    def is_property_set(self, attr):
+        return self._always_set
+
+
+def test_write_frame_attributes_shape_mismatch_writes_constant_fill(caplog):
+    """Fix 2 / 0-K regression guard: a modifier changed the vertex count between the
+    evaluated mesh the FEM solve ran on (history's vertex axis) and the base mesh
+    (n_verts). The old behaviour dropped sim_temperature entirely -- absent, so the
+    shader's `sim_temperature > 1.0` validity gate falls through to
+    heatsim_default_temperature for the RADIANCE pass but the temperature AOV (which has
+    no such gate) emits 0 K. The fix must still fill a constant sim_temperature equal to
+    the mean of the solved field's final timestep, must not leave emissivity absent
+    either, and must warn (naming the object)."""
+    obj = _FakeObj("mismatched_mesh", n_verts=4)  # base mesh: 4 verts
+    final_row = [300.0, 302.0, 304.0, 306.0, 308.0, 310.0]  # solve-time (evaluated): 6
+    history = {"mismatched_mesh": np.array([[295.0] * 6, final_row])}
+
+    scene = _FakeScene([obj])
+    with caplog.at_level("WARNING"):
+        adapter.write_frame_attributes(scene, history, -1, _DEFAULTS)
+
+    # NOT absent -- this is the actual 0-K regression guard.
+    assert "sim_temperature" in obj.data.attributes
+    vals = [d.value for d in obj.data.attributes["sim_temperature"].data]
+    expected_mean = float(np.mean(final_row))
+    assert vals == pytest.approx([expected_mean] * 4)
+    assert expected_mean > _DEFAULTS["initial_temperature_K"]  # real heating preserved
+
+    # emissivity must not be left absent either (same reasoning).
+    assert "emissivity" in obj.data.attributes
+    eps = [d.value for d in obj.data.attributes["emissivity"].data]
+    assert eps == pytest.approx([_DEFAULTS["emissivity"]] * 4)
+
+    assert any("mismatched_mesh" in rec.message for rec in caplog.records)
+
+
+def test_write_frame_attributes_missing_history_writes_fallback_fill():
+    """Fix 2: an object entirely absent from `history` (e.g. a DIRICHLET_SOURCE fluid
+    whose topology changes every frame, so no per-vertex field survives) must render at
+    its RESERVOIR temperature -- not ambient -- and must not be left with an absent
+    sim_temperature attribute."""
+    obj = _FakeObj("dirichlet_mesh", n_verts=3)
+    obj.heat_sim_material = _FakeMat(
+        always_set=True,
+        initial_temperature_K=295.0,
+        thermal_diffusivity_mm2_s=0.17,
+        density_kg_m3=1330.0,
+        specific_heat_J_kgK=880.0,
+        emissivity=0.9,
+        thermal_role="DIRICHLET_SOURCE",
+        dirichlet_temperature_K=350.0,
+    )
+
+    scene = _FakeScene([obj])
+    adapter.write_frame_attributes(scene, {}, -1, _DEFAULTS)
+
+    assert "sim_temperature" in obj.data.attributes
+    vals = [d.value for d in obj.data.attributes["sim_temperature"].data]
+    assert vals == pytest.approx([350.0, 350.0, 350.0])  # reservoir, not ambient (295 K)
+    assert obj["heatsim_default_temperature"] == pytest.approx(350.0)
+    assert "emissivity" in obj.data.attributes
+
+
+def test_atlas_participants_still_have_no_vertex_attribute():
+    """Fix 2 must not touch atlas participants: their per-pixel signal comes from the
+    atlas image, not a per-vertex mesh attribute, and an earlier fix already strips any
+    stale one left by a prior VERTEX-mode run. Confirms that invariant survives Fix 2's
+    new constant-fill branches (an atlas participant is also absent from `history`, which
+    would otherwise hit the same code path a non-participant does)."""
+    atlas_obj = _FakeObj("atlas_mesh", n_verts=5)
+    plan = _plan(
+        (8, 8),
+        {"atlas_mesh": atlas.TileSpec("atlas_mesh", (8, 8), (0, 0))},
+        {"atlas_mesh": {"xy": np.zeros((5, 2), dtype=np.int64)}},
+    )
+
+    scene = _FakeScene([atlas_obj])
+    # No history entry for the atlas object -- its signal lives in the atlas image.
+    adapter.write_frame_attributes(scene, {}, -1, _DEFAULTS, atlas_plan=plan)
+
+    assert "sim_temperature" not in atlas_obj.data.attributes
+    assert "emissivity" not in atlas_obj.data.attributes
+    assert atlas_obj["heatsim_default_temperature"] == pytest.approx(295.0)
+
+
+# ---------------------------------------------------------------------------
+# global_temperature_range already pools whatever is in `history`, TEXEL entries included
+# (they arrive there via the same _split_history/solve_scene path as VERTEX entries) --
+# this locks that behavior explicitly rather than relying on it being incidental.
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# End-to-end integration: drive the real BlenderService.exposed_prepare_thermal /
+# exposed_include_thermal with render_domain="TEXEL". Not one of the brief's named
+# fake-bpy tests, but the unit tests above (write_atlas, write_frame_attributes, the
+# shader node graph) each exercise one piece in isolation -- this closes the gap the
+# same way test_heatsim_animated.py's BlenderService-driven test does for the animated
+# path, catching a real orchestration mismatch between _thermal_solve/write_atlas/the
+# atlas-image load+pack/setup_temperature_aov that no single-function test would see.
+# ---------------------------------------------------------------------------
+
+
+def test_prepare_and_include_thermal_texel_mode_end_to_end(executable, tmp_path):
+    code = f"""
+import bpy
+from visionsim.simulate.heatsim import register
+register()
+
+bpy.ops.object.select_all(action='SELECT')
+bpy.ops.object.delete()
+
+# A coarse (4-vertex) plane spanning 4 m^2: well under any reasonable
+# atlas_texel_density, so it must join the atlas (mirrors test_heatsim_texel_mode.py's
+# end-to-end atlas smoke test).
+bpy.ops.mesh.primitive_plane_add(size=2.0)
+plane = bpy.context.active_object
+plane.name = 'CoarsePlane'
+plane.heat_simulation_enabled = True
+
+mat = bpy.data.materials.new('plane_mat')
+mat.use_nodes = True
+plane.data.materials.append(mat)
+
+bpy.ops.object.light_add(type='SUN')
+bpy.context.active_object.data.energy = 10.0
+world = bpy.context.scene.world
+world.use_nodes = True
+bg = world.node_tree.nodes.get('Background')
+bg.inputs['Strength'].default_value = 1.0
+
+blend_path = r'{tmp_path}/texel_test.blend'
+root_path = r'{tmp_path}'
+bpy.ops.wm.save_as_mainfile(filepath=blend_path)
+
+from visionsim.simulate.blender import BlenderService
+from visionsim.simulate.heatsim.constants import ATLAS_COVERAGE_PROP, ATLAS_IMAGE_NAME
+
+service = BlenderService()
+service.exposed_initialize(blend_path, root_path)
+
+service.exposed_prepare_thermal(
+    render_domain='TEXEL',
+    atlas_texel_density=64.0,
+    atlas_tile_min=16,
+    atlas_tile_max=64,
+    atlas_texel_soft_max=500_000,
+    domain='POINTS',
+    laplacian_backend='ROBUST',
+    device='cpu',
+    sim_time_s=0.1,
+    timestep_s=0.05,
+    initial_temperature_K=295.0,
+    thermal_diffusivity_mm2_s=0.17,
+    density_kg_m3=1330.0,
+    specific_heat_J_kgK=880.0,
+    emissivity=0.9,
+    irradiance_scale=100.0,
+)
+
+assert service._thermal_atlas_plan is not None
+assert 'CoarsePlane' in service._thermal_atlas_plan.texels
+
+plane_obj = bpy.data.objects['CoarsePlane']
+assert 'sim_temperature' not in plane_obj.data.attributes, 'atlas object must not get a per-vertex write'
+assert plane_obj[ATLAS_COVERAGE_PROP] == 1.0
+
+atlas_img = bpy.data.images.get(ATLAS_IMAGE_NAME)
+assert atlas_img is not None, 'atlas image was not loaded/packed'
+assert atlas_img.packed_file is not None, 'atlas image was not packed'
+
+# Re-fetch the material via the object rather than the captured Python `mat` handle --
+# the albedo bake path (triggered by texel irradiance for the atlas) may swap/copy
+# material slots, invalidating the original `bpy.types.Material` reference. That same
+# albedo bake also leaves its OWN ShaderNodeTexImage node (the bake target) on the
+# material, so look for the atlas-specific one by its image rather than assuming
+# there is exactly one Image Texture node.
+live_mat = plane_obj.material_slots[0].material
+assert live_mat is not None
+mat_nodes = live_mat.node_tree.nodes
+aov_nodes = [n for n in mat_nodes if n.type == 'OUTPUT_AOV']
+assert len(aov_nodes) == 1
+atlas_tex_nodes = [n for n in mat_nodes if n.bl_idname == 'ShaderNodeTexImage' and n.image is atlas_img]
+assert len(atlas_tex_nodes) == 1, [n.name for n in mat_nodes if n.bl_idname == 'ShaderNodeTexImage']
+
+service.exposed_include_thermal(render_domain='TEXEL')
+assert 'temperature' in service.render_layers.outputs
+
+print('TEXEL_E2E_OK')
+"""
+    out = subprocess.run([str(executable), "-b", "--python-expr", code], capture_output=True, text=True, check=False)
+    assert "TEXEL_E2E_OK" in out.stdout, out.stdout + "\n" + out.stderr
+
+
+def test_prepare_thermal_texel_static_branch_keeps_dirichlet_reservoir_fallback(executable, tmp_path):
+    """F2: exposed_prepare_thermal's static (non-animated) branch must stamp
+    heatsim_default_temperature (ambient) BEFORE write_frame_attributes runs, not after --
+    otherwise the stamp clobbers the Dirichlet-reservoir fallback write_frame_attributes
+    just set for a DIRICHLET_SOURCE atlas object back down to ambient."""
+    code = f"""
+import bpy
+from visionsim.simulate.heatsim import register
+register()
+
+bpy.ops.object.select_all(action='SELECT')
+bpy.ops.object.delete()
+
+bpy.ops.mesh.primitive_plane_add(size=2.0)
+plane = bpy.context.active_object
+plane.name = 'HotReservoir'
+plane.heat_simulation_enabled = True
+plane.heat_sim_material.thermal_role = 'DIRICHLET_SOURCE'
+plane.heat_sim_material.dirichlet_temperature_K = 350.0
+
+mat = bpy.data.materials.new('plane_mat')
+mat.use_nodes = True
+plane.data.materials.append(mat)
+
+bpy.ops.object.light_add(type='SUN')
+bpy.context.active_object.data.energy = 10.0
+world = bpy.context.scene.world
+world.use_nodes = True
+bg = world.node_tree.nodes.get('Background')
+bg.inputs['Strength'].default_value = 1.0
+
+blend_path = r'{tmp_path}/texel_dirichlet_test.blend'
+root_path = r'{tmp_path}'
+bpy.ops.wm.save_as_mainfile(filepath=blend_path)
+
+from visionsim.simulate.blender import BlenderService
+from visionsim.simulate.heatsim.constants import ATLAS_COVERAGE_PROP
+
+service = BlenderService()
+service.exposed_initialize(blend_path, root_path)
+
+service.exposed_prepare_thermal(
+    render_domain='TEXEL',
+    atlas_texel_density=64.0,
+    atlas_tile_min=16,
+    atlas_tile_max=64,
+    atlas_texel_soft_max=500_000,
+    domain='POINTS',
+    laplacian_backend='ROBUST',
+    device='cpu',
+    sim_time_s=0.1,
+    timestep_s=0.05,
+    initial_temperature_K=295.0,
+    thermal_diffusivity_mm2_s=0.17,
+    density_kg_m3=1330.0,
+    specific_heat_J_kgK=880.0,
+    emissivity=0.9,
+    irradiance_scale=100.0,
+)
+
+plane_obj = bpy.data.objects['HotReservoir']
+assert plane_obj[ATLAS_COVERAGE_PROP] == 1.0, 'expected this DIRICHLET_SOURCE object to be an atlas participant'
+# Must be the reservoir temperature (350K), NOT ambient (295K) -- a wrong stamp/write
+# order would have clobbered it back down to ambient.
+assert abs(plane_obj['heatsim_default_temperature'] - 350.0) < 1e-6, plane_obj['heatsim_default_temperature']
+
+print('DIRICHLET_FALLBACK_OK')
+"""
+    out = subprocess.run([str(executable), "-b", "--python-expr", code], capture_output=True, text=True, check=False)
+    assert "DIRICHLET_FALLBACK_OK" in out.stdout, out.stdout + "\n" + out.stderr
+
+
+def test_global_temperature_range_includes_texels():
+    # A "vertex" object near ambient plus an "atlas" (texel) object running much hotter --
+    # both keyed into `history` exactly the same way (solve_scene/​_split_history don't
+    # distinguish TEXEL from VERTEX entries), so the pooled range must span both.
+    history = {
+        "vertex_mesh": np.stack([np.full(50, 295.0), np.full(50, 295.5)]),
+        "atlas_mesh": np.stack([np.full(400, 295.0), np.full(400, 340.0)]),
+    }
+
+    tmin, tmax = adapter.global_temperature_range(history, default_K=295.0)
+
+    # The texel object's 340 K dominates the pool (400 texels vs 50 vertices), so P99 must
+    # land near it, not be capped near the near-ambient vertex object's ~295.5 K.
+    assert tmax > 330.0, tmax
+    assert tmin <= 295.5, tmin

--- a/tests/test_heatsim_cache.py
+++ b/tests/test_heatsim_cache.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import numpy as np
+
+from visionsim.simulate.heatsim import cache
+
+
+def test_cache_roundtrip_and_miss(tmp_path):
+    key = cache.cache_key(tmp_path / "scene.blend", {"dt": 0.05, "domain": "POINTS"})
+    assert isinstance(key, str) and key
+
+    assert cache.read_temperatures(tmp_path, key) is None  # miss before write
+
+    per_object = {"cup": np.full((4, 10), 295.0), "plate": np.full((4, 7), 296.0)}
+    out = cache.write_temperatures(tmp_path, key, per_object, {"num_timesteps": 4})
+    assert out.exists()
+
+    back = cache.read_temperatures(tmp_path, key)
+    assert back is not None
+    assert set(back) == {"cup", "plate"}
+    assert np.allclose(back["cup"], 295.0) and back["plate"].shape == (4, 7)
+
+
+def test_animated_roundtrip_and_miss(tmp_path):
+    cache_dir = tmp_path / "some_animated_key"
+    assert cache.read_animated(cache_dir) is None  # miss: dir doesn't exist yet
+
+    cache_dir.mkdir()
+    assert cache.read_animated(cache_dir) is None  # miss: dir exists but empty
+
+    history = {"cup": np.full((5, 100), 300.0), "plate": np.full((5, 40), 295.0)}
+    frames = [1, 2, 3, 4, 5]
+    out = cache.write_animated(cache_dir, history, frames, {"substeps": 4})
+    assert out.exists()
+
+    back = cache.read_animated(cache_dir)
+    assert back is not None
+    hist_back, frames_back = back
+    assert set(hist_back) == {"cup", "plate"}
+    assert hist_back["cup"].shape == (5, 100)
+    assert hist_back["plate"].shape == (5, 40)
+    assert np.allclose(hist_back["cup"], 300.0) and np.allclose(hist_back["plate"], 295.0)
+    assert frames_back == frames
+
+
+def test_animated_key_differs_from_static_key(tmp_path):
+    blend = tmp_path / "scene.blend"
+    static_cfg = {"dt": 0.05, "domain": "POINTS"}
+    animated_cfg = {
+        **static_cfg,
+        "animated": True,
+        "frame_start": 1,
+        "frame_end": 5,
+        "every_n": 1,
+        "substeps": 4,
+    }
+    static_key = cache.cache_key(blend, static_cfg)
+    animated_key = cache.cache_key(blend, animated_cfg)
+    assert static_key != animated_key

--- a/tests/test_heatsim_config.py
+++ b/tests/test_heatsim_config.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import inspect
+from dataclasses import asdict, fields
+
+from visionsim.simulate.blender import BlenderService
+from visionsim.simulate.config import ThermalConfig
+
+_ATLAS_FIELDS = (
+    "render_domain",
+    "atlas_texel_density",
+    "atlas_tile_min",
+    "atlas_tile_max",
+    "atlas_texel_soft_max",
+)
+
+
+def test_thermal_config_atlas_fields_dispatch_parity():
+    """The 5 atlas fields must exist on ThermalConfig with the spec'd defaults, and every
+    one of the three thermal-dispatch entry points must accept them with the SAME default
+    (not just the same name) -- ``**asdict(config.thermal)`` drives all three uniformly, so a
+    mismatched default would silently diverge from the config's own default whenever a caller
+    omits the field.
+    """
+    cfg = ThermalConfig()
+    assert cfg.render_domain == "VERTEX"
+    assert cfg.atlas_texel_density == 1500.0
+    assert cfg.atlas_tile_min == 16
+    assert cfg.atlas_tile_max == 512
+    assert cfg.atlas_texel_soft_max == 500_000
+
+    conf_defaults = {f.name: f.default for f in fields(ThermalConfig) if f.name in _ATLAS_FIELDS}
+    assert set(conf_defaults) == set(_ATLAS_FIELDS)
+
+    for method in (
+        BlenderService.exposed_prepare_thermal,
+        BlenderService.exposed_heatsim_solve,
+        BlenderService.exposed_include_thermal,
+    ):
+        sig_params = inspect.signature(method).parameters
+        for name in _ATLAS_FIELDS:
+            assert name in sig_params, f"{method.__name__} is missing {name!r}"
+            assert sig_params[name].default == conf_defaults[name], (
+                f"{method.__name__}.{name} default {sig_params[name].default!r} != "
+                f"ThermalConfig.{name} default {conf_defaults[name]!r}"
+            )
+
+    # asdict(ThermalConfig()) must round-trip through every key too (belt-and-suspenders,
+    # mirrors test_heatsim_assignments_integration.test_asdict_dispatch_matches_both_service_signatures).
+    keys = set(asdict(cfg))
+    for method in (BlenderService.exposed_prepare_thermal, BlenderService.exposed_heatsim_solve):
+        missing = keys - (set(inspect.signature(method).parameters) - {"self"})
+        assert not missing, f"{method.__name__} is missing {sorted(missing)}"
+
+
+def test_thermal_config_animated_defaults():
+    cfg = ThermalConfig()
+    assert cfg.animated is False
+    assert cfg.substeps_per_frame == 4
+    assert cfg.frame_start is None
+    assert cfg.frame_end is None
+    assert cfg.every_n_frames == 1
+
+    fields = asdict(cfg)
+    for key in ("animated", "substeps_per_frame", "frame_start", "frame_end", "every_n_frames"):
+        assert key in fields

--- a/tests/test_heatsim_dispatch.py
+++ b/tests/test_heatsim_dispatch.py
@@ -1,0 +1,66 @@
+"""Host-side (no Blender) unit tests for the thermal include-dispatch in ``render_job``.
+
+The parity test (``test_docstrings.test_output_configs``) only checks that the
+``ThermalConfig`` dataclass and the ``exposed_include_thermal`` signature agree; it
+does NOT exercise the job-level dispatch.  These tests close that gap by driving
+``render_job`` with a fake client and asserting that ``config.include_thermal``
+triggers ``prepare_thermal(**asdict(config.thermal))`` immediately followed by
+``include_thermal(**asdict(config.thermal))`` (and that nothing fires when disabled).
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+
+from visionsim.simulate.config import RenderConfig
+from visionsim.simulate.job import render_job
+
+
+class _RecordingClient:
+    """Fake Blender client: records every method call as ``(name, args, kwargs)``.
+
+    Every attribute access resolves to a no-op recorder, so ``render_job`` can run
+    end-to-end without a real Blender process while we inspect the call sequence.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple, dict]] = []
+
+    def __getattr__(self, name: str):
+        def _record(*args, **kwargs):
+            self.calls.append((name, args, kwargs))
+
+        return _record
+
+
+def test_render_job_dispatches_thermal_prepare_then_include():
+    client = _RecordingClient()
+    config = RenderConfig(include_thermal=True)
+
+    render_job(client, "scene.blend", "out", config=config, dry_run=True)
+
+    names = [name for name, _, _ in client.calls]
+    assert "prepare_thermal" in names, names
+    assert "include_thermal" in names, names
+
+    # prepare_thermal must come *immediately* before include_thermal.
+    i = names.index("prepare_thermal")
+    assert names[i + 1] == "include_thermal", names
+
+    expected = asdict(config.thermal)
+    _prep_name, prep_args, prep_kwargs = client.calls[i]
+    _incl_name, incl_args, incl_kwargs = client.calls[i + 1]
+    assert prep_args == () and incl_args == ()
+    assert prep_kwargs == expected
+    assert incl_kwargs == expected
+
+
+def test_render_job_skips_thermal_when_disabled():
+    client = _RecordingClient()
+    config = RenderConfig(include_thermal=False)
+
+    render_job(client, "scene.blend", "out", config=config, dry_run=True)
+
+    names = [name for name, _, _ in client.calls]
+    assert "prepare_thermal" not in names, names
+    assert "include_thermal" not in names, names

--- a/tests/test_heatsim_irradiance.py
+++ b/tests/test_heatsim_irradiance.py
@@ -1,0 +1,182 @@
+import subprocess
+
+
+def test_bake_albedo_map_returns_varying_pixels(executable):
+    code = r"""
+import bpy, numpy as np
+from visionsim.simulate.heatsim import register, irradiance
+
+register()
+bpy.ops.object.select_all(action='SELECT')
+bpy.ops.object.delete()
+bpy.ops.mesh.primitive_grid_add(x_subdivisions=12, y_subdivisions=12, size=2.0)
+obj = bpy.context.active_object
+
+mat = bpy.data.materials.new('checker_mat')
+mat.use_nodes = True
+nt = mat.node_tree
+bsdf = nt.nodes.get('Principled BSDF')
+checker = nt.nodes.new('ShaderNodeTexChecker')
+checker.inputs['Scale'].default_value = 6.0
+nt.links.new(checker.outputs['Color'], bsdf.inputs['Base Color'])
+obj.data.materials.append(mat)
+
+bpy.context.scene.render.engine = 'CYCLES'
+try:
+    bpy.context.scene.cycles.device = 'CPU'
+    bpy.context.scene.cycles.samples = 4
+except Exception:
+    pass
+
+baked = irradiance.bake_albedo_map(bpy.context.scene, obj, 128)
+assert baked is not None, 'bake_albedo_map returned None'
+px = baked.pixels
+assert px.ndim == 3 and px.shape[2] == 3, f'bad pixel shape {px.shape}'
+assert float(px.std()) > 0.1, f'expected high-contrast checker variation (std>0.1), got std={px.std()}'
+mean = float(px.mean())
+assert 0.0 <= mean <= 1.0, f'albedo mean out of range: {mean}'
+print('ALBEDO_BAKE_OK', px.shape, round(mean, 3), round(float(px.std()), 3))
+"""
+    out = subprocess.run(
+        [str(executable), "-b", "--python-expr", code],
+        capture_output=True, text=True,
+     check=False)
+    assert "ALBEDO_BAKE_OK" in out.stdout, out.stdout + "\n" + out.stderr
+
+
+def test_solve_produces_varying_albedo_attribute(executable, tmp_path):
+    code = r"""
+import bpy, numpy as np
+from pathlib import Path
+from visionsim.simulate.heatsim import register, adapter
+
+register()
+bpy.ops.object.select_all(action='SELECT')
+bpy.ops.object.delete()
+bpy.ops.mesh.primitive_grid_add(x_subdivisions=20, y_subdivisions=20, size=2.0)
+obj = bpy.context.active_object
+obj.name = 'ThermalPlane'
+obj.heat_simulation_enabled = True
+
+mat = bpy.data.materials.new('checker_mat')
+mat.use_nodes = True
+nt = mat.node_tree
+bsdf = nt.nodes.get('Principled BSDF')
+checker = nt.nodes.new('ShaderNodeTexChecker')
+checker.inputs['Scale'].default_value = 6.0
+nt.links.new(checker.outputs['Color'], bsdf.inputs['Base Color'])
+obj.data.materials.append(mat)
+
+bpy.ops.object.light_add(type='SUN')
+bpy.context.active_object.data.energy = 10.0
+world = bpy.context.scene.world
+world.use_nodes = True
+bg = world.node_tree.nodes.get('Background')
+bg.inputs['Strength'].default_value = 1.0
+
+defaults = dict(initial_temperature_K=295.0, thermal_diffusivity_mm2_s=0.17,
+                density_kg_m3=1330.0, specific_heat_J_kgK=880.0, emissivity=0.9,
+                irradiance_scale=100.0)
+solver_cfg = dict(sim_time_s=0.1, timestep_s=0.05, domain='POINTS',
+                  laplacian_backend='ROBUST', device='cpu')
+adapter.solve_scene(bpy.context.scene, defaults=defaults,
+                    solver_cfg=solver_cfg, cache_root=Path(r'{tmp}'))
+
+mesh = obj.data
+attr = mesh.attributes.get('albedo')
+assert attr is not None, 'no albedo attribute after solve'
+vals = np.zeros(len(mesh.vertices), dtype=np.float32)
+attr.data.foreach_get('value', vals)
+assert float(vals.std()) > 0.05, f'albedo not varying (std={{vals.std()}}) - bake did not run'
+assert 0.0 < float(vals.mean()) < 1.0, f'albedo mean out of range: {{vals.mean()}}'
+print('VARYING_ALBEDO_OK', round(float(vals.mean()), 3), round(float(vals.std()), 3))
+""".replace("{tmp}", str(tmp_path))
+    out = subprocess.run(
+        [str(executable), "-b", "--python-expr", code],
+        capture_output=True, text=True,
+     check=False)
+    assert "VARYING_ALBEDO_OK" in out.stdout, out.stdout + "\n" + out.stderr
+
+
+def test_authored_irradiance_scale_read_under_bpy(executable):
+    code = r"""
+import bpy
+from visionsim.simulate.heatsim import register, adapter
+register()
+sc = bpy.context.scene
+sc['heat_sim_settings'] = {'irradiance_scale': 1000.0}
+val = adapter.read_authored_irradiance_scale(sc)
+assert val == 1000.0, f'expected 1000.0, got {val!r}'
+del sc['heat_sim_settings']
+assert adapter.read_authored_irradiance_scale(sc) is None
+print('AUTHORED_SCALE_OK')
+"""
+    out = subprocess.run(
+        [str(executable), "-b", "--python-expr", code],
+        capture_output=True, text=True,
+     check=False)
+    assert "AUTHORED_SCALE_OK" in out.stdout, out.stdout + "\n" + out.stderr
+
+
+def test_all_zero_cached_albedo_is_ignored_and_rebaked(executable):
+    code = r"""
+import bpy, numpy as np
+from visionsim.simulate.heatsim import register, irradiance_kernel
+register()
+bpy.ops.object.select_all(action='SELECT'); bpy.ops.object.delete()
+bpy.ops.mesh.primitive_grid_add(x_subdivisions=12, y_subdivisions=12, size=2.0)
+obj = bpy.context.active_object
+mat = bpy.data.materials.new('checker'); mat.use_nodes = True
+nt = mat.node_tree; bsdf = nt.nodes.get('Principled BSDF')
+ck = nt.nodes.new('ShaderNodeTexChecker'); ck.inputs['Scale'].default_value = 6.0
+nt.links.new(ck.outputs['Color'], bsdf.inputs['Base Color'])
+obj.data.materials.append(mat)
+bpy.context.scene.render.engine = 'CYCLES'
+try: bpy.context.scene.cycles.device = 'CPU'; bpy.context.scene.cycles.samples = 4
+except Exception: pass
+nv = len(obj.data.vertices)
+# Stale all-zeros disk cache for this object must NOT be served; must re-bake.
+amap = irradiance_kernel.get_or_bake_vertex_albedo(
+    bpy.context.scene, [obj], texture_size=128,
+    disk_cache={obj.name: np.zeros(nv, dtype=np.float64)})
+alb = amap.get(obj.name)
+assert alb is not None, 'albedo absent'
+assert float(alb.std()) > 0.05, f'zeros cache was served instead of re-baking (std={alb.std()})'
+print('ZERO_CACHE_IGNORED_OK', round(float(alb.mean()),3), round(float(alb.std()),3))
+"""
+    out = subprocess.run([str(executable), "-b", "--python-expr", code],
+                         capture_output=True, text=True, check=False)
+    assert "ZERO_CACHE_IGNORED_OK" in out.stdout, out.stdout + "\n" + out.stderr
+
+
+def test_all_zero_attribute_albedo_is_ignored_and_rebaked(executable):
+    code = r"""
+import bpy, numpy as np
+from visionsim.simulate.heatsim import register, irradiance_kernel
+register()
+bpy.ops.object.select_all(action='SELECT'); bpy.ops.object.delete()
+bpy.ops.mesh.primitive_grid_add(x_subdivisions=12, y_subdivisions=12, size=2.0)
+obj = bpy.context.active_object
+mat = bpy.data.materials.new('checker'); mat.use_nodes = True
+nt = mat.node_tree; bsdf = nt.nodes.get('Principled BSDF')
+ck = nt.nodes.new('ShaderNodeTexChecker'); ck.inputs['Scale'].default_value = 6.0
+nt.links.new(ck.outputs['Color'], bsdf.inputs['Base Color'])
+obj.data.materials.append(mat)
+bpy.context.scene.render.engine = 'CYCLES'
+try: bpy.context.scene.cycles.device = 'CPU'; bpy.context.scene.cycles.samples = 4
+except Exception: pass
+nv = len(obj.data.vertices)
+# Stale all-zeros mesh attribute for this object must NOT be served; must re-bake.
+mesh = obj.data
+attr = mesh.attributes.new(name='albedo', type='FLOAT', domain='POINT')
+attr.data.foreach_set('value', np.zeros(nv, dtype=np.float64))
+amap = irradiance_kernel.get_or_bake_vertex_albedo(
+    bpy.context.scene, [obj], texture_size=128)
+alb = amap.get(obj.name)
+assert alb is not None, 'albedo absent'
+assert float(alb.std()) > 0.05, f'zeros attribute was served instead of re-baking (std={alb.std()})'
+print('ZERO_ATTR_IGNORED_OK', round(float(alb.mean()),3), round(float(alb.std()),3))
+"""
+    out = subprocess.run([str(executable), "-b", "--python-expr", code],
+                         capture_output=True, text=True, check=False)
+    assert "ZERO_ATTR_IGNORED_OK" in out.stdout, out.stdout + "\n" + out.stderr

--- a/tests/test_heatsim_laplacian.py
+++ b/tests/test_heatsim_laplacian.py
@@ -1,0 +1,117 @@
+"""Non-finite Laplacian sanitization (visionsim.simulate.heatsim.laplacian).
+
+Regression cover for a defect that produced a completely NaN temperature field while the
+pipeline exited 0 and rendered every frame from it. ``robust_laplacian`` emitted ``-inf``
+on the Laplacian diagonal for 2 of 120,183 nodes -- degenerate local neighbourhoods, where
+coincident points leave the local tangent plane undefined. The damage was global rather
+than local because it propagates through a scalar: an ``inf`` diagonal makes ``diagA``
+inf, the Jacobi preconditioner entry becomes 0, ``A @ p`` goes non-finite, and PCG's
+``alpha = rz_old / (p . Ap)`` -- one scalar -- becomes NaN, poisoning every node on the
+first timestep.
+
+These tests fake ``robust_laplacian`` so they run on the host interpreter, where the real
+package is not installed (it lives in Blender's Python).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import scipy.sparse as sp
+
+from visionsim.simulate.heatsim import laplacian as L
+
+
+def _fake_backend(monkeypatch, make):
+    """Point `laplacian` at a stub whose point_cloud_laplacian returns `make(n)`."""
+
+    class _Stub:
+        @staticmethod
+        def point_cloud_laplacian(points, mollify_factor=1e-5, n_neighbors=30):
+            return make(len(points))
+
+    monkeypatch.setattr(L, "robust_laplacian", _Stub)
+    monkeypatch.setattr(L, "HAS_ROBUST_LAPLACIAN", True)
+
+
+def _clean(n):
+    lap = sp.diags([2.0] * n).tolil()
+    for i in range(n - 1):
+        lap[i, i + 1] = -1.0
+        lap[i + 1, i] = -1.0
+    return lap.tocsr(), sp.diags([1.0] * n, format="csr")
+
+
+def test_non_finite_diagonal_is_isolated_not_propagated(monkeypatch):
+    """An -inf on one row must not survive into the returned operator."""
+    bad_row = 3
+
+    def make(n):
+        lap, mass = _clean(n)
+        lap = lap.tolil()
+        lap[bad_row, bad_row] = -np.inf
+        return lap.tocsr(), mass
+
+    _fake_backend(monkeypatch, make)
+    pts = np.random.default_rng(0).random((8, 3))
+
+    with pytest.warns(RuntimeWarning, match="non-finite"):
+        lap, mass = L.point_cloud_laplacian_and_mass(pts)
+
+    assert np.all(np.isfinite(lap.toarray())), "a non-finite entry survived sanitization"
+    assert np.all(np.isfinite(mass.diagonal()))
+    # The offending node is isolated: it conducts to nobody and nobody conducts to it.
+    dense = lap.toarray()
+    assert not dense[bad_row, :].any(), "bad row was not zeroed"
+    assert not dense[:, bad_row].any(), "bad column was not zeroed"
+    # Every other node keeps its coupling -- this is a local repair, not a global reset.
+    assert dense[0, 1] != 0.0
+
+
+def test_warning_names_the_offending_node(monkeypatch):
+    """The warning has to say WHICH node, or it cannot be acted on."""
+
+    def make(n):
+        lap, mass = _clean(n)
+        lap = lap.tolil()
+        lap[5, 5] = np.nan
+        return lap.tocsr(), mass
+
+    _fake_backend(monkeypatch, make)
+    with pytest.warns(RuntimeWarning) as rec:
+        L.point_cloud_laplacian_and_mass(np.random.default_rng(1).random((9, 3)))
+    assert "5" in str(rec[0].message)
+
+
+def test_non_positive_mass_is_repaired(monkeypatch):
+    """A zero or negative lumped mass divides by ~zero downstream."""
+
+    def make(n):
+        lap, mass = _clean(n)
+        diag = mass.diagonal().copy()
+        diag[2] = 0.0
+        diag[4] = -1.0
+        return lap, sp.diags(diag, format="csr")
+
+    _fake_backend(monkeypatch, make)
+    with pytest.warns(RuntimeWarning, match="mass"):
+        _, mass = L.point_cloud_laplacian_and_mass(np.random.default_rng(2).random((7, 3)))
+    diag = mass.diagonal()
+    assert np.all(np.isfinite(diag))
+    assert np.all(diag > 0.0), "a non-positive mass entry survived"
+
+
+def test_clean_input_is_untouched_and_silent(monkeypatch):
+    """Sanitization must be a no-op on a well-conditioned cloud."""
+    _fake_backend(monkeypatch, _clean)
+    pts = np.random.default_rng(3).random((10, 3))
+
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # any warning here fails the test
+        lap, mass = L.point_cloud_laplacian_and_mass(pts)
+
+    expected_lap, expected_mass = _clean(10)
+    assert np.allclose(lap.toarray(), expected_lap.toarray())
+    assert np.allclose(mass.diagonal(), expected_mass.diagonal())

--- a/tests/test_heatsim_materials.py
+++ b/tests/test_heatsim_materials.py
@@ -1,0 +1,386 @@
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import json
+
+import numpy as np
+import pytest
+
+from visionsim.simulate.heatsim import constants, materials
+
+# ---------------------------------------------------------------------------
+# 1. Preset library
+# ---------------------------------------------------------------------------
+
+# Seeded from the vendored constants.py dicts; alpha/rho/c must agree exactly so
+# the new library and the addon-parity constants cannot silently drift apart.
+_SEEDED = ["aluminium", "pvc", "glass", "copper", "polystyrene", "wood", "steel",
+           "brick", "concrete", "plaster", "asphalt", "iron", "li_ion"]
+
+
+def test_library_is_well_formed():
+    assert len(materials.PRESETS) == 29
+    for key, preset in materials.PRESETS.items():
+        assert preset.key == key
+        assert preset.alpha_mm2_s > 0.0, key
+        assert preset.density_kg_m3 > 0.0, key
+        assert preset.specific_heat_J_kgK > 0.0, key
+        assert 0.0 <= preset.emissivity_ir <= 1.0, key
+        assert preset.notes, key
+
+
+def test_preset_keys_are_sorted_and_complete():
+    keys = materials.preset_keys()
+    assert keys == sorted(keys)
+    assert set(keys) == set(materials.PRESETS)
+
+
+def test_seeded_presets_agree_with_vendored_constants():
+    for key in _SEEDED:
+        preset = materials.PRESETS[key]
+        assert preset.alpha_mm2_s == pytest.approx(constants.TDiff[key]), key
+        # constants.Density is kg/mm^3 (kg/m^3 divided by 1000**3).
+        assert preset.density_kg_m3 == pytest.approx(constants.Density[key] * 1.0e9), key
+        assert preset.specific_heat_J_kgK == pytest.approx(constants.SpecificHeat[key]), key
+
+
+def test_polished_and_painted_metal_are_distinct():
+    """The single largest visual lever in LWIR - see spec section 4b."""
+    assert materials.PRESETS["aluminium_polished"].emissivity_ir < 0.10
+    assert materials.PRESETS["metal_painted"].emissivity_ir > 0.85
+
+
+def test_alpha_spans_three_orders_of_magnitude():
+    """Sanity: the library must actually discriminate insulators from conductors."""
+    alphas = np.array([p.alpha_mm2_s for p in materials.PRESETS.values()])
+    assert alphas.max() / alphas.min() > 1000.0
+
+
+def test_presets_are_immutable():
+    # ThermalPreset is frozen: resolve_material/resolve_vertex_materials hand the SAME
+    # instance to every caller, so a mutable preset would let one caller poison the
+    # global library. Assert the specific error rather than bare Exception.
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        materials.PRESETS["wood"].alpha_mm2_s = 999.0  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# 2. Sidecar parsing
+# ---------------------------------------------------------------------------
+
+
+def _write(tmp_path, block, default_preset="plaster", name="scene.thermal.json"):
+    path = tmp_path / name
+    path.write_text(json.dumps({
+        "schema_version": 1,
+        "scene": "kitchen1.blend",
+        "defaults": {"preset": default_preset},
+        "materials": block,
+    }), encoding="utf-8")
+    return path
+
+
+def test_loads_a_well_formed_sidecar(tmp_path):
+    path = _write(tmp_path, {
+        "MADERA ESTANTES": {"preset": "wood", "role": "FEM_PARTICIPANT", "confidence": 0.95, "reason": "madera"},
+    })
+    sa = materials.load_assignments(path)
+    assert sa.scene == "kitchen1.blend"
+    assert sa.default_preset is not None and sa.default_preset.key == "plaster"
+    entry = sa.entry_for("MADERA ESTANTES")
+    assert entry is not None and entry.preset is not None
+    assert entry.preset.key == "wood"
+    assert entry.role == "FEM_PARTICIPANT" and entry.dirichlet_K is None
+
+
+def test_material_absent_from_the_sidecar_returns_none(tmp_path):
+    sa = materials.load_assignments(_write(tmp_path, {"a": {"preset": "wood"}}))
+    assert sa.entry_for("NOT PRESENT") is None
+
+
+def test_null_reason_does_not_become_the_literal_string_none(tmp_path):
+    """``spec.get("reason", "")`` would turn a JSON ``null`` into the string "None"
+    (``str(None)``); the ``or``-fallback used elsewhere in this file must be used here too."""
+    path = _write(tmp_path, {"x": {"preset": "wood", "reason": None}})
+    entry = materials.load_assignments(path).entry_for("x")
+    assert entry is not None
+    assert entry.reason == ""
+
+
+def test_null_scene_does_not_become_the_literal_string_none(tmp_path):
+    """Same ``.get(key, default)`` vs ``or``-fallback hazard for the top-level ``scene``
+    field, which reaches the solve cache key - a stray "None" there would be a silently
+    wrong (but stable-looking) cache key component."""
+    path = tmp_path / "scene.thermal.json"
+    path.write_text(json.dumps({
+        "schema_version": 1, "scene": None, "defaults": {}, "materials": {},
+    }), encoding="utf-8")
+    sa = materials.load_assignments(path)
+    assert sa.scene == path.name
+
+
+def test_unknown_preset_becomes_unassigned_and_warns(tmp_path):
+    """An out-of-enum preset must never be silently guessed at - spec section 5."""
+    path = _write(tmp_path, {"weird": {"preset": "unobtainium"}})
+    with pytest.warns(UserWarning, match="unobtainium"):
+        sa = materials.load_assignments(path)
+    entry = sa.entry_for("weird")
+    assert entry is not None and entry.preset is None
+
+
+def test_dirichlet_source_keeps_an_in_band_temperature(tmp_path):
+    path = _write(tmp_path, {"ilum": {"preset": "glass", "role": "DIRICHLET_SOURCE", "dirichlet_K": 345.0}})
+    entry = materials.load_assignments(path).entry_for("ilum")
+    assert entry is not None
+    assert entry.role == "DIRICHLET_SOURCE" and entry.dirichlet_K == 345.0
+
+
+@pytest.mark.parametrize("bad", [12.0, 5000.0])
+def test_out_of_band_dirichlet_temperature_is_dropped_and_warns(tmp_path, bad):
+    """An out-of-band dirichlet_K must not leave the slot pinned at ambient with role
+    still DIRICHLET_SOURCE (alpha=0, no incident flux) - that would silently turn an
+    intended heat source into a heat sink. The role degrades to FEM_PARTICIPANT too."""
+    path = _write(tmp_path, {"ilum": {"preset": "glass", "role": "DIRICHLET_SOURCE", "dirichlet_K": bad}})
+    with pytest.warns(UserWarning, match="dirichlet_K"):
+        sa = materials.load_assignments(path)
+    entry = sa.entry_for("ilum")
+    assert entry is not None and entry.dirichlet_K is None
+    assert entry.role == "FEM_PARTICIPANT"
+
+
+def test_unknown_role_falls_back_to_fem_and_warns(tmp_path):
+    path = _write(tmp_path, {"x": {"preset": "wood", "role": "TELEPORTER"}})
+    with pytest.warns(UserWarning, match="role"):
+        sa = materials.load_assignments(path)
+    entry = sa.entry_for("x")
+    assert entry is not None and entry.role == "FEM_PARTICIPANT"
+
+
+def test_role_defaults_to_fem_participant(tmp_path):
+    entry = materials.load_assignments(_write(tmp_path, {"x": {"preset": "wood"}})).entry_for("x")
+    assert entry is not None and entry.role == "FEM_PARTICIPANT"
+
+
+def test_unknown_default_preset_warns_and_disables_the_default(tmp_path):
+    path = _write(tmp_path, {"x": {"preset": "wood"}}, default_preset="nonsense")
+    with pytest.warns(UserWarning, match="nonsense"):
+        sa = materials.load_assignments(path)
+    assert sa.default_preset is None
+
+
+def test_bad_schema_version_raises(tmp_path):
+    path = tmp_path / "s.json"
+    path.write_text(json.dumps({"schema_version": 99, "scene": "s", "defaults": {}, "materials": {}}), "utf-8")
+    with pytest.raises(ValueError, match="schema_version"):
+        materials.load_assignments(path)
+
+
+def test_non_numeric_dirichlet_k_raises_naming_the_sidecar(tmp_path):
+    path = _write(tmp_path, {"ilum": {"preset": "glass", "role": "DIRICHLET_SOURCE", "dirichlet_K": "hot"}})
+    with pytest.raises(ValueError, match="scene.thermal.json"):
+        materials.load_assignments(path)
+
+
+def test_null_defaults_block_raises_naming_the_sidecar(tmp_path):
+    path = tmp_path / "scene.thermal.json"
+    path.write_text(json.dumps({
+        "schema_version": 1, "scene": "kitchen1.blend", "defaults": None, "materials": {},
+    }), encoding="utf-8")
+    with pytest.raises(ValueError, match="scene.thermal.json"):
+        materials.load_assignments(path)
+
+
+def test_null_materials_block_raises_naming_the_sidecar(tmp_path):
+    path = tmp_path / "scene.thermal.json"
+    path.write_text(json.dumps({
+        "schema_version": 1, "scene": "kitchen1.blend", "defaults": {}, "materials": None,
+    }), encoding="utf-8")
+    with pytest.raises(ValueError, match="scene.thermal.json"):
+        materials.load_assignments(path)
+
+
+def test_non_dict_material_spec_raises_naming_the_sidecar_and_material(tmp_path):
+    path = _write(tmp_path, {"ilum": ["not", "a", "dict"]})
+    with pytest.raises(ValueError, match=r"scene\.thermal\.json.*'ilum'"):
+        materials.load_assignments(path)
+
+
+def test_digest_tracks_file_bytes(tmp_path):
+    path = _write(tmp_path, {"x": {"preset": "wood"}})
+    sa = materials.load_assignments(path)
+    assert sa.digest == hashlib.sha256(path.read_bytes()).hexdigest()
+
+    # Editing the sidecar must change the digest, so the solve cache invalidates.
+    path.write_text(path.read_text(encoding="utf-8").replace("wood", "steel"), encoding="utf-8")
+    assert materials.load_assignments(path).digest != sa.digest
+
+
+# ---------------------------------------------------------------------------
+# 3. Slot -> per-vertex resolution
+# ---------------------------------------------------------------------------
+
+# Distinctive globals: no value here can be confused with a preset or a
+# PropertyGroup default (mirrors tests/test_heatsim_adapter.py).
+_FALLBACK = {
+    "initial_temperature_K": 300.0,
+    "thermal_diffusivity_mm2_s": 0.42,
+    "density_kg_m3": 1234.0,
+    "specific_heat_J_kgK": 777.0,
+    "emissivity": 0.5,
+    "thermal_role": "FEM_PARTICIPANT",
+    "dirichlet_temperature_K": 0.0,
+}
+
+
+class _Poly:
+    def __init__(self, vertices, material_index, area):
+        self.vertices = list(vertices)
+        self.material_index = material_index
+        self.area = area
+
+
+class _Mesh:
+    def __init__(self, n_verts, polygons):
+        self.vertices = [object()] * n_verts
+        self.polygons = list(polygons)
+
+
+class _Obj:
+    def __init__(self, name, mesh, slot_names):
+        self.name = name
+        self.data = mesh
+        self.material_slots = [type("S", (), {"material": type("M", (), {"name": n})()})() for n in slot_names]
+
+
+def _stool():
+    """Verts 0,1 pure wood; verts 4,5 pure steel; verts 2,3 on the seam.
+
+       0---1---(2---3)---4---5    wood area 6 on the left, steel area 2 on the right
+    """
+    polys = [_Poly([0, 1, 2, 3], 0, area=6.0), _Poly([2, 3, 4, 5], 1, area=2.0)]
+    return _Obj("stool", _Mesh(6, polys), ["MADERA BANQUETAS", "METALBANQUETAS"])
+
+
+def _sidecar(tmp_path, block, default_preset=None):
+    return materials.load_assignments(_write(tmp_path, block, default_preset=default_preset))
+
+
+def test_interior_vertices_get_their_slot_preset_exactly(tmp_path):
+    sa = _sidecar(tmp_path, {"MADERA BANQUETAS": {"preset": "wood"}, "METALBANQUETAS": {"preset": "steel"}})
+    out = materials.resolve_vertex_materials(_stool(), sa, _FALLBACK)
+    assert out is not None
+    assert out["alpha"][1] == pytest.approx(materials.PRESETS["wood"].alpha_mm2_s)
+    assert out["eps"][1] == pytest.approx(materials.PRESETS["wood"].emissivity_ir)
+    assert out["alpha"][4] == pytest.approx(materials.PRESETS["steel"].alpha_mm2_s)
+    assert out["rho"][4] == pytest.approx(materials.PRESETS["steel"].density_kg_m3)
+
+
+def test_seam_vertices_get_the_area_weighted_mean(tmp_path):
+    wood, steel = materials.PRESETS["wood"], materials.PRESETS["steel"]
+    sa = _sidecar(tmp_path, {"MADERA BANQUETAS": {"preset": "wood"}, "METALBANQUETAS": {"preset": "steel"}})
+    out = materials.resolve_vertex_materials(_stool(), sa, _FALLBACK)
+    assert out is not None
+
+    expected_alpha = (wood.alpha_mm2_s * 6.0 + steel.alpha_mm2_s * 2.0) / 8.0
+    expected_c = (wood.specific_heat_J_kgK * 6.0 + steel.specific_heat_J_kgK * 2.0) / 8.0
+    for v in (2, 3):
+        assert out["alpha"][v] == pytest.approx(expected_alpha)
+        assert out["c"][v] == pytest.approx(expected_c)
+    assert wood.alpha_mm2_s < out["alpha"][2] < steel.alpha_mm2_s
+
+
+def test_categorical_role_is_dominant_not_blended(tmp_path):
+    """A vertex is pinned or it is not - a 75/25 split must not make it 'partly pinned'."""
+    sa = _sidecar(tmp_path, {
+        "MADERA BANQUETAS": {"preset": "wood"},
+        "METALBANQUETAS": {"preset": "steel", "role": "DIRICHLET_SOURCE", "dirichlet_K": 345.0},
+    })
+    out = materials.resolve_vertex_materials(_stool(), sa, _FALLBACK)
+    assert out is not None
+    assert not out["dirichlet_mask"][2] and not out["dirichlet_mask"][3]  # wood dominates the seam
+    assert out["dirichlet_mask"][4] and out["dirichlet_mask"][5]
+    assert out["t0"][4] == pytest.approx(345.0)
+
+
+def test_dominant_flips_when_the_area_split_flips(tmp_path):
+    sa = _sidecar(tmp_path, {
+        "A": {"preset": "wood"},
+        "B": {"preset": "steel", "role": "DIRICHLET_SOURCE", "dirichlet_K": 350.0},
+    })
+    obj = _Obj("o", _Mesh(6, [_Poly([0, 1, 2, 3], 0, 1.0), _Poly([2, 3, 4, 5], 1, 9.0)]), ["A", "B"])
+    out = materials.resolve_vertex_materials(obj, sa, _FALLBACK)
+    assert out is not None
+    assert out["dirichlet_mask"][2] and out["dirichlet_mask"][3]
+
+
+def test_unassigned_material_falls_back_to_the_object_defaults(tmp_path):
+    sa = _sidecar(tmp_path, {"MADERA BANQUETAS": {"preset": "wood"}})  # slot 1 absent
+    out = materials.resolve_vertex_materials(_stool(), sa, _FALLBACK)
+    assert out is not None
+    assert out["alpha"][4] == pytest.approx(_FALLBACK["thermal_diffusivity_mm2_s"])
+    assert out["eps"][4] == pytest.approx(_FALLBACK["emissivity"])
+
+
+def test_sidecar_default_preset_covers_unlisted_materials(tmp_path):
+    sa = _sidecar(tmp_path, {"MADERA BANQUETAS": {"preset": "wood"}}, default_preset="plaster")
+    out = materials.resolve_vertex_materials(_stool(), sa, _FALLBACK)
+    assert out is not None
+    assert out["alpha"][4] == pytest.approx(materials.PRESETS["plaster"].alpha_mm2_s)
+
+
+def test_loose_vertices_take_the_object_defaults(tmp_path):
+    """kitchen1 has objects with unreferenced verts; they must not produce NaN."""
+    sa = _sidecar(tmp_path, {"A": {"preset": "wood"}})
+    obj = _Obj("o", _Mesh(4, [_Poly([0, 1], 0, 3.0)]), ["A"])
+    out = materials.resolve_vertex_materials(obj, sa, _FALLBACK)
+    assert out is not None
+    assert out["alpha"][2] == pytest.approx(_FALLBACK["thermal_diffusivity_mm2_s"])
+    assert np.all(np.isfinite(out["alpha"])) and not out["dirichlet_mask"][2]
+
+
+def test_zero_area_faces_still_vote(tmp_path):
+    sa = _sidecar(tmp_path, {"A": {"preset": "wood"}})
+    obj = _Obj("o", _Mesh(3, [_Poly([0, 1, 2], 0, 0.0)]), ["A"])
+    out = materials.resolve_vertex_materials(obj, sa, _FALLBACK)
+    assert out is not None
+    assert np.all(np.isfinite(out["alpha"]))
+    assert out["alpha"][0] == pytest.approx(materials.PRESETS["wood"].alpha_mm2_s)
+
+
+def test_out_of_range_material_index_is_clamped(tmp_path):
+    """Blender allows a polygon material_index past the end of material_slots."""
+    sa = _sidecar(tmp_path, {"A": {"preset": "wood"}})
+    obj = _Obj("o", _Mesh(3, [_Poly([0, 1, 2], 7, 1.0)]), ["A"])
+    out = materials.resolve_vertex_materials(obj, sa, _FALLBACK)
+    assert out is not None
+    assert out["alpha"][0] == pytest.approx(materials.PRESETS["wood"].alpha_mm2_s)
+
+
+def test_dirichlet_without_temperature_uses_the_object_initial_temperature(tmp_path):
+    sa = _sidecar(tmp_path, {"A": {"preset": "steel", "role": "DIRICHLET_SOURCE"}})
+    obj = _Obj("o", _Mesh(3, [_Poly([0, 1, 2], 0, 1.0)]), ["A"])
+    out = materials.resolve_vertex_materials(obj, sa, _FALLBACK)
+    assert out is not None
+    assert out["dirichlet_mask"][0]
+    assert out["t0"][0] == pytest.approx(_FALLBACK["initial_temperature_K"])
+
+
+@pytest.mark.parametrize("slot_names,n_verts", [([], 3), (["A"], 0)])
+def test_returns_none_when_slots_cannot_drive_resolution(tmp_path, slot_names, n_verts):
+    sa = _sidecar(tmp_path, {"A": {"preset": "wood"}})
+    obj = _Obj("o", _Mesh(n_verts, []), slot_names)
+    assert materials.resolve_vertex_materials(obj, sa, _FALLBACK) is None
+
+
+def test_shapes_dtypes_and_emissivity_range(tmp_path):
+    sa = _sidecar(tmp_path, {
+        "MADERA BANQUETAS": {"preset": "aluminium_polished"},
+        "METALBANQUETAS": {"preset": "skin"},
+    })
+    out = materials.resolve_vertex_materials(_stool(), sa, _FALLBACK)
+    assert out is not None
+    for key in ("t0", "alpha", "rho", "c", "eps"):
+        assert out[key].shape == (6,) and out[key].dtype == np.float64
+    assert out["dirichlet_mask"].shape == (6,) and out["dirichlet_mask"].dtype == np.bool_
+    assert np.all(out["eps"] >= 0.0) and np.all(out["eps"] <= 1.0)

--- a/tests/test_heatsim_mesh_alignment.py
+++ b/tests/test_heatsim_mesh_alignment.py
@@ -1,0 +1,125 @@
+"""The bake must describe the same mesh the solver does.
+
+Regression cover for two defects that each silently produced a complete, plausible-looking
+render:
+
+* The Cycles irradiance bake reduced per-vertex values against ``obj.data`` while the
+  solver builds its nodes from the EVALUATED mesh (modifiers applied). When a modifier
+  changed the vertex count the arrays disagreed, ``_combine`` dropped the flux, and the
+  object absorbed nothing -- 229 of 289 objects on one interior scene, every one of them
+  pinned at its initial temperature regardless of the flux computed for it.
+
+* ``prepare_object_bake_uv`` guarded on the truthiness of ``mesh.uv_layers``. An empty UV
+  collection is falsy, so it returned early on exactly the meshes that needed a UV layer
+  created -- no bake UV, hence no atlas UV, hence demotion out of the texture atlas. On a
+  scene where 85% of objects carry no authored UVs that was 231 objects demoted, most of
+  which then rendered as a single flat temperature.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+
+def test_irradiance_bake_is_indexed_against_the_evaluated_mesh(executable):
+    """vertex_flux must be sized to the mesh the solver uses, not the pre-modifier one."""
+    code = r"""
+import bpy
+from visionsim.simulate.heatsim import irradiance
+
+for o in list(bpy.data.objects):
+    bpy.data.objects.remove(o, do_unlink=True)
+
+bpy.ops.mesh.primitive_plane_add(size=2)
+obj = bpy.context.active_object
+obj.modifiers.new("Subsurf", "SUBSURF").levels = 2   # changes the vertex count
+
+base_n = len(obj.data.vertices)
+dg = bpy.context.evaluated_depsgraph_get()
+eval_n = len(obj.evaluated_get(dg).data.vertices)
+assert eval_n != base_n, "modifier did not change the vertex count; test is vacuous"
+
+bpy.context.scene.cycles.device = 'CPU'
+bpy.context.scene.cycles.samples = 4
+baked = irradiance.bake_irradiance_map(bpy.context.scene, obj, 64, samples=4)
+assert baked is not None, "bake returned None"
+
+n = len(baked.vertex_flux)
+assert n == eval_n, f"vertex_flux has {n} entries, evaluated mesh has {eval_n} (base has {base_n})"
+print("EVALUATED_MESH_ALIGNMENT_OK")
+"""
+    out = subprocess.run([str(executable), "-b", "--python-expr", code], capture_output=True, text=True, check=False)
+    assert "EVALUATED_MESH_ALIGNMENT_OK" in out.stdout, out.stdout + out.stderr
+
+
+def test_albedo_and_irradiance_bakes_agree_on_the_mesh(executable):
+    """The two bakes feed one multiply, so they must return the same length.
+
+    They are produced by separate code paths (``bake_albedo_map`` /
+    ``irradiance_kernel.get_or_bake_vertex_albedo`` vs ``bake_irradiance_map``), and the
+    evaluated-mesh fix was originally applied to only one of them. A mismatch is not
+    loud: the caller discards the albedo and assumes full absorption, overestimating
+    absorbed flux by up to ~4x on a light surface.
+    """
+    code = r"""
+import bpy
+from visionsim.simulate.heatsim import irradiance, irradiance_kernel
+
+for o in list(bpy.data.objects):
+    bpy.data.objects.remove(o, do_unlink=True)
+
+bpy.ops.mesh.primitive_plane_add(size=2)
+obj = bpy.context.active_object
+obj.data.materials.append(bpy.data.materials.new("m"))
+obj.modifiers.new("Subsurf", "SUBSURF").levels = 2
+
+bpy.context.scene.cycles.device = 'CPU'
+bpy.context.scene.cycles.samples = 4
+
+flux = irradiance.bake_irradiance_map(bpy.context.scene, obj, 64, samples=4)
+albedo = irradiance_kernel.get_or_bake_vertex_albedo(bpy.context.scene, [obj], texture_size=64)
+a = albedo.get(obj.name)
+assert flux is not None and a is not None, "one of the bakes returned nothing"
+dg = bpy.context.evaluated_depsgraph_get()
+eval_n = len(obj.evaluated_get(dg).data.vertices)
+assert eval_n != len(obj.data.vertices), "modifier did not change the count; test is vacuous"
+assert len(flux.vertex_flux) == eval_n, f"irradiance has {len(flux.vertex_flux)}, evaluated has {eval_n}"
+assert len(a) == eval_n, f"albedo has {len(a)}, evaluated has {eval_n}"
+print("BAKE_LENGTHS_AGREE_OK")
+"""
+    out = subprocess.run([str(executable), "-b", "--python-expr", code], capture_output=True, text=True, check=False)
+    assert "BAKE_LENGTHS_AGREE_OK" in out.stdout, out.stdout + out.stderr
+
+
+def test_bake_uv_is_created_on_a_mesh_with_no_authored_uvs(executable):
+    """A mesh with zero UV layers must still get a bake UV, and still reach the atlas."""
+    code = r"""
+import bpy
+from visionsim.simulate.heatsim import adapter, atlas, irradiance
+from visionsim.simulate.heatsim.constants import BAKE_UV_LAYER_NAME
+
+for o in list(bpy.data.objects):
+    bpy.data.objects.remove(o, do_unlink=True)
+
+bpy.ops.mesh.primitive_plane_add(size=8)   # large + few verts => wants the atlas
+obj = bpy.context.active_object
+while obj.data.uv_layers:
+    obj.data.uv_layers.remove(obj.data.uv_layers[0])
+assert len(obj.data.uv_layers) == 0, "failed to strip UVs; test is vacuous"
+
+irradiance.prepare_object_bake_uv(obj)
+assert BAKE_UV_LAYER_NAME in obj.data.uv_layers, (
+    "prepare_object_bake_uv left a UV-less mesh without a bake UV"
+)
+
+# ... and the object must actually survive into the atlas rather than being demoted.
+plan = adapter.build_atlas_plan(
+    bpy.context.scene, [obj],
+    {"atlas_texel_density": 1500.0, "atlas_tile_min": 16, "atlas_tile_max": 512,
+     "atlas_texel_soft_max": 500000},
+)
+assert obj.name in plan.texels, f"object demoted from the atlas; texels={list(plan.texels)}"
+print("UVLESS_MESH_REACHES_ATLAS_OK")
+"""
+    out = subprocess.run([str(executable), "-b", "--python-expr", code], capture_output=True, text=True, check=False)
+    assert "UVLESS_MESH_REACHES_ATLAS_OK" in out.stdout, out.stdout + out.stderr

--- a/tests/test_heatsim_occluders.py
+++ b/tests/test_heatsim_occluders.py
@@ -1,0 +1,195 @@
+"""Which meshes block a shortwave shadow ray (visionsim.simulate.heatsim.occluders)."""
+
+from __future__ import annotations
+
+import subprocess
+
+
+def test_transparent_and_shadowless_meshes_do_not_occlude(executable):
+    """Glass panes, Cycles light portals and shadow-disabled props must not
+    block shortwave shadow rays; opaque, alpha-cutout and partly-transmissive
+    geometry must keep casting shadows."""
+    code = r"""
+import bpy
+from visionsim.simulate.heatsim import irradiance_kernel as ik
+from visionsim.simulate.heatsim import occluders
+
+def group_shader_output(group):
+    # `node_group.interface` is Blender 4.0+; 3.6 uses `node_group.outputs`. The behaviour
+    # under test (glass inside a node group still reads as clear) is version-independent,
+    # so support both rather than skipping the 3.6 CI leg.
+    if hasattr(group, "interface"):
+        group.interface.new_socket('Shader', in_out='OUTPUT', socket_type='NodeSocketShader')
+    else:
+        group.outputs.new('NodeSocketShader', 'Shader')
+
+def mesh(name):
+    bpy.ops.mesh.primitive_plane_add()
+    o = bpy.context.active_object
+    o.name = name
+    return o
+
+def make_mat(name, build):
+    # Build a material whose Surface output is driven by build's shader.
+    m = bpy.data.materials.new(name)
+    m.use_nodes = True
+    tree = m.node_tree
+    out = next(n for n in tree.nodes if n.type == 'OUTPUT_MATERIAL')
+    # Drop the default Principled so only what `build` returns feeds the output.
+    for n in [n for n in tree.nodes if n.type == 'BSDF_PRINCIPLED']:
+        tree.nodes.remove(n)
+    tree.links.new(build(tree).outputs[0], out.inputs['Surface'])
+    return m
+
+def add(tree, bl_idname):
+    return tree.nodes.new(bl_idname)
+
+def glass(tree):
+    return add(tree, 'ShaderNodeBsdfGlass')
+
+def transparent(tree):
+    return add(tree, 'ShaderNodeBsdfTransparent')
+
+def principled(weight):
+    def build(tree):
+        n = add(tree, 'ShaderNodeBsdfPrincipled')
+        for key in ('Transmission Weight', 'Transmission'):
+            if key in n.inputs:
+                n.inputs[key].default_value = weight
+        return n
+    return build
+
+def cutout_leaf(tree):
+    # Opaque leaf mixed with a Transparent BSDF - standard alpha cutout.
+    mix = add(tree, 'ShaderNodeMixShader')
+    tree.links.new(transparent(tree).outputs[0], mix.inputs[1])
+    tree.links.new(principled(0.0)(tree).outputs[0], mix.inputs[2])
+    return mix
+
+def transparent_plus_diffuse(tree):
+    mix = add(tree, 'ShaderNodeMixShader')
+    tree.links.new(transparent(tree).outputs[0], mix.inputs[1])
+    tree.links.new(add(tree, 'ShaderNodeBsdfDiffuse').outputs[0], mix.inputs[2])
+    return mix
+
+def driven_transmission(tree):
+    # Transmission fed by a texture - unknowable statically, must be opaque.
+    n = add(tree, 'ShaderNodeBsdfPrincipled')
+    key = next(k for k in ('Transmission Weight', 'Transmission') if k in n.inputs)
+    tree.links.new(add(tree, 'ShaderNodeTexNoise').outputs[0], n.inputs[key])
+    return n
+
+def check(name, build, should_occlude):
+    o = mesh(name)
+    if build is not None:
+        o.data.materials.append(make_mat(name + '_m', build))
+    got = occluders.casts_shadow(o)
+    assert got == should_occlude, f'{name}: expected occlude={should_occlude}, got {got}'
+    return o
+
+check('no_slots', None, True)
+check('glass', glass, False)
+check('portal', transparent, False)
+check('clear_principled', principled(1.0), False)
+check('frosted', principled(0.5), True)
+check('opaque', principled(0.0), True)
+check('cutout_leaf', cutout_leaf, True)
+check('decal', transparent_plus_diffuse, True)
+check('driven', driven_transmission, True)
+
+# Glass wrapped in a node group must still read as clear (review finding).
+group = bpy.data.node_groups.new('GlassGroup', 'ShaderNodeTree')
+g_out = group.nodes.new('NodeGroupOutput')
+group_shader_output(group)
+group.links.new(group.nodes.new('ShaderNodeBsdfGlass').outputs[0], g_out.inputs[0])
+
+def grouped_glass(tree):
+    n = tree.nodes.new('ShaderNodeGroup')
+    n.node_tree = group
+    return n
+
+check('grouped_glass', grouped_glass, False)
+
+# An opaque BSDF hidden inside a group must still occlude.
+ogroup = bpy.data.node_groups.new('OpaqueGroup', 'ShaderNodeTree')
+og_out = ogroup.nodes.new('NodeGroupOutput')
+group_shader_output(ogroup)
+ogroup.links.new(ogroup.nodes.new('ShaderNodeBsdfDiffuse').outputs[0], og_out.inputs[0])
+
+def grouped_opaque(tree):
+    n = tree.nodes.new('ShaderNodeGroup')
+    n.node_tree = ogroup
+    return n
+
+check('grouped_opaque', grouped_opaque, True)
+
+# Only the ACTIVE Group Output feeds the instance. A leftover inactive one wired
+# to an opaque shader must not turn a clear pane into a shadow caster.
+stale = bpy.data.node_groups.new('StaleGroup', 'ShaderNodeTree')
+group_shader_output(stale)
+live_out = stale.nodes.new('NodeGroupOutput')
+live_out.is_active_output = True
+stale.links.new(stale.nodes.new('ShaderNodeBsdfGlass').outputs[0], live_out.inputs[0])
+dead_out = stale.nodes.new('NodeGroupOutput')
+dead_out.is_active_output = False
+stale.links.new(stale.nodes.new('ShaderNodeBsdfDiffuse').outputs[0], dead_out.inputs[0])
+
+def grouped_stale(tree):
+    n = tree.nodes.new('ShaderNodeGroup')
+    n.node_tree = stale
+    return n
+
+check('grouped_stale_output', grouped_stale, False)
+
+# An empty material slot renders opaque, so [None, glass] must keep its shadow.
+empty_and_glass = mesh('empty_and_glass')
+empty_and_glass.data.materials.append(None)
+empty_and_glass.data.materials.append(make_mat('eg_glass', glass))
+assert occluders.casts_shadow(empty_and_glass), 'None slot + glass must occlude'
+
+# Volume-only material (Surface unlinked) has no surface to block a ray.
+volbox = mesh('volbox')
+vm = bpy.data.materials.new('vol_m')
+vm.use_nodes = True
+vt = vm.node_tree
+vout = next(n for n in vt.nodes if n.type == 'OUTPUT_MATERIAL')
+for n in [n for n in vt.nodes if n.type == 'BSDF_PRINCIPLED']:
+    vt.nodes.remove(n)
+vt.links.new(vt.nodes.new('ShaderNodeVolumePrincipled').outputs[0], vout.inputs['Volume'])
+volbox.data.materials.append(vm)
+assert not occluders.casts_shadow(volbox), 'volume-only material must not occlude'
+
+# An unconnected leftover Principled must not make a glass pane opaque.
+stray = mesh('stray')
+m = bpy.data.materials.new('stray_m')
+m.use_nodes = True
+tree = m.node_tree
+out = next(n for n in tree.nodes if n.type == 'OUTPUT_MATERIAL')
+tree.links.new(tree.nodes.new('ShaderNodeBsdfGlass').outputs[0], out.inputs['Surface'])
+stray.data.materials.append(m)
+assert not occluders.casts_shadow(stray), 'orphaned Principled must not force opacity'
+
+# One opaque slot is enough to keep the whole object casting shadows.
+mixed = mesh('mixed')
+mixed.data.materials.append(make_mat('mixed_glass', glass))
+mixed.data.materials.append(make_mat('mixed_opaque', principled(0.0)))
+assert occluders.casts_shadow(mixed), 'mixed slots must occlude'
+
+noshadow = check('noshadow_base', principled(0.0), True)
+noshadow.visible_shadow = False
+assert not occluders.casts_shadow(noshadow), 'visible_shadow=False must not occlude'
+
+# The BVH collector must agree with _casts_shadow.
+collected = ik._collect_scene_meshes_world(bpy.context.scene)
+expected = sum(
+    1 for o in bpy.context.scene.objects
+    if o.type == 'MESH' and not o.hide_render and o.visible_get() and occluders.casts_shadow(o)
+)
+assert len(collected) == expected, (len(collected), expected)
+print('OCCLUDER_FILTER_OK')
+"""
+    out = subprocess.run(
+        [str(executable), "-b", "--python-expr", code],
+        capture_output=True, text=True,
+     check=False)
+    assert "OCCLUDER_FILTER_OK" in out.stdout, out.stdout + "\n" + out.stderr

--- a/tests/test_heatsim_properties.py
+++ b/tests/test_heatsim_properties.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import subprocess
+
+
+def test_object_thermal_props_register(executable):
+    code = (
+        "import bpy;"
+        "from visionsim.simulate.heatsim import register;"
+        "register();"
+        "o=bpy.data.objects.new('o', bpy.data.meshes.new('m'));"
+        "o.heat_sim_material.emissivity=0.7;"
+        "assert abs(o.heat_sim_material.emissivity-0.7)<1e-6;"
+        "assert hasattr(o,'heat_simulation_enabled');"
+        "print('THERMAL_PROPS_OK')"
+    )
+    out = subprocess.run([str(executable), "-b", "--python-expr", code], capture_output=True, text=True, check=False)
+    assert "THERMAL_PROPS_OK" in out.stdout, out.stderr

--- a/tests/test_heatsim_shader.py
+++ b/tests/test_heatsim_shader.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+import subprocess
+
+
+def test_temperature_aov_registered(executable):
+    code = (
+        "import bpy;"
+        "from visionsim.simulate.heatsim import thermal_shader as ts;"
+        "bpy.ops.mesh.primitive_cube_add();"
+        "vl=bpy.context.view_layer;"
+        "ts.setup_temperature_aov(bpy.context.scene, vl);"
+        "assert any(a.name=='temperature' for a in vl.aovs);"
+        "print('THERMAL_AOV_OK')"
+    )
+    out = subprocess.run([str(executable), "-b", "--python-expr", code], capture_output=True, text=True, check=False)
+    assert "THERMAL_AOV_OK" in out.stdout, out.stderr
+
+
+def test_atlas_shader_group_samples_atlas_and_mixes_by_alpha(executable):
+    """Both temperature-source consumers (gray-body radiance and the AOV chain) must gain
+    the atlas UV -> Image Texture(Non-Color, Linear, CLIP) -> Mix-by-alpha extension, wired
+    from the SAME shared chain (one node group's worth of logic, not duplicated per-material
+    node trees) - see docs/superpowers/specs/2026-08-04-thermal-atlas-design.md §4.6.
+    """
+    code = r"""
+import bpy
+from visionsim.simulate.heatsim import thermal_shader as ts
+from visionsim.simulate.heatsim.constants import ATLAS_COVERAGE_PROP, ATLAS_IMAGE_NAME, ATLAS_UV_LAYER_NAME
+
+# Register the atlas image datablock so the Image Texture node picks it up at build time.
+img = bpy.data.images.new(ATLAS_IMAGE_NAME, width=2, height=2, alpha=True, float_buffer=True)
+img.pixels.foreach_set([310.0, 310.0, 310.0, 1.0] * 4)
+
+def _check(nodes, links, label):
+    attrs = {n.attribute_name: n for n in nodes if n.bl_idname == 'ShaderNodeAttribute'}
+    assert ATLAS_UV_LAYER_NAME in attrs, f'{label}: missing atlas UV attribute node'
+    assert attrs[ATLAS_UV_LAYER_NAME].attribute_type == 'GEOMETRY'
+    assert ATLAS_COVERAGE_PROP in attrs, f'{label}: missing atlas coverage gate attribute node'
+    assert attrs[ATLAS_COVERAGE_PROP].attribute_type == 'OBJECT'
+    assert 'sim_temperature' in attrs and 'heatsim_default_temperature' in attrs
+
+    tex_nodes = [n for n in nodes if n.bl_idname == 'ShaderNodeTexImage']
+    assert len(tex_nodes) == 1, f'{label}: expected exactly one Image Texture node'
+    tex = tex_nodes[0]
+    assert tex.image is not None and tex.image.name == ATLAS_IMAGE_NAME
+    assert tex.image.colorspace_settings.name == 'Non-Color'
+    assert tex.interpolation == 'Linear'
+    assert tex.extension == 'CLIP'
+    # UV attribute feeds the Image Texture's Vector input.
+    uv_node = attrs[ATLAS_UV_LAYER_NAME]
+    assert any(
+        link.from_node == uv_node and link.to_node == tex and link.to_socket.identifier == 'Vector'
+        for link in links
+    ), f'{label}: atlas UV attribute not wired into the Image Texture Vector input'
+
+    mix_nodes = [n for n in nodes if n.bl_idname == 'ShaderNodeMix']
+    assert len(mix_nodes) == 1, f'{label}: expected exactly one Mix node'
+    mix = mix_nodes[0]
+    assert mix.data_type == 'FLOAT'
+    assert mix.inputs['Factor'].is_linked, f'{label}: Mix Factor not wired'
+    assert mix.inputs['A'].is_linked and mix.inputs['B'].is_linked, f'{label}: Mix A/B not wired'
+
+    # Mix Factor traces back (within 2 hops) to the Image Texture's Alpha output -- the
+    # atlas validity signal must gate the mix, not just feed some unrelated math chain.
+    factor_link = next(link for link in links if link.to_socket == mix.inputs['Factor'])
+    gate_node = factor_link.from_node
+    assert gate_node.bl_idname == 'ShaderNodeMath' and gate_node.operation == 'MULTIPLY'
+    def _upstream(node, max_hops=4):
+        seen, frontier = set(), [node]
+        for _ in range(max_hops):
+            nxt = [ln.from_node for ln in links if ln.to_node in frontier]
+            nxt = [n for n in nxt if n not in seen]
+            if not nxt:
+                break
+            seen.update(nxt)
+            frontier = nxt
+        return seen
+
+    gate_sources = _upstream(gate_node)
+    assert tex in gate_sources, f'{label}: Mix Factor does not trace back to the atlas Alpha'
+    assert attrs[ATLAS_COVERAGE_PROP] in gate_sources, f'{label}: Mix Factor missing the object-level gate'
+
+    # Mix B traces back to a channel split of the Image Texture's Color output (the R channel).
+    b_link = next(link for link in links if link.to_socket == mix.inputs['B'])
+    sep = b_link.from_node
+    assert sep.bl_idname == 'ShaderNodeSeparateColor'
+    assert any(link.from_node == tex and link.to_node == sep for link in links)
+
+# -- Gray-body radiance material --------------------------------------------
+mat = ts._build_gray_body_material(1.0)
+_check(mat.node_tree.nodes, mat.node_tree.links, 'gray-body')
+# The Mix Result must feed the POWER(4) chain (T_eff -> sigma*T^4), not a stale
+# pre-atlas temp_effective node.
+pow4 = next(n for n in mat.node_tree.nodes if n.bl_idname == 'ShaderNodeMath' and n.operation == 'POWER')
+mix = next(n for n in mat.node_tree.nodes if n.bl_idname == 'ShaderNodeMix')
+assert any(
+    link.from_node == mix and link.to_node == pow4 for link in mat.node_tree.links
+), 'gray-body: Mix result not wired into the T^4 chain'
+
+# -- AOV material --------------------------------------------------------
+mat2 = bpy.data.materials.new('atlas_aov_mat')
+mat2.use_nodes = True
+ts._append_temperature_aov_nodes(mat2, 'temperature')
+_check(mat2.node_tree.nodes, mat2.node_tree.links, 'aov')
+aov = next(n for n in mat2.node_tree.nodes if n.type == 'OUTPUT_AOV')
+mix2 = next(n for n in mat2.node_tree.nodes if n.bl_idname == 'ShaderNodeMix')
+_links2 = mat2.node_tree.links
+_frontier, _reached = [mix2], set()
+for _ in range(4):
+    _nxt = [ln.to_node for ln in _links2 if ln.from_node in _frontier and ln.to_node not in _reached]
+    if not _nxt:
+        break
+    _reached.update(_nxt)
+    _frontier = _nxt
+assert aov in _reached, 'aov: Mix result does not reach the OutputAOV'
+
+print('ATLAS_SHADER_OK')
+"""
+    out = subprocess.run([str(executable), "-b", "--python-expr", code], capture_output=True, text=True, check=False)
+    assert "ATLAS_SHADER_OK" in out.stdout, out.stdout + "\n" + out.stderr
+
+
+def test_atlas_shader_group_falls_back_when_no_atlas_image(executable):
+    """No ``HeatSim_Temperature_Atlas`` image registered (render_domain=VERTEX, the atlas is
+    never built) -> the Image Texture node has no image, but the graph must still build (no
+    exceptions) and every node this test can reach must exist -- the byte-identical VERTEX
+    guarantee is enforced by the mix factor being multiplied by the OBJECT-level gate, which
+    is never stamped (and so defaults to 0) whenever ``write_frame_attributes`` is called
+    without an ``atlas_plan`` -- this test only guards the structural half (no crash, no
+    dangling/unlinked sockets) since the zero-default-attribute behavior itself is core
+    Blender semantics, not something under test here.
+    """
+    code = r"""
+import bpy
+from visionsim.simulate.heatsim import thermal_shader as ts
+
+mat = ts._build_gray_body_material(2.0)
+tex = next(n for n in mat.node_tree.nodes if n.bl_idname == 'ShaderNodeTexImage')
+assert tex.image is None
+mix = next(n for n in mat.node_tree.nodes if n.bl_idname == 'ShaderNodeMix')
+assert mix.inputs['Factor'].is_linked and mix.inputs['A'].is_linked and mix.inputs['B'].is_linked
+
+mat2 = bpy.data.materials.new('novatlas_aov')
+mat2.use_nodes = True
+ts._append_temperature_aov_nodes(mat2, 'temperature')
+aov = next(n for n in mat2.node_tree.nodes if n.type == 'OUTPUT_AOV')
+assert aov.inputs['Value'].is_linked
+
+print('NO_ATLAS_FALLBACK_OK')
+"""
+    out = subprocess.run([str(executable), "-b", "--python-expr", code], capture_output=True, text=True, check=False)
+    assert "NO_ATLAS_FALLBACK_OK" in out.stdout, out.stdout + "\n" + out.stderr
+
+
+def test_enter_restore_round_trip(executable):
+    """enter_thermal_scene then restore_scene must leave materials, lights, and world unchanged."""
+    code = (
+        "import bpy;"
+        "from visionsim.simulate.heatsim import thermal_shader as ts;"
+        # Build a simple scene: cube with a named material + a point light.
+        "bpy.ops.object.select_all(action='SELECT');"
+        "bpy.ops.object.delete();"
+        "bpy.ops.mesh.primitive_cube_add();"
+        "cube = bpy.context.active_object;"
+        "mat = bpy.data.materials.new('TestMat');"
+        "cube.data.materials.append(mat);"
+        "bpy.ops.object.light_add(type='POINT');"
+        "light = bpy.context.active_object;"
+        # Record original state.
+        "orig_mat_name = cube.material_slots[0].material.name;"
+        "orig_light_hide = light.hide_render;"
+        "orig_light_hide_vp = light.hide_viewport;"
+        "scene = bpy.context.scene;"
+        "orig_world = scene.world;"
+        # Round-trip.
+        "state = ts.enter_thermal_scene(scene, radiance_scale=1.0);"
+        "ts.restore_scene(scene, state);"
+        # Verify materials restored.
+        "restored_name = cube.material_slots[0].material.name if cube.material_slots[0].material else None;"
+        "assert restored_name == orig_mat_name, f'material: expected {orig_mat_name!r}, got {restored_name!r}';"
+        # Verify light visibility restored (enter_thermal_scene mutates both flags).
+        "assert light.hide_render == orig_light_hide, f'light hide_render changed';"
+        "assert light.hide_viewport == orig_light_hide_vp, f'light hide_viewport changed';"
+        # Verify world restored.
+        "assert scene.world is orig_world, f'world not restored: {scene.world!r} vs {orig_world!r}';"
+        "print('ROUND_TRIP_OK')"
+    )
+    out = subprocess.run([str(executable), "-b", "--python-expr", code], capture_output=True, text=True, check=False)
+    assert "ROUND_TRIP_OK" in out.stdout, out.stderr
+
+
+def test_meshes_without_materials_get_a_temperature_carrying_surface(executable):
+    """A mesh with no material (or an empty slot) has no shader to write the value
+    AOV, so it renders 0 K however well it was simulated. It must be given one."""
+    code = r"""
+import bpy
+from visionsim.simulate.heatsim import thermal_shader
+
+for o in list(bpy.data.objects):
+    bpy.data.objects.remove(o, do_unlink=True)
+
+def plane(name):
+    bpy.ops.mesh.primitive_plane_add()
+    o = bpy.context.active_object
+    o.name = name
+    return o
+
+bare = plane('bare')
+bare.data.materials.clear()
+assert len(bare.material_slots) == 0
+
+authored = plane('authored')
+m = bpy.data.materials.new('authored_m')
+m.use_nodes = True
+authored.data.materials.append(m)
+
+half = plane('half')
+half.data.materials.append(bpy.data.materials.new('half_m'))
+half.data.materials['half_m'].use_nodes = True
+half.data.materials.append(None)
+assert any(s.material is None for s in half.material_slots)
+
+sc = bpy.context.scene
+thermal_shader.setup_temperature_aov(sc, bpy.context.view_layer)
+
+def aov_count(obj):
+    n = 0
+    for slot in obj.material_slots:
+        mat = slot.material
+        assert mat is not None, f'{obj.name}: still has an empty slot'
+        n += sum(1 for node in mat.node_tree.nodes if node.type == 'OUTPUT_AOV')
+    return n
+
+for o in (bare, authored, half):
+    assert len(o.material_slots) > 0, f'{o.name}: no material slot'
+    assert aov_count(o) > 0, f'{o.name}: no temperature AOV on its material'
+
+# The stand-in must not disturb the authored material.
+assert authored.material_slots[0].material.name == 'authored_m'
+
+# It is shared, not one material per object.
+default_name = thermal_shader._DEFAULT_SURFACE_MATERIAL_NAME
+assert bare.material_slots[0].material.name == default_name
+assert sum(1 for m in bpy.data.materials if m.name.startswith(default_name)) == 1
+
+# Idempotent: a second pass must not add more slots.
+before = [len(o.material_slots) for o in (bare, authored, half)]
+thermal_shader.setup_temperature_aov(sc, bpy.context.view_layer)
+assert [len(o.material_slots) for o in (bare, authored, half)] == before
+
+print('DEFAULT_SURFACE_OK')
+"""
+    out = subprocess.run(
+        [str(executable), "-b", "--python-expr", code],
+        capture_output=True, text=True,
+     check=False)
+    assert "DEFAULT_SURFACE_OK" in out.stdout, out.stdout + "\n" + out.stderr
+
+
+def test_radiance_matches_gray_body_for_per_vertex_emissivity(executable):
+    """Rendered radiance must equal eps*sigma*T^4 + (1-eps)*sigma*T_amb^4, per surface.
+
+    Two defects made this false. The gray-body shader baked ONE emissivity constant into
+    the mix factor and assigned that single material to every mesh, so the per-vertex
+    ``emissivity`` attribute the solve writes was never read and every surface radiated as
+    if eps=0.9. And the thermal world emitted ``_AMBIENT_K`` (295.372 -- a temperature)
+    where the reflected ``(1 - eps)`` term needs a radiance, ``sigma*T_amb^4`` (431.6).
+
+    The second was a ~4% error while eps was pinned at 0.9 and invisible; it dominates at
+    low emissivity, where a surface is mostly a mirror. Both matter for LWIR: the preset
+    library spans eps 0.05 (polished aluminium) to 0.98 (skin), and a low-emissivity
+    surface reading close to ambient IS the physical behaviour that makes polished metal
+    hard to measure with a thermal camera.
+    """
+    code = r"""
+import bpy, numpy as np, tempfile, os
+from visionsim.simulate.heatsim import thermal_shader as ts
+
+SIGMA = 5.670374419e-8
+T_AMB = ts._AMBIENT_K
+T_HOT = 350.0
+
+def render_with(eps):
+    for o in list(bpy.data.objects):
+        bpy.data.objects.remove(o, do_unlink=True)
+    sc = bpy.context.scene
+    sc.render.engine = 'CYCLES'; sc.cycles.device = 'CPU'; sc.cycles.samples = 16
+    sc.render.resolution_x = sc.render.resolution_y = 32
+    sc.render.film_transparent = True
+    bpy.ops.mesh.primitive_plane_add(size=3.0, location=(0, 0, 0))
+    o = bpy.context.active_object; me = o.data; n = len(me.vertices)
+    for name, val in (("sim_temperature", T_HOT), ("emissivity", eps)):
+        a = me.attributes.new(name=name, type='FLOAT', domain='POINT')
+        a.data.foreach_set("value", np.full(n, val, dtype=np.float32))
+    o["heatsim_default_temperature"] = T_HOT
+    bpy.ops.object.camera_add(location=(0, 0, 6)); sc.camera = bpy.context.object
+    sc.camera.data.type = 'ORTHO'; sc.camera.data.ortho_scale = 4.0
+    state = ts.enter_thermal_scene(sc, radiance_scale=1.0)
+    try:
+        out = os.path.join(tempfile.mkdtemp(), "r.exr")
+        sc.render.image_settings.file_format = 'OPEN_EXR'
+        sc.render.image_settings.color_depth = '32'
+        sc.render.filepath = out
+        bpy.ops.render.render(write_still=True)
+    finally:
+        ts.restore_scene(sc, state)
+    img = bpy.data.images.load(out); w, h = img.size
+    px = np.array(img.pixels[:], dtype=np.float64).reshape(h, w, 4)
+    lit = px[:, :, 3] > 0.5
+    return float(np.median(px[:, :, 0][lit]))
+
+for eps in (0.05, 0.50, 0.98):
+    got = render_with(eps)
+    want = eps * SIGMA * T_HOT**4 + (1.0 - eps) * SIGMA * T_AMB**4
+    rel = abs(got - want) / want
+    assert rel < 0.02, f"eps={eps}: rendered {got:.2f}, gray body predicts {want:.2f} ({rel:.1%} off)"
+
+# And the emissivity must actually be read per surface, not collapsed to one constant.
+lo, hi = render_with(0.05), render_with(0.98)
+assert hi - lo > 300.0, f"emissivity barely changed radiance: {lo:.1f} vs {hi:.1f}"
+print("GRAY_BODY_EMISSIVITY_OK")
+"""
+    out = subprocess.run([str(executable), "-b", "--python-expr", code], capture_output=True, text=True, check=False)
+    assert "GRAY_BODY_EMISSIVITY_OK" in out.stdout, out.stdout + out.stderr

--- a/tests/test_heatsim_solver.py
+++ b/tests/test_heatsim_solver.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+
+from visionsim.simulate.heatsim.solver import HeatSimFEM
+
+# ---------------------------------------------------------------------------
+# Minimal surrogate objects for gen_params / sim_params
+# ---------------------------------------------------------------------------
+# HeatSimFEM.__init__ expects two positional objects:
+#   gen_params  — accessed for .device, .RHO, .C, .K, .NUM_FRAME_DELTA
+#   sim_params  — accessed for .sim_radiation, .sim_convection,
+#                 .add_tikhonov_reg, .sim_time, .record_time
+#
+# perform_gt_heat_simulation derives dt = gen_params.NUM_FRAME_DELTA / 60.0
+# and sim_steps = int(sim_params.sim_time / dt).
+#
+# Setting record_time == sim_time makes record_attimestep = 0, which triggers
+# the "record all" branch: the returned array has shape (sim_steps + 1, N).
+# ---------------------------------------------------------------------------
+
+_DT = 0.05  # seconds per timestep
+_NUM_STEPS = 5
+_SIM_TIME = _NUM_STEPS * _DT  # 0.25 s
+
+
+def _make_params(n: int):
+    gen_params = SimpleNamespace(
+        device="cpu",
+        RHO=1330.0 / 1e9,  # kg/mm^3  (fallback scalar; per-vertex maps override)
+        C=880.0,            # J/(kg·K)
+        K=0.17,             # mm^2/s
+        NUM_FRAME_DELTA=_DT * 60.0,  # → dt = NUM_FRAME_DELTA / 60 = _DT
+    )
+    sim_params = SimpleNamespace(
+        sim_radiation=True,
+        sim_convection=False,   # CONVECTION_COEFF is 0 anyway
+        add_tikhonov_reg=False,
+        sim_time=_SIM_TIME,
+        record_time=_SIM_TIME,  # record_attimestep = 0 → record all steps
+    )
+    return gen_params, sim_params
+
+
+def test_solver_produces_finite_physical_temperatures():
+    """
+    Run a 5-step implicit-Euler FEM solve on a tiny random point cloud (POINTS/ROBUST).
+    Asserts: no NaN, all temperatures in the physical range [200 K, 2000 K].
+    """
+    n = 64
+    rng = np.random.default_rng(0)
+    points = rng.uniform(-10.0, 10.0, size=(n, 3)).astype(np.float64)   # mm
+    irradiance = np.full(n, 1e-4, dtype=np.float64)                     # W/mm^2
+
+    # Per-vertex material maps (PVC-like)
+    density = np.full(n, 1330.0 / 1e9, dtype=np.float64)    # kg/mm^3
+    specific_heat = np.full(n, 880.0, dtype=np.float64)      # J/(kg·K)
+    tdiff = np.full(n, 0.17, dtype=np.float64)               # mm^2/s
+    emissivity = np.full(n, 0.9, dtype=np.float64)
+
+    # Initial temperature (slightly above ambient)
+    u0 = np.full(n, 295.0, dtype=np.float64)
+
+    gen_params, sim_params = _make_params(n)
+
+    fem = HeatSimFEM(
+        gen_params,
+        sim_params,
+        laplacian_domain="POINTS",
+        laplacian_backend="ROBUST",
+    )
+
+    # perform_gt_heat_simulation real signature:
+    #   verts_np, faces_np, boundary_faces_np,
+    #   boundary_verts_mask_override=None, u0=None, irradiance_map=None,
+    #   thermal_diffusivity_map=None, density_map=None, specific_heat_map=None,
+    #   emissivity_map=None, steady_state=False, tol_K_per_s=0.0,
+    #   store_only_final=False
+    #
+    # In POINTS mode, faces_np and boundary_faces_np are unused; pass None.
+    history = fem.perform_gt_heat_simulation(
+        verts_np=points,
+        faces_np=None,
+        boundary_faces_np=None,
+        u0=u0,
+        irradiance_map=irradiance,
+        thermal_diffusivity_map=tdiff,
+        density_map=density,
+        specific_heat_map=specific_heat,
+        emissivity_map=emissivity,
+    )
+
+    arr = np.asarray(history, dtype=np.float64)
+
+    # Shape: (sim_steps + 1, n)  — initial state + _NUM_STEPS post-step states
+    assert arr.ndim == 2, f"Expected 2-D array, got shape {arr.shape}"
+    assert arr.shape[1] == n, f"Expected {n} vertices, got {arr.shape[1]}"
+    assert not np.isnan(arr).any(), "NaN values found in temperature history"
+    assert arr.min() > 200.0, f"Temperature below 200 K: min={arr.min():.2f}"
+    assert arr.max() < 2000.0, f"Temperature above 2000 K: max={arr.max():.2f}"
+
+
+def _run_history(solver_mode: str) -> np.ndarray:
+    """Same 5-step solve as above, run through one linear-solver mode."""
+    n = 64
+    rng = np.random.default_rng(0)
+    points = rng.uniform(-10.0, 10.0, size=(n, 3)).astype(np.float64)
+    irradiance = np.full(n, 1e-4, dtype=np.float64)
+
+    density = np.full(n, 1330.0 / 1e9, dtype=np.float64)
+    specific_heat = np.full(n, 880.0, dtype=np.float64)
+    tdiff = np.full(n, 0.17, dtype=np.float64)
+    emissivity = np.full(n, 0.9, dtype=np.float64)
+    u0 = np.full(n, 295.0, dtype=np.float64)
+
+    gen_params, sim_params = _make_params(n)
+    fem = HeatSimFEM(
+        gen_params,
+        sim_params,
+        laplacian_domain="POINTS",
+        laplacian_backend="ROBUST",
+        solver_mode=solver_mode,
+    )
+    history = fem.perform_gt_heat_simulation(
+        verts_np=points,
+        faces_np=None,
+        boundary_faces_np=None,
+        u0=u0,
+        irradiance_map=irradiance,
+        thermal_diffusivity_map=tdiff,
+        density_map=density,
+        specific_heat_map=specific_heat,
+        emissivity_map=emissivity,
+    )
+    return np.asarray(history, dtype=np.float64)
+
+
+# Agreement bound between the two linear-solver modes, in Kelvin. Both stop on the
+# same ``||r||_2 < 1e-5`` criterion but reach it along different iteration paths, and
+# the solve runs in float32, where one ulp at 295 K is already 3.1e-5 K. A few dozen
+# ulps of accumulated drift is therefore the expected disagreement; anything that
+# changes the physics moves temperatures by O(0.1) K or more and still trips this.
+_SOLVER_MODE_TOL_K = 5e-3
+
+
+def test_pcg_jacobi_matches_unpreconditioned_cg():
+    """The Jacobi preconditioner must change the iteration count, not the answer.
+
+    Guards the default flipping to ``pcg_jacobi`` from silently changing physics.
+    On a 2000-point cloud the preconditioner cuts the solve from 51 matrix-vector
+    products per timestep to 4, for a ~3x wall-clock win.
+    """
+    pcg = _run_history("pcg_jacobi")
+    cg = _run_history("cg")
+
+    assert pcg.shape == cg.shape
+    assert not np.isnan(pcg).any()
+    max_abs = float(np.abs(pcg - cg).max())
+    assert max_abs < _SOLVER_MODE_TOL_K, f"pcg_jacobi and cg disagree by {max_abs:.3e} K"

--- a/tests/test_heatsim_texel_mode.py
+++ b/tests/test_heatsim_texel_mode.py
@@ -1,0 +1,847 @@
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from visionsim.simulate.heatsim import adapter, materials
+
+_DEFAULTS = {
+    "initial_temperature_K": 300.0,
+    "thermal_diffusivity_mm2_s": 0.42,
+    "density_kg_m3": 1234.0,
+    "specific_heat_J_kgK": 777.0,
+    "emissivity": 0.5,
+    "irradiance_scale": 1.0,
+}
+_SOLVER_CFG = {"domain": "POINTS"}
+
+
+# ---------------------------------------------------------------------------
+# Fake-bpy fixtures (mirrors tests/test_heatsim_assignments_integration.py)
+# ---------------------------------------------------------------------------
+
+
+class _Poly:
+    def __init__(self, vertices, material_index, area):
+        self.vertices = list(vertices)
+        self.material_index = material_index
+        self.area = area
+
+
+class _Mesh:
+    def __init__(self, verts_xyz, polygons):
+        self._xyz = np.asarray(verts_xyz, dtype=np.float64)
+        self.vertices = [object()] * len(self._xyz)
+        self.polygons = list(polygons)
+
+
+class _Obj:
+    __hash__ = object.__hash__
+    __eq__ = object.__eq__
+
+    def __init__(self, name, mesh, slot_names):
+        self.name = name
+        self.type = "MESH"
+        self.data = mesh
+        self.material_slots = [type("S", (), {"material": type("M", (), {"name": n})()})() for n in slot_names]
+        self.heat_sim_material = None
+
+
+class _NS:
+    """Like ``SimpleNamespace`` but hashable by identity (mirrors real ``bpy`` objects,
+    which ``_combine``'s ``flux_by_obj`` dict keys on)."""
+
+    __hash__ = object.__hash__
+    __eq__ = object.__eq__
+
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+def _square(name="square"):
+    """4 verts, 2 coplanar tris; tri 0 uses slot 0 (WOODY), tri 1 uses slot 1 (STEELY)."""
+    xyz = [(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (1.0, 1.0, 0.0), (0.0, 1.0, 0.0)]
+    return _Obj(name, _Mesh(xyz, [_Poly([0, 1, 2], 0, 0.5), _Poly([0, 2, 3], 1, 0.5)]), ["WOODY", "STEELY"])
+
+
+def _sidecar(tmp_path, block, name="s.thermal.json"):
+    path = tmp_path / name
+    path.write_text(json.dumps({
+        "schema_version": 1, "scene": "s.blend", "defaults": {"preset": None}, "materials": block,
+    }), encoding="utf-8")
+    return materials.load_assignments(path)
+
+
+@pytest.fixture(autouse=True)
+def _stub_geometry(monkeypatch):
+    """_extract_geometry needs bpy/mathutils; feed it straight from the fake mesh."""
+    def fake(obj):
+        verts = np.asarray(obj.data._xyz, dtype=np.float64) * 1000.0  # m -> mm
+        faces = np.asarray([list(p.vertices) for p in obj.data.polygons], dtype=np.int32)
+        return verts, faces, len(verts)
+
+    monkeypatch.setattr(adapter, "_extract_geometry", fake)
+
+
+# ---------------------------------------------------------------------------
+# materials.resolve_face_materials
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_face_materials_exact_per_face(tmp_path):
+    sa = _sidecar(tmp_path, {
+        "WOODY": {"preset": "wood"},
+        "STEELY": {"preset": "steel", "role": "DIRICHLET_SOURCE", "dirichlet_K": 350.0},
+    })
+    obj = _square()
+    face_slots = np.array([0, 1], dtype=np.int32)  # face 0 -> WOODY, face 1 -> STEELY
+
+    out = materials.resolve_face_materials(obj, sa, _DEFAULTS, face_slots)
+
+    assert out is not None
+    for key in ("t0", "alpha", "rho", "c", "eps"):
+        assert out[key].shape == (2,)
+    assert out["alpha"][0] == pytest.approx(materials.PRESETS["wood"].alpha_mm2_s)
+    assert out["alpha"][1] == pytest.approx(materials.PRESETS["steel"].alpha_mm2_s)
+    # No averaging: the two faces' values are exactly the two distinct presets, not a blend.
+    assert out["alpha"][0] != pytest.approx(out["alpha"][1])
+    assert not (materials.PRESETS["wood"].alpha_mm2_s < out["alpha"][0] < materials.PRESETS["steel"].alpha_mm2_s)
+
+    # Dirichlet slot faces are flagged; the FEM slot's face is not.
+    assert not out["dirichlet_mask"][0]
+    assert out["dirichlet_mask"][1]
+    assert out["t0"][1] == pytest.approx(350.0)
+
+
+def test_resolve_face_materials_returns_none_without_slots(tmp_path):
+    sa = _sidecar(tmp_path, {"WOODY": {"preset": "wood"}})
+    obj = _square()
+    obj.material_slots = []
+    assert materials.resolve_face_materials(obj, sa, _DEFAULTS, np.array([0], dtype=np.int32)) is None
+
+
+def test_resolve_face_materials_out_of_range_index_is_clamped(tmp_path):
+    sa = _sidecar(tmp_path, {"WOODY": {"preset": "wood"}, "STEELY": {"preset": "steel"}})
+    obj = _square()
+    out = materials.resolve_face_materials(obj, sa, _DEFAULTS, np.array([7], dtype=np.int32))
+    assert out is not None
+    assert out["alpha"][0] == pytest.approx(materials.PRESETS["steel"].alpha_mm2_s)
+
+
+# ---------------------------------------------------------------------------
+# adapter._combine TEXEL mode
+# ---------------------------------------------------------------------------
+
+
+def _texel_table(k, face, face_material_index):
+    rng = np.random.default_rng(0)
+    return {
+        "position_mm": rng.uniform(0.0, 100.0, size=(k, 3)),
+        "normal": np.tile(np.array([0.0, 0.0, 1.0]), (k, 1)),
+        "uv": np.zeros((k, 2), dtype=np.float64),
+        "face": np.asarray(face, dtype=np.int64),
+        "face_material_index": np.asarray(face_material_index, dtype=np.int32),
+    }
+
+
+def test_combine_texel_mode_mixes_texel_and_vertex_objects():
+    k = 5
+    sparse_obj = _NS(name="sparse", heat_sim_material=None)
+    dense_obj = _square("dense")
+
+    atlas_plan = SimpleNamespace(texels={
+        "sparse": _texel_table(k, face=np.zeros(k, dtype=np.int64), face_material_index=[0]),
+    })
+
+    combined = adapter._combine([sparse_obj, dense_obj], {}, _DEFAULTS, _SOLVER_CFG, atlas_plan=atlas_plan)
+
+    assert combined is not None
+    n_dense = 4
+    assert combined.verts.shape[0] == k + n_dense
+    assert combined.alpha.shape[0] == k + n_dense
+    assert combined.layout == [
+        ("sparse", 0, k, "TEXEL"),
+        ("dense", k, n_dense, "VERTEX"),
+    ]
+    # TEXEL object contributes no faces (POINTS-only); VERTEX object's faces are offset by k.
+    assert combined.faces.shape[0] == 2  # only "dense"'s two triangles
+    assert combined.faces.min() >= k
+
+
+def test_combine_texel_mode_object_level_materials_when_no_assignment():
+    """No sidecar: a TEXEL object still gets the object-level constant, broadcast per-texel."""
+    k = 3
+    obj = _NS(name="sparse", heat_sim_material=None)
+    atlas_plan = SimpleNamespace(texels={
+        "sparse": _texel_table(k, face=np.zeros(k, dtype=np.int64), face_material_index=[0]),
+    })
+
+    combined = adapter._combine([obj], {}, _DEFAULTS, _SOLVER_CFG, atlas_plan=atlas_plan)
+
+    assert combined is not None
+    assert np.allclose(combined.alpha, _DEFAULTS["thermal_diffusivity_mm2_s"])
+    assert np.allclose(combined.eps, _DEFAULTS["emissivity"])
+    assert np.allclose(combined.t0, _DEFAULTS["initial_temperature_K"])
+    assert np.all(combined.boundary_mask)
+
+
+def test_combine_texel_dirichlet_pinning_per_texel(tmp_path):
+    sa = _sidecar(tmp_path, {
+        "WOODY": {"preset": "wood"},
+        "STEELY": {"preset": "steel", "role": "DIRICHLET_SOURCE", "dirichlet_K": 350.0},
+    })
+    obj = _square()  # name "square", slots WOODY (face 0), STEELY (face 1)
+    tex = _texel_table(4, face=[0, 0, 1, 1], face_material_index=[0, 1])
+    atlas_plan = SimpleNamespace(texels={"square": tex})
+    flux_by_obj = {obj: np.array([10.0, 10.0, 10.0, 10.0])}
+
+    combined = adapter._combine([obj], flux_by_obj, _DEFAULTS, _SOLVER_CFG, assignment=sa, atlas_plan=atlas_plan)
+
+    assert combined is not None
+    pinned = ~combined.boundary_mask
+    assert pinned.tolist() == [False, False, True, True]
+    assert np.allclose(combined.alpha[pinned], 0.0)
+    assert np.allclose(combined.irradiance[pinned], 0.0)
+    assert np.all(combined.irradiance[~pinned] > 0.0)
+    assert np.allclose(combined.t0[pinned], 350.0)
+    assert np.allclose(combined.t0[~pinned], _DEFAULTS["initial_temperature_K"])
+
+
+def test_combine_vertex_mode_unchanged_when_no_plan():
+    """Backward-compat gate: atlas_plan=None (or omitted) reproduces today's behaviour."""
+    obj = _square()
+    combined_default = adapter._combine([obj], {}, _DEFAULTS, _SOLVER_CFG)
+    combined_explicit = adapter._combine([obj], {}, _DEFAULTS, _SOLVER_CFG, atlas_plan=None)
+
+    for combined in (combined_default, combined_explicit):
+        assert combined is not None
+        assert np.allclose(combined.alpha, _DEFAULTS["thermal_diffusivity_mm2_s"])
+        assert np.allclose(combined.eps, _DEFAULTS["emissivity"])
+        assert np.allclose(combined.t0, _DEFAULTS["initial_temperature_K"])
+        assert np.all(combined.boundary_mask)
+        assert combined.layout == [("square", 0, 4, "VERTEX")]
+
+    assert np.array_equal(combined_default.alpha, combined_explicit.alpha)
+    assert np.array_equal(combined_default.verts, combined_explicit.verts)
+    assert np.array_equal(combined_default.faces, combined_explicit.faces)
+
+
+# ---------------------------------------------------------------------------
+# adapter.build_atlas_plan
+# ---------------------------------------------------------------------------
+
+
+class _AtlasMesh:
+    def __init__(self, n_verts):
+        self.vertices = [object()] * n_verts
+
+
+class _AtlasObj:
+    def __init__(self, name, n_verts):
+        self.name = name
+        self.data = _AtlasMesh(n_verts)
+        self.heat_sim_material = None
+
+
+def _big_plane_geom(side_mm=10_000.0):
+    """4 verts spanning a 10m x 10m plane => 100 m^2 for ~0.04 verts/m^2 (well under any
+    reasonable atlas_texel_density, so select_for_atlas admits it)."""
+    verts = np.array([
+        [0.0, 0.0, 0.0], [side_mm, 0.0, 0.0], [side_mm, side_mm, 0.0], [0.0, side_mm, 0.0],
+    ])
+    faces = np.array([[0, 1, 2], [0, 2, 3]], dtype=np.int32)
+    return verts, faces, 4
+
+
+_ATLAS_CFG = {"atlas_texel_density": 50.0, "atlas_tile_min": 16, "atlas_tile_max": 512, "atlas_texel_soft_max": 500_000}
+
+
+def test_uv_failure_demotes_to_vertex_path_with_warning(monkeypatch, caplog):
+    good = _AtlasObj("good", 4)
+    bad = _AtlasObj("bad", 4)
+    geoms = {"good": _big_plane_geom(), "bad": _big_plane_geom()}
+
+    monkeypatch.setattr(adapter, "_extract_geometry", lambda obj: geoms[obj.name])
+    monkeypatch.setattr(adapter, "_prepare_bake_uv", lambda obj: None)
+
+    captured = {}
+
+    def spy_write(o, tile, atlas_size, src_layer_name):
+        captured[o.name] = (tile, atlas_size)
+
+    monkeypatch.setattr(adapter, "_write_atlas_uv_layer", spy_write)
+
+    raw_uv = np.array([
+        [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0]],
+        [[0.0, 0.0], [1.0, 1.0], [0.0, 1.0]],
+    ])
+
+    def fake_uv(obj, layer_name):
+        if obj.name == "bad":
+            return None  # simulates an unwrap that never produced a usable UV layer
+        # Mirror the real _write_atlas_uv_layer -> _extract_evaluated_face_uv_and_slots
+        # round trip (as test_build_atlas_plan_vertex_count_mismatch_no_longer_demotes
+        # does): apply the forward tile-local -> atlas-global remap here, so
+        # build_atlas_plan's inverse remap gets back exactly `raw_uv` instead of
+        # double-remapping already tile-local coordinates out of [0, 1].
+        tile, atlas_size = captured[obj.name]
+        aw, ah = atlas_size
+        tw, th = tile.size
+        tx, ty = tile.offset
+        atlas_uv = np.empty_like(raw_uv)
+        atlas_uv[..., 0] = (tx + raw_uv[..., 0] * tw) / aw
+        atlas_uv[..., 1] = (ty + raw_uv[..., 1] * th) / ah
+        face_material_index = np.array([0, 0], dtype=np.int32)
+        return atlas_uv, face_material_index
+
+    monkeypatch.setattr(adapter, "_extract_evaluated_face_uv_and_slots", fake_uv)
+
+    with caplog.at_level(logging.WARNING):
+        plan = adapter.build_atlas_plan(scene=None, sim_objects=[good, bad], cfg=_ATLAS_CFG)
+
+    assert "good" in plan.texels
+    assert "bad" not in plan.texels
+    assert plan.texels["good"]["position_mm"].shape[0] > 0
+
+    messages = [rec.getMessage() for rec in caplog.records]
+    assert any("bad" in m and "demoted" in m for m in messages)
+
+
+def test_build_atlas_plan_vertex_count_mismatch_no_longer_demotes(monkeypatch):
+    """Regression for the evaluated-mesh rasterization fix: a base/evaluated vertex-count
+    mismatch (the hallmark of a topology-changing modifier, e.g. Bevel or Geometry Nodes)
+    must NOT demote the object anymore. A temperature atlas is UV-addressed, not
+    vertex-addressed: :func:`build_atlas_plan` reads both geometry and UVs from the
+    evaluated mesh, so it no longer cares that the base mesh disagrees on vertex count.
+
+    Simulates the write-then-read-back round trip _write_atlas_uv_layer/
+    _extract_evaluated_face_uv_and_slots perform: a spy captures the (tile, atlas_size)
+    the real write call would have used, and the fake evaluated-UV reader applies the
+    exact same forward remap _write_atlas_uv_layer does, so build_atlas_plan's inverse
+    remap round-trips back to the original tile-local UV.
+    """
+    obj = _AtlasObj("mod_obj", n_verts=6)  # base mesh reports 6 verts
+    evaluated = _big_plane_geom()  # evaluated geometry has 4 verts
+
+    monkeypatch.setattr(adapter, "_extract_geometry", lambda o: evaluated)
+    prep_calls = []
+    monkeypatch.setattr(adapter, "_prepare_bake_uv", lambda o: prep_calls.append(o.name))
+
+    captured = {}
+
+    def spy_write(o, tile, atlas_size, src_layer_name):
+        captured["tile"] = tile
+        captured["atlas_size"] = atlas_size
+
+    monkeypatch.setattr(adapter, "_write_atlas_uv_layer", spy_write)
+
+    raw_uv = np.array([
+        [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0]],
+        [[0.0, 0.0], [1.0, 1.0], [0.0, 1.0]],
+    ])
+
+    def fake_evaluated_uv(o, layer_name):
+        tile = captured["tile"]
+        aw, ah = captured["atlas_size"]
+        tw, th = tile.size
+        tx, ty = tile.offset
+        atlas_uv = np.empty_like(raw_uv)
+        atlas_uv[..., 0] = (tx + raw_uv[..., 0] * tw) / aw
+        atlas_uv[..., 1] = (ty + raw_uv[..., 1] * th) / ah
+        face_material_index = np.array([0, 0], dtype=np.int32)
+        return atlas_uv, face_material_index
+
+    monkeypatch.setattr(adapter, "_extract_evaluated_face_uv_and_slots", fake_evaluated_uv)
+
+    plan = adapter.build_atlas_plan(scene=None, sim_objects=[obj], cfg=_ATLAS_CFG)
+
+    assert "mod_obj" in plan.texels
+    assert prep_calls == ["mod_obj"]  # bake UV prep still runs before the atlas UV write
+    assert plan.texels["mod_obj"]["position_mm"].shape[0] > 0
+
+
+def test_build_atlas_plan_excludes_dense_objects(monkeypatch):
+    """An object whose native vertex density already exceeds the target keeps the vertex path."""
+    dense = _AtlasObj("dense", n_verts=50_000)
+    dense_geom = (np.random.default_rng(0).uniform(0, 10, size=(50_000, 3)),
+                  np.array([[0, 1, 2]], dtype=np.int32), 50_000)
+
+    monkeypatch.setattr(adapter, "_extract_geometry", lambda o: dense_geom)
+
+    plan = adapter.build_atlas_plan(scene=None, sim_objects=[dense], cfg=_ATLAS_CFG)
+    assert plan.texels == {}
+
+
+def _build_two_object_plan(monkeypatch, *, drop_second: bool):
+    """Shared setup for the digest-participation tests below: two same-sized objects on
+    the same allocation (so ``layout.tiles`` is identical either way); ``drop_second``
+    controls whether "obj_b" makes it through rasterization (mirrors
+    ``test_uv_failure_demotes_to_vertex_path_with_warning``'s UV-extraction-failure
+    setup) or fully participates."""
+    obj_a = _AtlasObj("obj_a", 4)
+    obj_b = _AtlasObj("obj_b", 4)
+    geoms = {"obj_a": _big_plane_geom(), "obj_b": _big_plane_geom()}
+
+    monkeypatch.setattr(adapter, "_extract_geometry", lambda obj: geoms[obj.name])
+    monkeypatch.setattr(adapter, "_prepare_bake_uv", lambda obj: None)
+
+    captured = {}
+
+    def spy_write(o, tile, atlas_size, src_layer_name):
+        captured[o.name] = (tile, atlas_size)
+
+    monkeypatch.setattr(adapter, "_write_atlas_uv_layer", spy_write)
+
+    raw_uv = np.array([
+        [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0]],
+        [[0.0, 0.0], [1.0, 1.0], [0.0, 1.0]],
+    ])
+
+    def fake_uv(obj, layer_name):
+        if drop_second and obj.name == "obj_b":
+            return None  # simulates an unwrap that never produced a usable UV layer
+        tile, atlas_size = captured[obj.name]
+        aw, ah = atlas_size
+        tw, th = tile.size
+        tx, ty = tile.offset
+        atlas_uv = np.empty_like(raw_uv)
+        atlas_uv[..., 0] = (tx + raw_uv[..., 0] * tw) / aw
+        atlas_uv[..., 1] = (ty + raw_uv[..., 1] * th) / ah
+        face_material_index = np.array([0, 0], dtype=np.int32)
+        return atlas_uv, face_material_index
+
+    monkeypatch.setattr(adapter, "_extract_evaluated_face_uv_and_slots", fake_uv)
+
+    return adapter.build_atlas_plan(scene=None, sim_objects=[obj_a, obj_b], cfg=_ATLAS_CFG)
+
+
+def test_atlas_digest_reflects_realized_texel_participation(monkeypatch):
+    """Finding 1 regression: `atlas.allocate` assigns tiles for both "obj_a" and "obj_b"
+    before rasterization runs, so the tile layout alone (name/size/offset) is identical
+    whether "obj_b" ends up contributing texels or gets dropped by a UV failure. The
+    digest must still differ, because a materially different simulation (one fewer
+    object's temperature actually solved into the atlas) must not silently reuse a
+    cached solve keyed on the allocation alone."""
+    plan_both = _build_two_object_plan(monkeypatch, drop_second=False)
+    plan_dropped = _build_two_object_plan(monkeypatch, drop_second=True)
+
+    assert "obj_a" in plan_both.texels and "obj_b" in plan_both.texels
+    assert "obj_a" in plan_dropped.texels and "obj_b" not in plan_dropped.texels
+    # Same objects, same density/config => same tile allocation either way.
+    assert plan_both.layout.tiles.keys() == plan_dropped.layout.tiles.keys()
+
+    assert plan_both.digest != plan_dropped.digest
+
+
+def test_atlas_digest_stable_across_identical_builds(monkeypatch):
+    """The digest must be deterministic: two builds over the same inputs produce the
+    same digest, regardless of dict/set iteration order."""
+    plan1 = _build_two_object_plan(monkeypatch, drop_second=False)
+    plan2 = _build_two_object_plan(monkeypatch, drop_second=False)
+
+    assert plan1.digest == plan2.digest
+
+
+# ---------------------------------------------------------------------------
+# solve_scene cache key
+# ---------------------------------------------------------------------------
+
+
+class _FakeScene:
+    def __init__(self):
+        self.objects = []
+
+
+def test_cache_key_gains_atlas_digest(tmp_path, monkeypatch):
+    """Finding 1 regression: with ``atlas_plan=None`` the ``"atlas"`` key must be
+    entirely ABSENT from key_cfg -- not present with value ``None`` -- so the JSON
+    (and therefore the SHA1 cache key) is byte-identical to before the atlas feature
+    existed, per solve_scene's docstring guarantee ("reproduces today's behaviour
+    exactly, including the cache key"). Only once an AtlasPlan is actually supplied
+    does the key gain the layout-sensitive ``"atlas"`` entry."""
+    captured = []
+    from visionsim.simulate.heatsim import cache as cache_mod
+
+    real_cache_key = cache_mod.cache_key
+
+    def spy(blend_path, key_cfg):
+        captured.append(key_cfg)
+        return real_cache_key(blend_path, key_cfg)
+
+    monkeypatch.setattr(adapter, "gather_meshes", lambda scene: [])
+    monkeypatch.setattr(adapter.cache, "cache_key", spy)
+
+    scene = _FakeScene()
+    adapter.solve_scene(scene, defaults=_DEFAULTS, solver_cfg=_SOLVER_CFG, cache_root=tmp_path)
+
+    fake_plan = SimpleNamespace(
+        texels={}, density=50.0, tile_min=16, tile_max=512, soft_max=500_000, digest="deadbeef",
+    )
+    adapter.solve_scene(
+        scene, defaults=_DEFAULTS, solver_cfg=_SOLVER_CFG, cache_root=tmp_path, atlas_plan=fake_plan,
+    )
+
+    assert len(captured) == 2
+    assert "atlas" not in captured[0]
+    assert captured[1]["atlas"] == {
+        "density": 50.0, "tile_min": 16, "tile_max": 512, "soft_max": 500_000, "layout_digest": "deadbeef",
+    }
+
+
+def test_cache_key_is_byte_identical_to_pre_atlas_baseline(tmp_path, monkeypatch):
+    """Stronger form of the above: reconstruct the pre-atlas key_cfg by hand (no
+    "atlas" field at all) and assert solve_scene's atlas_plan=None key_cfg matches it
+    exactly, so an existing .heatsim cache from before the atlas feature is not busted."""
+    captured = []
+    monkeypatch.setattr(adapter, "gather_meshes", lambda scene: [])
+    monkeypatch.setattr(adapter.cache, "cache_key", lambda blend_path, key_cfg: captured.append(key_cfg) or "k")
+
+    scene = _FakeScene()
+    adapter.solve_scene(scene, defaults=_DEFAULTS, solver_cfg=_SOLVER_CFG, cache_root=tmp_path)
+
+    expected_pre_atlas_key_cfg = {
+        "solver": dict(_SOLVER_CFG),
+        "defaults": dict(_DEFAULTS),
+        "objects": [],
+        "assignments": None,
+    }
+    assert captured[0] == expected_pre_atlas_key_cfg
+
+
+# ---------------------------------------------------------------------------
+# solve_scene: atlas objects skip the per-vertex irradiance pass (Finding 2)
+# ---------------------------------------------------------------------------
+
+
+def test_solve_scene_only_computes_vertex_irradiance_for_non_atlas_objects(tmp_path, monkeypatch):
+    """_compute_irradiance must not do the expensive per-vertex albedo-bake + shadow-ray
+    work for objects the atlas plan is going to solve at texel resolution and whose
+    per-vertex result would be discarded by _combine's TEXEL branch."""
+    atlas_obj = _NS(name="atlas_obj", heat_sim_material=None)
+    vertex_obj = _NS(name="vertex_obj", heat_sim_material=None)
+
+    monkeypatch.setattr(adapter, "gather_meshes", lambda scene: [atlas_obj, vertex_obj])
+
+    vertex_call_objects: list = []
+
+    def fake_compute_irradiance(scene, sim_objects, solver_cfg, defaults):
+        vertex_call_objects.extend(sim_objects)
+        return {}
+
+    texel_calls: list = []
+
+    def fake_compute_texel_irradiance(scene, sim_objects, atlas_plan, solver_cfg, defaults):
+        texel_calls.append(list(sim_objects))
+        return {}
+
+    monkeypatch.setattr(adapter, "_compute_irradiance", fake_compute_irradiance)
+    monkeypatch.setattr(adapter, "_compute_texel_irradiance", fake_compute_texel_irradiance)
+    monkeypatch.setattr(adapter, "_combine", lambda *a, **kw: None)
+
+    atlas_plan = SimpleNamespace(
+        texels={"atlas_obj": _texel_table(3, face=np.zeros(3, dtype=np.int64), face_material_index=[0])},
+        density=50.0, tile_min=16, tile_max=512, soft_max=500_000, digest="abc123",
+    )
+
+    scene = _FakeScene()
+    adapter.solve_scene(
+        scene, defaults=_DEFAULTS, solver_cfg=_SOLVER_CFG, cache_root=tmp_path, atlas_plan=atlas_plan,
+    )
+
+    # Only the object NOT covered by the atlas plan reaches the per-vertex kernel...
+    assert vertex_call_objects == [vertex_obj]
+    # ...while the texel path still sees every sim object (it filters by atlas_plan.texels
+    # itself, and still needs to trigger the albedo bake for its own participants).
+    assert texel_calls == [[atlas_obj, vertex_obj]]
+
+
+def test_solve_scene_runs_vertex_irradiance_for_all_objects_without_an_atlas_plan(tmp_path, monkeypatch):
+    """Backward-compat gate: atlas_plan=None must not filter anything out."""
+    obj_a = _NS(name="a", heat_sim_material=None)
+    obj_b = _NS(name="b", heat_sim_material=None)
+    monkeypatch.setattr(adapter, "gather_meshes", lambda scene: [obj_a, obj_b])
+
+    vertex_call_objects: list = []
+    monkeypatch.setattr(
+        adapter, "_compute_irradiance",
+        lambda scene, sim_objects, solver_cfg, defaults: (vertex_call_objects.extend(sim_objects) or {}),
+    )
+    monkeypatch.setattr(adapter, "_combine", lambda *a, **kw: None)
+
+    scene = _FakeScene()
+    adapter.solve_scene(scene, defaults=_DEFAULTS, solver_cfg=_SOLVER_CFG, cache_root=tmp_path)
+
+    assert vertex_call_objects == [obj_a, obj_b]
+
+
+# ---------------------------------------------------------------------------
+# _compute_texel_irradiance: shared BVH build + shadow-ray count (Findings 3 & 4)
+# ---------------------------------------------------------------------------
+
+
+def test_compute_texel_irradiance_builds_bvh_once_and_threads_shadow_ray_count(executable):
+    """_compute_texel_irradiance must build the scene BVH backend exactly once per call
+    (not once per atlas-participating object -- irradiance_kernel.compute_irradiance_at_points
+    builds a full scene BVH internally whenever no backend is supplied) and must thread
+    solver_cfg['direct_kernel_soft_shadow_rays'] through to the kernel instead of relying on
+    its hardcoded default of 8. Needs real bpy (irradiance_kernel imports it unconditionally),
+    so this spies via direct module-attribute patching inside a Blender subprocess -- the same
+    pattern test_heatsim_irradiance.py's under-bpy tests use.
+    """
+    code = r"""
+import bpy, numpy as np
+from visionsim.simulate.heatsim import register, adapter, bvh_backend, irradiance_kernel
+
+register()
+bpy.ops.object.select_all(action='SELECT')
+bpy.ops.object.delete()
+
+
+def make_plane(name, x):
+    bpy.ops.mesh.primitive_plane_add(size=2.0, location=(x, 0.0, 0.0))
+    obj = bpy.context.active_object
+    obj.name = name
+    obj.heat_simulation_enabled = True
+    mat = bpy.data.materials.new(name + '_mat')
+    mat.use_nodes = True
+    obj.data.materials.append(mat)
+    return obj
+
+
+make_plane('A', 0.0)
+make_plane('B', 5.0)
+
+bpy.ops.object.light_add(type='SUN')
+bpy.context.active_object.data.energy = 10.0
+world = bpy.context.scene.world
+world.use_nodes = True
+bg = world.node_tree.nodes.get('Background')
+bg.inputs['Strength'].default_value = 1.0
+
+atlas_cfg = dict(atlas_texel_density=64.0, atlas_tile_min=16, atlas_tile_max=64, atlas_texel_soft_max=500_000)
+sim_objects = adapter.gather_meshes(bpy.context.scene)
+plan = adapter.build_atlas_plan(bpy.context.scene, sim_objects, atlas_cfg)
+assert set(plan.texels) == {'A', 'B'}, plan.texels.keys()
+
+build_calls = []
+best_available_calls = []
+orig_best_available = bvh_backend.best_available
+
+
+def counting_best_available():
+    best_available_calls.append(1)
+    backend = orig_best_available()
+    orig_build = backend.build_for_meshes
+
+    def counted(meshes):
+        build_calls.append(1)
+        return orig_build(meshes)
+    backend.build_for_meshes = counted
+    return backend
+
+
+bvh_backend.best_available = counting_best_available
+
+captured_n_samples = []
+orig_compute_at_points = irradiance_kernel.compute_irradiance_at_points
+
+
+def spy_compute_at_points(scene, positions, normals, albedo, **kwargs):
+    captured_n_samples.append(kwargs.get('n_samples_for_area'))
+    return orig_compute_at_points(scene, positions, normals, albedo, **kwargs)
+
+
+irradiance_kernel.compute_irradiance_at_points = spy_compute_at_points
+
+defaults = dict(initial_temperature_K=295.0, thermal_diffusivity_mm2_s=0.17,
+                density_kg_m3=1330.0, specific_heat_J_kgK=880.0, emissivity=0.9,
+                irradiance_scale=100.0)
+
+# 1. A custom shadow-ray count in solver_cfg must reach the kernel, and the BVH must be
+#    built exactly once even though there are 2 atlas-participating objects.
+solver_cfg_custom = dict(sim_time_s=0.1, timestep_s=0.05, domain='POINTS',
+                          laplacian_backend='ROBUST', device='cpu',
+                          direct_kernel_soft_shadow_rays=3)
+flux = adapter._compute_texel_irradiance(bpy.context.scene, sim_objects, plan, solver_cfg_custom, defaults)
+assert set(o.name for o in flux) == {'A', 'B'}, flux.keys()
+assert len(best_available_calls) == 1, best_available_calls
+assert len(build_calls) == 1, build_calls
+assert len(captured_n_samples) == 2, captured_n_samples
+assert all(n == 3 for n in captured_n_samples), captured_n_samples
+
+# 2. Omitting the knob from solver_cfg must fall back to the kernel's original hardcoded
+#    default (8), not silently pass 0/None through.
+build_calls.clear(); best_available_calls.clear(); captured_n_samples.clear()
+solver_cfg_default = dict(sim_time_s=0.1, timestep_s=0.05, domain='POINTS',
+                           laplacian_backend='ROBUST', device='cpu')
+adapter._compute_texel_irradiance(bpy.context.scene, sim_objects, plan, solver_cfg_default, defaults)
+assert len(best_available_calls) == 1, best_available_calls
+assert len(build_calls) == 1, build_calls
+assert all(n == 8 for n in captured_n_samples), captured_n_samples
+
+print('TEXEL_BVH_ONCE_AND_SHADOW_RAYS_OK')
+"""
+    out = subprocess.run([str(executable), "-b", "--python-expr", code], capture_output=True, text=True, check=False)
+    assert "TEXEL_BVH_ONCE_AND_SHADOW_RAYS_OK" in out.stdout, out.stdout + "\n" + out.stderr
+
+
+# ---------------------------------------------------------------------------
+# End-to-end smoke test (real bpy): build_atlas_plan -> solve_scene(atlas_plan=...)
+# -> write_frame_attributes, on a genuine low-vertex-density plane. Not one of the
+# brief's named fake-bpy tests, but the fake fixtures above cannot catch a real bpy
+# API mismatch (foreach_get signatures, UV layer creation, ...), so this closes that
+# gap the same way test_heatsim_irradiance.py's executable tests do for the bake path.
+# ---------------------------------------------------------------------------
+
+
+def test_texel_pipeline_solves_end_to_end_under_bpy(executable, tmp_path):
+    code = f"""
+import bpy, numpy as np
+from pathlib import Path
+from visionsim.simulate.heatsim import register, adapter
+from visionsim.simulate.heatsim.constants import ATLAS_UV_LAYER_NAME
+
+register()
+bpy.ops.object.select_all(action='SELECT')
+bpy.ops.object.delete()
+
+# A coarse (4-vertex) plane spanning 4 m^2: at any reasonable density this is
+# well under the atlas_texel_density target, so it must join the atlas.
+bpy.ops.mesh.primitive_plane_add(size=2.0)
+plane = bpy.context.active_object
+plane.name = 'CoarsePlane'
+plane.heat_simulation_enabled = True
+
+mat = bpy.data.materials.new('plane_mat')
+mat.use_nodes = True
+plane.data.materials.append(mat)
+
+bpy.ops.object.light_add(type='SUN')
+bpy.context.active_object.data.energy = 10.0
+world = bpy.context.scene.world
+world.use_nodes = True
+bg = world.node_tree.nodes.get('Background')
+bg.inputs['Strength'].default_value = 1.0
+
+defaults = dict(initial_temperature_K=295.0, thermal_diffusivity_mm2_s=0.17,
+                density_kg_m3=1330.0, specific_heat_J_kgK=880.0, emissivity=0.9,
+                irradiance_scale=100.0)
+solver_cfg = dict(sim_time_s=0.1, timestep_s=0.05, domain='POINTS',
+                  laplacian_backend='ROBUST', device='cpu')
+atlas_cfg = dict(atlas_texel_density=64.0, atlas_tile_min=16, atlas_tile_max=64,
+                  atlas_texel_soft_max=500_000)
+
+sim_objects = adapter.gather_meshes(bpy.context.scene)
+plan = adapter.build_atlas_plan(bpy.context.scene, sim_objects, atlas_cfg)
+assert 'CoarsePlane' in plan.texels, 'coarse plane should have joined the atlas'
+n_texels = plan.texels['CoarsePlane']['position_mm'].shape[0]
+assert n_texels > len(plane.data.vertices), (n_texels, len(plane.data.vertices))
+
+# HeatSim_Atlas_UV must have been written for the render-time shader lookup.
+assert ATLAS_UV_LAYER_NAME in plane.data.uv_layers
+
+hist = adapter.solve_scene(bpy.context.scene, defaults=defaults, solver_cfg=solver_cfg,
+                           cache_root=Path(r'{tmp_path}'), atlas_plan=plan)
+assert 'CoarsePlane' in hist, list(hist.keys())
+T_hist = np.asarray(hist['CoarsePlane'])
+assert T_hist.ndim == 2 and T_hist.shape[1] == n_texels, T_hist.shape
+assert np.isfinite(T_hist).all()
+assert T_hist.min() > 200 and T_hist.max() < 2000, (float(T_hist.min()), float(T_hist.max()))
+
+print('TEXEL_PIPELINE_OK', n_texels, len(plane.data.vertices))
+"""
+    out = subprocess.run([str(executable), "-b", "--python-expr", code], capture_output=True, text=True, check=False)
+    assert "TEXEL_PIPELINE_OK" in out.stdout, out.stdout + "\n" + out.stderr
+
+
+# ---------------------------------------------------------------------------
+# Real-bpy regression: topology-changing modifiers no longer demote an object
+# from the atlas (evaluated-mesh rasterization fix).
+# ---------------------------------------------------------------------------
+
+
+def test_build_atlas_plan_promotes_object_with_topology_changing_modifier(executable):
+    """Before the fix, an object whose evaluated (post-modifier) vertex count
+    disagreed with its base mesh's was unconditionally demoted from the atlas -
+    and, since the per-vertex write-back path also can't handle a shape mismatch,
+    its solved temperatures were silently discarded (flat ambient at render time).
+
+    A Subdivision Surface modifier reliably changes a plane's vertex count
+    headless (4 base verts -> many more evaluated verts), so it stands in for the
+    Bevel/Geometry-Nodes/EdgeSplit modifiers the design doc calls out. Asserts the
+    object IS an atlas participant with a nonzero texel count, and that every
+    rasterized texel position lies within the object's evaluated world-space
+    bounding box - a coordinate-convention regression (e.g. mixing up tile-local
+    and atlas-global UV space) would place texels far outside this box.
+    """
+    code = r"""
+import bpy, numpy as np
+from visionsim.simulate.heatsim import register, adapter
+from visionsim.simulate.heatsim.constants import ATLAS_UV_LAYER_NAME
+
+register()
+bpy.ops.object.select_all(action='SELECT')
+bpy.ops.object.delete()
+
+bpy.ops.mesh.primitive_plane_add(size=2.0)
+plane = bpy.context.active_object
+plane.name = 'ModPlane'
+plane.heat_simulation_enabled = True
+
+mat = bpy.data.materials.new('plane_mat')
+mat.use_nodes = True
+plane.data.materials.append(mat)
+
+subsurf = plane.modifiers.new(name='Subsurf', type='SUBSURF')
+subsurf.levels = 2
+subsurf.render_levels = 2
+
+bpy.ops.object.light_add(type='SUN')
+bpy.context.active_object.data.energy = 10.0
+world = bpy.context.scene.world
+world.use_nodes = True
+bg = world.node_tree.nodes.get('Background')
+bg.inputs['Strength'].default_value = 1.0
+
+base_n_verts = len(plane.data.vertices)
+
+depsgraph = bpy.context.evaluated_depsgraph_get()
+eval_mesh = plane.evaluated_get(depsgraph).data
+eval_n_verts = len(eval_mesh.vertices)
+# Sanity check on the test setup itself: the modifier must actually change the
+# vertex count, or this test would not exercise the bug at all.
+assert eval_n_verts != base_n_verts, (base_n_verts, eval_n_verts)
+
+verts_local = np.array([tuple(v.co) for v in eval_mesh.vertices], dtype=np.float64)
+mw = np.array(plane.matrix_world, dtype=np.float64)
+verts_world_mm = ((verts_local @ mw[:3, :3].T) + mw[:3, 3]) * 1000.0
+bbox_lo = verts_world_mm.min(axis=0) - 1.0e-3
+bbox_hi = verts_world_mm.max(axis=0) + 1.0e-3
+
+atlas_cfg = dict(atlas_texel_density=64.0, atlas_tile_min=16, atlas_tile_max=64,
+                  atlas_texel_soft_max=500_000)
+sim_objects = adapter.gather_meshes(bpy.context.scene)
+plan = adapter.build_atlas_plan(bpy.context.scene, sim_objects, atlas_cfg)
+
+assert 'ModPlane' in plan.texels, 'topology-changing-modifier object was demoted from the atlas'
+pos_mm = plan.texels['ModPlane']['position_mm']
+n_texels = pos_mm.shape[0]
+assert n_texels > 0, n_texels
+
+assert np.all(pos_mm >= bbox_lo) and np.all(pos_mm <= bbox_hi), (
+    pos_mm.min(axis=0), pos_mm.max(axis=0), bbox_lo, bbox_hi,
+)
+
+# The atlas UV layer must have landed on the BASE mesh (so both the modifier
+# stack and the render-time shader can see it), not just the evaluated copy.
+assert ATLAS_UV_LAYER_NAME in plane.data.uv_layers
+
+print('TOPOLOGY_MODIFIER_ATLAS_PROMOTED_OK', n_texels, base_n_verts, eval_n_verts)
+"""
+    out = subprocess.run([str(executable), "-b", "--python-expr", code], capture_output=True, text=True, check=False)
+    assert "TOPOLOGY_MODIFIER_ATLAS_PROMOTED_OK" in out.stdout, out.stdout + "\n" + out.stderr

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -1,5 +1,6 @@
 import itertools
 import os
+import shutil
 from pathlib import Path
 
 import numpy as np
@@ -8,7 +9,7 @@ import pytest
 from peewee import SqliteDatabase
 
 from visionsim.dataset import Dataset, Metadata
-from visionsim.simulate.blender import INDEX_PADDING, ITEMS_PER_SUBFOLDER, BlenderClients
+from visionsim.simulate.blender import INDEX_PADDING, ITEMS_PER_SUBFOLDER, BlenderClient, BlenderClients
 from visionsim.simulate.schema import _MODELS, _Data
 
 
@@ -37,6 +38,9 @@ from visionsim.simulate.schema import _MODELS, _Data
         # "specular/light",
         "points",
         "previews/points",
+        "temperature",
+        "previews/temperature",
+        "thermal_radiance",
     ],
 )
 def test_render_layout(cube_dataset, gt_type):
@@ -71,6 +75,8 @@ def test_render_layout(cube_dataset, gt_type):
         ("specular/indirect", ["RGB"]),
         # ("specular/light", ["RGB"]),
         ("points", ["RGB"]),
+        ("temperature", ["V"]),
+        ("thermal_radiance", ["RGB"]),
     ],
 )
 def test_groundtruth_exrs(cube_dataset, subdir, channels):
@@ -107,6 +113,8 @@ def test_groundtruth_exrs(cube_dataset, subdir, channels):
         ("specular/indirect", (50, 50, 3), False),
         # ("specular/light", (50, 50, 3)),
         ("points", (50, 50, 3), False),
+        ("temperature", (50, 50, 1), True),
+        ("thermal_radiance", (50, 50, 3), False),
     ],
 )
 def test_load_exrs(cube_dataset, subdir, shape, auto_collapse):
@@ -154,3 +162,79 @@ def test_metadata_roundtrip_from_db(cube_dataset):
         meta.save(path.parent / "transforms.json")
 
         assert Metadata.load(path.parent / "transforms.json").model_dump() == meta.model_dump()
+
+
+def test_render_thermal(tmp_path_factory, executable):
+    """End-to-end thermal render gate (M1 acceptance).
+
+    Solves the heat-transfer FEM on the reused cube fixture, then renders the
+    main RGB pass plus the thermal outputs and asserts that:
+      * the radiance second-render pass did NOT clobber the main RGB ``frames/``,
+      * ``temperature/`` ground-truth EXRs are written (single channel, Kelvin),
+      * the inferno-colormap ``previews/temperature/`` PNGs are written, and
+      * the gray-body ``thermal_radiance/`` EXRs are written.
+
+    N is the number of frames rendered by this gate.
+    """
+    N = 2
+
+    out = tmp_path_factory.mktemp("renders")
+    log_dir = tmp_path_factory.mktemp("logs")
+    repo_scene = Path(__file__).parent / "test_files" / "scenes" / "cube.blend"
+
+    # Cache isolation: `prepare_thermal` derives its FEM solve-cache dir from the
+    # *source* blend path (`<blend>.heatsim/`). Initialize from a tmp copy so the
+    # cache lands under tmp_path (auto-cleaned) instead of polluting the repo tree.
+    scene = tmp_path_factory.mktemp("scene") / "cube.blend"
+    shutil.copy(repo_scene, scene)
+
+    with BlenderClient.spawn(executable=executable, timeout=60, log=log_dir) as client:
+        client.initialize(scene.resolve(), out.resolve())
+        client.set_resolution(50, 50)
+        # Mirror cube_dataset's keyframe scaling so the cube stays in-frame, then
+        # render exactly N frames (stop is exclusive: [10, 10 + N) -> 10, 11).
+        client.move_keyframes(scale=1 / 5)
+        client.set_animation_range(10, 10 + N)
+        client.include_frames()
+        # CPU solve for determinism. POINTS is the default/recommended domain, so
+        # the gate covers it. The reused cube fixture has a single 8-vertex Cube;
+        # robust_laplacian's point-cloud Laplacian defaults to 30 neighbours, which
+        # would raise "k+1 is greater than number of points" on 8 verts, but the
+        # laplacian backend now clamps n_neighbors to len(points)-1 (-> 7 here), so
+        # the solve runs. An 8-point solve is physically degenerate, but this gate
+        # only checks the solve -> temperature-AOV -> radiance render plumbing.
+        client.prepare_thermal(device="cpu", domain="POINTS")
+        client.include_thermal(radiance=True, preview=True)
+        client.render_animation()
+
+    frames = out / "frames"
+    temp = out / "temperature"
+    preview = out / "previews" / "temperature"
+    rad = out / "thermal_radiance"
+
+    # frames/ intact: the radiance second-render pass must NOT clobber the main RGB render.
+    assert frames.exists()
+    assert len(list(frames.glob("**/*.png"))) == N
+
+    # temperature ground-truth EXRs (Kelvin), single channel.
+    assert temp.exists()
+    assert (temp / "transforms.db").exists()
+    temp_exrs = sorted(temp.glob("**/*.exr"))
+    assert len(temp_exrs) == N
+    assert Dataset.load_data(temp_exrs[0]).shape == (50, 50, 1)
+    Metadata.load(temp / "transforms.db")  # round-trips without error
+
+    # inferno-colormap previews.
+    assert preview.exists()
+    assert len(list(preview.glob("**/*.png"))) == N
+
+    # gray-body thermal radiance EXRs: determine the ACTUAL channel count rather
+    # than assuming (50, 50, 1) vs (50, 50, 3). The output is registered as a
+    # 3-channel RGB EXR, so load with auto_collapse=False to read its true shape.
+    assert rad.exists()
+    assert (rad / "transforms.db").exists()
+    Metadata.load(rad / "transforms.db")  # round-trips without error
+    rad_exrs = sorted(rad.glob("**/*.exr"))
+    assert len(rad_exrs) == N
+    rad_shape = Dataset.load_data(rad_exrs[0], auto_collapse=False).shape
+    assert rad_shape == (50, 50, 3)

--- a/tests/test_thermal_assign.py
+++ b/tests/test_thermal_assign.py
@@ -1,0 +1,334 @@
+from __future__ import annotations
+
+import sys
+import warnings
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import thermal_assign
+
+from visionsim.simulate.heatsim.materials import MAX_DIRICHLET_K, MIN_DIRICHLET_K, preset_keys
+
+# --- dump -------------------------------------------------------------------
+
+
+class _Poly:
+    def __init__(self, material_index, area):
+        self.material_index = material_index
+        self.area = area
+
+
+class _Mesh:
+    def __init__(self, polygons, n_verts):
+        self.polygons = list(polygons)
+        self.vertices = [object()] * n_verts
+
+
+class _Node:
+    def __init__(self, type_, inputs=None):
+        self.type = type_
+        self.inputs = inputs or {}
+
+
+class _Socket:
+    def __init__(self, value):
+        self.default_value = value
+
+
+class _Material:
+    def __init__(self, name, use_nodes=True, nodes=None):
+        self.name = name
+        self.use_nodes = use_nodes
+        self.node_tree = type("T", (), {"nodes": list(nodes or [])})()
+
+
+class _Obj:
+    def __init__(self, name, mesh, mats, hide_render=False):
+        self.name = name
+        self.type = "MESH"
+        self.data = mesh
+        self.material_slots = [type("S", (), {"material": m})() for m in mats]
+        self.hide_render = hide_render
+
+    def visible_get(self):
+        return True
+
+
+def _scene(objects):
+    return type("S", (), {"objects": list(objects)})()
+
+
+def _data(mats):
+    return type("D", (), {"materials": list(mats)})()
+
+
+def test_face_area_share_ranks_by_coverage_and_sums_to_one():
+    wall, knob = _Material("MUROS"), _Material("bronce")
+    obj = _Obj("o", _Mesh([_Poly(0, 90.0), _Poly(1, 10.0)], 8), [wall, knob])
+    dump = thermal_assign.collect_scene_materials(_scene([obj]), _data([wall, knob]))
+
+    shares = {m["name"]: m["face_area_share"] for m in dump["materials"]}
+    assert shares["MUROS"] == pytest.approx(0.9)
+    assert shares["bronce"] == pytest.approx(0.1)
+    assert [m["name"] for m in dump["materials"]] == ["MUROS", "bronce"], "sorted by share, descending"
+    assert dump["n_mesh_objects"] == 1 and dump["n_vertices"] == 8
+
+
+def test_emission_and_bsdf_are_captured():
+    lamp = _Material("ilum", nodes=[_Node("EMISSION", {"Strength": _Socket(4.0)})])
+    wood = _Material("MADERA", nodes=[_Node("BSDF_PRINCIPLED", {
+        "Base Color": _Socket([0.40, 0.32, 0.23, 1.0]), "Metallic": _Socket(0.51),
+    })])
+    obj = _Obj("o", _Mesh([_Poly(0, 1.0), _Poly(1, 1.0)], 6), [lamp, wood])
+    dump = thermal_assign.collect_scene_materials(_scene([obj]), _data([lamp, wood]))
+    by_name = {m["name"]: m for m in dump["materials"]}
+
+    assert by_name["ilum"]["emission"] == {"is_emissive": True, "strength": pytest.approx(4.0)}
+    assert by_name["MADERA"]["bsdf"]["metallic"] == pytest.approx(0.51)
+    assert by_name["MADERA"]["emission"]["is_emissive"] is False
+
+
+def test_principled_emission_strength_with_black_color_is_not_emissive():
+    """Blender 4.x defaults Principled BSDF to Emission Strength=1.0 with BLACK emission
+    color, i.e. zero actual emission - strength alone must not flag it."""
+    mat = _Material("wall", nodes=[_Node("BSDF_PRINCIPLED", {
+        "Emission Strength": _Socket(1.0), "Emission Color": _Socket([0.0, 0.0, 0.0, 1.0]),
+    })])
+    obj = _Obj("o", _Mesh([_Poly(0, 1.0)], 3), [mat])
+    dump = thermal_assign.collect_scene_materials(_scene([obj]), _data([mat]))
+    assert dump["materials"][0]["emission"]["is_emissive"] is False
+
+
+def test_principled_emission_strength_with_non_black_color_is_emissive():
+    mat = _Material("lamp", nodes=[_Node("BSDF_PRINCIPLED", {
+        "Emission Strength": _Socket(1.0), "Emission Color": _Socket([1.0, 0.9, 0.7, 1.0]),
+    })])
+    obj = _Obj("o", _Mesh([_Poly(0, 1.0)], 3), [mat])
+    dump = thermal_assign.collect_scene_materials(_scene([obj]), _data([mat]))
+    assert dump["materials"][0]["emission"] == {"is_emissive": True, "strength": pytest.approx(1.0)}
+
+
+def test_principled_emission_strength_without_color_socket_is_emissive():
+    """Older Blender with no Emission Color socket: strength alone is the right signal."""
+    mat = _Material("lamp_old", nodes=[_Node("BSDF_PRINCIPLED", {"Emission Strength": _Socket(2.0)})])
+    obj = _Obj("o", _Mesh([_Poly(0, 1.0)], 3), [mat])
+    dump = thermal_assign.collect_scene_materials(_scene([obj]), _data([mat]))
+    assert dump["materials"][0]["emission"] == {"is_emissive": True, "strength": pytest.approx(2.0)}
+
+
+def test_unused_materials_hidden_objects_and_node_free_materials_are_handled():
+    used, unused = _Material("USED"), _Material("UNUSED", use_nodes=False)
+    hidden = _Obj("h", _Mesh([_Poly(0, 100.0)], 3), [used], hide_render=True)
+    shown = _Obj("s", _Mesh([_Poly(0, 1.0)], 3), [used])
+    dump = thermal_assign.collect_scene_materials(_scene([hidden, shown]), _data([used, unused]))
+    by_name = {m["name"]: m for m in dump["materials"]}
+
+    assert by_name["UNUSED"]["face_area_share"] == pytest.approx(0.0)
+    assert by_name["UNUSED"]["bsdf"] == {}
+    assert by_name["USED"]["objects"] == ["s"], "hidden objects must not contribute"
+
+
+# --- assign -----------------------------------------------------------------
+
+
+def _dump(materials):
+    return {"schema_version": 1, "n_mesh_objects": 1, "n_vertices": 10, "materials": materials}
+
+
+def _material(name, emissive=False, share=0.5):
+    return {"name": name, "textures": [], "bsdf": {}, "node_types": [], "objects": ["o"],
+            "emission": {"is_emissive": emissive, "strength": 4.0 if emissive else 0.0},
+            "face_area_share": share}
+
+
+def test_prompt_lists_the_materials_and_the_closed_preset_menu():
+    prompt = thermal_assign.build_prompt(_dump([_material("MADERA ESTANTES"), _material("ilum", emissive=True)]))
+    assert "MADERA ESTANTES" in prompt and "ilum" in prompt
+    assert "aluminium_polished" in prompt and "metal_painted" in prompt
+    assert "emissive" in prompt.lower()
+    for key in preset_keys():
+        assert key in prompt
+
+
+def test_emissive_material_is_forced_to_a_source_role():
+    """Deterministic guard: the EMISSION node is ground truth and outranks the model."""
+    raw = [{"material": "ilum", "preset": "glass", "role": "FEM_PARTICIPANT",
+            "dirichlet_K": None, "confidence": 0.6, "reason": "lamp glass"}]
+    with pytest.warns(UserWarning, match="overrid"):
+        out = thermal_assign.apply_guards(_dump([_material("ilum", emissive=True)]), raw)
+    assert out["ilum"]["role"] == "DIRICHLET_SOURCE"
+    assert out["ilum"]["dirichlet_K"] is not None
+
+
+def test_emissive_material_already_marked_source_does_not_warn_about_override():
+    """No warning-spam: the model already got it right, so the force is a no-op."""
+    raw = [{"material": "ilum", "preset": "glass", "role": "DIRICHLET_SOURCE",
+            "dirichlet_K": 350.0, "confidence": 0.9, "reason": "lamp element"}]
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        out = thermal_assign.apply_guards(_dump([_material("ilum", emissive=True)]), raw)
+    assert not any("overrid" in str(w.message) for w in caught)
+    assert out["ilum"]["role"] == "DIRICHLET_SOURCE"
+    assert out["ilum"]["dirichlet_K"] == pytest.approx(350.0)
+
+
+def test_emissive_material_skipped_by_model_is_forced_to_source_and_warns_accurately():
+    """A skipped emissive material is forced to DIRICHLET_SOURCE, not left 'unassigned'."""
+    with pytest.warns(UserWarning, match="EMISSION node"):
+        out = thermal_assign.apply_guards(_dump([_material("ilum", emissive=True)]), [])
+    assert out["ilum"]["role"] == "DIRICHLET_SOURCE"
+    assert out["ilum"]["dirichlet_K"] == pytest.approx(thermal_assign.DEFAULT_LAMP_K)
+    assert MIN_DIRICHLET_K <= out["ilum"]["dirichlet_K"] <= MAX_DIRICHLET_K
+
+
+def test_unknown_role_becomes_fem_participant_and_warns():
+    raw = [{"material": "MUROS", "preset": "plaster", "role": "MOLTEN",
+            "dirichlet_K": None, "confidence": 0.4, "reason": "??"}]
+    with pytest.warns(UserWarning, match="role"):
+        out = thermal_assign.apply_guards(_dump([_material("MUROS")]), raw)
+    assert out["MUROS"]["role"] == "FEM_PARTICIPANT"
+    assert out["MUROS"]["dirichlet_K"] is None
+
+
+def test_non_emissive_material_keeps_its_model_role():
+    raw = [{"material": "MUROS", "preset": "plaster", "role": "FEM_PARTICIPANT",
+            "dirichlet_K": None, "confidence": 0.9, "reason": "walls"}]
+    out = thermal_assign.apply_guards(_dump([_material("MUROS")]), raw)
+    assert out["MUROS"]["role"] == "FEM_PARTICIPANT" and out["MUROS"]["dirichlet_K"] is None
+
+
+def test_out_of_enum_preset_becomes_unassigned_and_warns():
+    raw = [{"material": "_87", "preset": "unobtainium", "role": "FEM_PARTICIPANT",
+            "dirichlet_K": None, "confidence": 0.2, "reason": "no idea"}]
+    with pytest.warns(UserWarning, match="unobtainium"):
+        out = thermal_assign.apply_guards(_dump([_material("_87")]), raw)
+    assert out["_87"]["preset"] is None
+
+
+def test_out_of_band_dirichlet_temperature_is_dropped_and_warns():
+    """A non-emissive DIRICHLET_SOURCE with an out-of-band K must not stay pinned at
+    ambient (which would silently act as a heat sink): the role is degraded too."""
+    raw = [{"material": "hob", "preset": "steel", "role": "DIRICHLET_SOURCE",
+            "dirichlet_K": 5000.0, "confidence": 0.7, "reason": "stove"}]
+    with pytest.warns(UserWarning, match="dirichlet_K"):
+        out = thermal_assign.apply_guards(_dump([_material("hob")]), raw)
+    assert out["hob"]["dirichlet_K"] is None
+    assert out["hob"]["role"] == "FEM_PARTICIPANT"
+
+
+def test_out_of_band_dirichlet_temperature_on_emissive_material_still_forced_to_source():
+    """Ground truth (the EMISSION node) still wins even after the out-of-band-K degrade:
+    the role guard drops to FEM_PARTICIPANT first, then the emission check forces it back
+    to DIRICHLET_SOURCE with DEFAULT_LAMP_K instead of the rejected out-of-band value."""
+    raw = [{"material": "ilum", "preset": "glass", "role": "DIRICHLET_SOURCE",
+            "dirichlet_K": 5000.0, "confidence": 0.7, "reason": "lamp"}]
+    with pytest.warns(UserWarning, match="dirichlet_K"):
+        out = thermal_assign.apply_guards(_dump([_material("ilum", emissive=True)]), raw)
+    assert out["ilum"]["role"] == "DIRICHLET_SOURCE"
+    assert out["ilum"]["dirichlet_K"] == pytest.approx(thermal_assign.DEFAULT_LAMP_K)
+
+
+def test_skipped_material_is_added_back_and_hallucinated_one_is_dropped():
+    raw = [
+        {"material": "A", "preset": "wood", "role": "FEM_PARTICIPANT", "dirichlet_K": None,
+         "confidence": 0.9, "reason": "wood"},
+        {"material": "GHOST", "preset": "steel", "role": "FEM_PARTICIPANT", "dirichlet_K": None,
+         "confidence": 0.9, "reason": "invented"},
+    ]
+    with pytest.warns(UserWarning):
+        out = thermal_assign.apply_guards(_dump([_material("A"), _material("B")]), raw)
+    assert set(out) == {"A", "B"}, "B added back, GHOST dropped"
+    assert out["B"]["preset"] is None
+
+
+def test_sidecar_round_trips_through_the_loader(tmp_path):
+    import json
+
+    from visionsim.simulate.heatsim.materials import load_assignments
+
+    dump = _dump([_material("MADERA"), _material("ilum", emissive=True)])
+    raw = [{"material": "MADERA", "preset": "wood", "role": "FEM_PARTICIPANT",
+            "dirichlet_K": None, "confidence": 0.95, "reason": "madera = wood"}]
+    with pytest.warns(UserWarning):
+        guarded = thermal_assign.apply_guards(dump, raw)
+    sidecar = thermal_assign.to_sidecar(dump, guarded, "kitchen1.blend")
+
+    path = tmp_path / "kitchen1.thermal.json"
+    path.write_text(json.dumps(sidecar, indent=2), encoding="utf-8")
+
+    parsed = load_assignments(path)
+    assert parsed.scene == "kitchen1.blend"
+    entry = parsed.entry_for("MADERA")
+    assert entry is not None and entry.preset is not None and entry.preset.key == "wood"
+    lamp = parsed.entry_for("ilum")
+    assert lamp is not None and lamp.role == "DIRICHLET_SOURCE"
+
+
+# --- response parsing -------------------------------------------------------
+
+
+def test_parse_assignments_accepts_a_bare_json_object():
+    out = thermal_assign.parse_assignments_content('{"assignments": [{"material": "A", "preset": "wood"}]}')
+    assert out == [{"material": "A", "preset": "wood"}]
+
+
+def test_parse_assignments_strips_a_markdown_fence():
+    """Reasoning models (GLM etc.) fence their JSON even under response_format=json_object."""
+    fenced = '```json\n{"assignments": [{"material": "A", "preset": "wood"}]}\n```'
+    out = thermal_assign.parse_assignments_content(fenced)
+    assert out == [{"material": "A", "preset": "wood"}]
+
+
+def test_parse_assignments_strips_a_bare_triple_backtick_fence():
+    fenced = '```\n{"assignments": []}\n```'
+    assert thermal_assign.parse_assignments_content(fenced) == []
+
+
+def test_parse_assignments_rejects_non_json():
+    with pytest.raises(ValueError, match="did not return JSON"):
+        thermal_assign.parse_assignments_content("I cannot help with that.")
+
+
+def test_parse_assignments_rejects_json_without_the_assignments_key():
+    with pytest.raises(ValueError, match="assignments"):
+        thermal_assign.parse_assignments_content('{"result": "ok"}')
+
+
+# --- report -----------------------------------------------------------------
+
+
+def _report_inputs():
+    dump = _dump([_material("MUROS", share=0.7), _material("_87", share=0.2),
+                  _material("ilum", emissive=True, share=0.1)])
+    sidecar = {
+        "schema_version": 1, "scene": "kitchen1.blend", "defaults": {"preset": "plaster"},
+        "materials": {
+            "MUROS": {"preset": "drywall", "role": "FEM_PARTICIPANT", "dirichlet_K": None,
+                      "confidence": 0.95, "reason": "muros = walls"},
+            "_87": {"preset": None, "role": "FEM_PARTICIPANT", "dirichlet_K": None,
+                    "confidence": 0.0, "reason": "opaque name"},
+            "ilum": {"preset": "glass", "role": "DIRICHLET_SOURCE", "dirichlet_K": 345.0,
+                     "confidence": 1.0, "reason": "EMISSION node"},
+        },
+    }
+    return dump, sidecar
+
+
+def test_report_is_self_contained_area_ordered_and_flags_the_rows_needing_attention():
+    html = thermal_assign.build_report(*_report_inputs())
+    assert html.lstrip().startswith("<!DOCTYPE html>") and "<style>" in html
+    assert "http://" not in html and "https://" not in html, "must not reference external assets"
+    assert html.index("MUROS") < html.index("_87") < html.index("ilum")
+    assert "UNASSIGNED" in html and "SOURCE" in html and "345" in html
+    assert "drywall" in html and "0.31" in html  # resolved alpha is shown
+
+
+def test_report_escapes_material_names():
+    dump, sidecar = _report_inputs()
+    dump["materials"][0]["name"] = "<script>x</script>"
+    sidecar["materials"]["<script>x</script>"] = sidecar["materials"].pop("MUROS")
+    html = thermal_assign.build_report(dump, sidecar)
+    assert "<script>x</script>" not in html and "&lt;script&gt;" in html

--- a/tests/test_thermal_preview.py
+++ b/tests/test_thermal_preview.py
@@ -1,0 +1,70 @@
+"""Tests for the thermal preview colormap: the global temperature range helper
+and the inferno-stop compositor node group (see
+docs/superpowers/specs/2026-07-07-visionsim-thermal-parity-design.md §9).
+
+Both run inside ``blender --background`` (adapter imports bpy; the node group
+builds a compositor tree), matching the pattern in ``test_heatsim_irradiance``.
+"""
+
+import subprocess
+
+
+def test_global_temperature_range_is_robust_to_outliers(executable):
+    code = r"""
+import numpy as np
+from visionsim.simulate.heatsim import adapter
+
+# A realistic scene: the bulk sits near ambient with a modest warm spread, plus a
+# handful of artifact-hot vertices (2000 K, well under 1% of the data) that must
+# NOT dictate the colormap.
+final = np.full(1000, 295.0)
+final[:100] = np.linspace(296.0, 310.0, 100)   # genuine warm spread, up to ~310 K
+final[-3:] = 2000.0                             # 0.3% runaway artifact vertices
+hist = {'room': np.stack([np.full(1000, 295.0), final])}   # (timesteps, vertices)
+
+tmin, tmax = adapter.global_temperature_range(hist, default_K=295.0)
+assert abs(tmin - 295.0) < 1e-6, tmin          # floored at default / P1 of the ambient bulk
+assert tmax < 320.0, tmax                       # P99 rejects the 2000 K outliers
+assert tmax > 300.0, tmax                       # but still covers the genuine warm spread
+
+# empty history -> (default, default + 1)
+lo, hi = adapter.global_temperature_range({}, 295.0)
+assert (lo, hi) == (295.0, 296.0), (lo, hi)
+
+# near-uniform field -> span widened to >= 1 K (no colour collapse)
+lo, hi = adapter.global_temperature_range({'o': np.full((2, 4), 300.0)}, 300.0)
+assert lo == 300.0 and (hi - lo) >= 1.0, (lo, hi)
+
+print('RANGE_OK', round(tmin, 3), round(tmax, 3))
+"""
+    out = subprocess.run([str(executable), "-b", "--python-expr", code], capture_output=True, text=True, check=False)
+    assert "RANGE_OK" in out.stdout, out.stdout + "\n" + out.stderr
+
+
+def test_thermal_preview_node_group_uses_inferno_stops_and_range(executable):
+    code = r"""
+import bpy  # noqa: F401
+from visionsim.simulate.nodes import thermal_preview_node_group
+
+ng = thermal_preview_node_group(tmin=295.0, tmax=297.0)
+
+# MapRange wired to [tmin, tmax] -> [0, 1]
+mr = ng.nodes['TempNormalize']
+assert abs(mr.inputs[1].default_value - 295.0) < 1e-6, mr.inputs[1].default_value
+assert abs(mr.inputs[2].default_value - 297.0) < 1e-6, mr.inputs[2].default_value
+
+# Inferno ramp: 11 stops from near-black to pale yellow (heat-sim _INFERNO_STOPS)
+ramp = ng.nodes['InfernoRamp'].color_ramp
+assert len(ramp.elements) == 11, len(ramp.elements)
+lo, hi = ramp.elements[0], ramp.elements[10]
+assert abs(lo.position - 0.0) < 1e-6 and abs(hi.position - 1.0) < 1e-6
+assert lo.color[0] < 0.02 and lo.color[2] < 0.02, tuple(lo.color)   # near-black low end
+assert hi.color[0] > 0.9 and hi.color[1] > 0.9, tuple(hi.color)     # pale-yellow high end
+
+# Regression guard: the old turbo low stop was blue-ish (0.190, 0.072, 0.232)
+assert abs(lo.color[0] - 0.18995) > 1e-3, 'colormap is still turbo, not inferno'
+
+print('INFERNO_NODEGROUP_OK')
+"""
+    out = subprocess.run([str(executable), "-b", "--python-expr", code], capture_output=True, text=True, check=False)
+    assert "INFERNO_NODEGROUP_OK" in out.stdout, out.stdout + "\n" + out.stderr

--- a/visionsim/cli/blender.py
+++ b/visionsim/cli/blender.py
@@ -94,6 +94,61 @@ def render_animation(
         )
 
 
+def heatsim_solve(
+    blend_file: Path,
+    /,
+    config: RenderConfig,
+    output_file: Path | None = None,
+) -> None:
+    """Run the FEM heat-transfer solve on a blend-file without rendering.
+
+    Primes the scene's heat simulation cache so that a subsequent
+    ``vsim blender.render-animation`` call with ``config.include_thermal = True``
+    can skip the expensive solve step. Opens the blend-file in a single background
+    Blender instance, runs the FEM solve via ``clients.heatsim_solve``, and
+    optionally saves the modified blend-file to disk.
+
+    Args:
+        blend_file: Path to blend file.
+        config: Render configuration; ``config.thermal`` drives the FEM solver
+            parameters and ``config.executable``, ``config.log_dir``,
+            ``config.timeout``, and ``config.autoexec`` control the Blender
+            instance.
+        output_file: If set, write the modified blend file to this path.
+            Helpful for troubleshooting. Defaults to not saving.
+    """
+    from dataclasses import asdict
+
+    from visionsim.cli import _log, _run  # avoid circular import
+    from visionsim.simulate.blender import BlenderClients
+    from visionsim.utils.progress import ElapsedProgress
+
+    if _run(f"{config.executable or 'blender'} --version", shell=True, hide=True).returncode != 0:
+        raise RuntimeError("No blender installation found on path!")
+    if not (blend_file := blend_file.resolve()).exists():
+        raise FileNotFoundError(f"Blender file {blend_file} not found.")
+
+    output_file = output_file.resolve() if output_file else None
+
+    _log.info(f"Running thermal solve on {blend_file.stem}...")
+
+    with (
+        BlenderClients.spawn(
+            jobs=1,
+            log=config.log_dir,
+            timeout=config.timeout,
+            executable=config.executable,
+            autoexec=config.autoexec,
+        ) as clients,
+        ElapsedProgress() as progress,
+    ):
+        progress.add_task(f"Solving {blend_file.stem}...")
+        clients.initialize(blend_file, blend_file.parent)
+        clients.heatsim_solve(**asdict(config.thermal))
+        if output_file is not None:
+            clients.save_file(output_file)
+
+
 def optimize_rate(
     blend_file: Path,
     /,
@@ -186,6 +241,7 @@ def optimize_rate(
     probe_config.include_materials = False
     probe_config.include_points = False
     probe_config.include_segmentations = False
+    probe_config.include_thermal = False
     probe_config.previews = False
     probe_config.autoscale = False
     probe_config.jobs = 1

--- a/visionsim/simulate/blender.py
+++ b/visionsim/simulate/blender.py
@@ -460,6 +460,16 @@ class BlenderService(rpyc.Service):
         self._warned_no_outputs: bool = False
         self._outputs: dict[str, Any] = {}
         self._camera: bpy.types.Camera | None = None
+        self._thermal_radiance: dict[str, Any] | None = None
+        # Animated thermal state, populated by exposed_prepare_thermal's animated
+        # branch and consumed by _thermal_write_frame / exposed_render_frame.
+        self._thermal_animated_history: dict[str, Any] | None = None
+        self._thermal_animated_frames: list[int] | None = None
+        self._thermal_animated_defaults: dict[str, Any] | None = None
+        self._thermal_assignment: Any | None = None
+        # TEXEL render domain: the AtlasPlan from the most recent exposed_prepare_thermal
+        # call (None in VERTEX mode, or if TEXEL mode found nothing atlas-eligible).
+        self._thermal_atlas_plan: Any | None = None
 
     def _clear_cached_properties(self) -> None:
         # Based on: https://stackoverflow.com/a/71579485
@@ -502,6 +512,12 @@ class BlenderService(rpyc.Service):
         self._warned_no_outputs = False
         self._outputs = {}
         self._camera = None
+        self._thermal_radiance = None
+        self._thermal_animated_history = None
+        self._thermal_animated_frames = None
+        self._thermal_animated_defaults = None
+        self._thermal_assignment = None
+        self._thermal_atlas_plan = None
 
     def register_output_type(
         self,
@@ -551,6 +567,7 @@ class BlenderService(rpyc.Service):
         exr_codec: EXR_CODECS = "DWAA",
         bit_depth: int = 32,
         preview: bool = False,
+        preview_view_transform: str | None = None,
         c: int | None = None,
         denoise: bool = False,
     ) -> None:
@@ -565,6 +582,9 @@ class BlenderService(rpyc.Service):
             exr_codec (str, optional): EXR codec to use. Defaults to "DWAA".
             bit_depth (int, optional): Bit depth to use. Defaults to 32.
             preview (bool, optional): If true, output node will be configured for preview. Defaults to False.
+            preview_view_transform (str, optional): When set on a preview output, overrides the preview
+                default "Raw" view transform (e.g. "Standard" to sRGB-encode a colormapped image).
+                Ignored for non-preview outputs. Defaults to None (leave the preview default "Raw").
             c (int, optional): Number of channels for registration. Defaults to None (inferred from color_mode).
             denoise (bool, optional): If true, insert a denoise compositor node before the file output.
                 This enables the Cycles denoising data view layer passes (albedo and normal) and connects
@@ -610,6 +630,11 @@ class BlenderService(rpyc.Service):
             self.tree.links.new(source_socket, socket)
         else:
             self.tree.links.new(source_socket, socket)
+
+        if preview and preview_view_transform is not None:
+            # file_output_node(preview=True) forces "Raw"; override it (e.g. to
+            # "Standard") when the compositor output must be display-encoded.
+            node.format.view_settings.view_transform = preview_view_transform
 
         if c is None:
             c = COLOR_MODE_CHANNELS.get(color_mode.upper())
@@ -744,6 +769,14 @@ class BlenderService(rpyc.Service):
         self.blend_file: Path = Path(str(blend_file)).resolve()
         bpy.ops.wm.open_mainfile(filepath=str(blend_file), **kwargs)
         self.log.info(f"Successfully loaded {blend_file}")
+
+        # Register the heatsim per-object thermal material properties so that
+        # ``obj.heat_sim_material`` and ``obj.heat_simulation_enabled`` are available
+        # on any loaded blend. Guarded so repeated initializations don't re-register.
+        from visionsim.simulate.heatsim import register as heatsim_register
+
+        if not hasattr(bpy.types.Object, "heat_sim_material"):
+            heatsim_register()
 
         # Init various variables to track state
         self._use_animation: bool = True
@@ -1467,6 +1500,799 @@ class BlenderService(rpyc.Service):
             c=3,
         )
 
+    def _thermal_config(
+        self,
+        *,
+        initial_temperature_K: float,
+        thermal_diffusivity_mm2_s: float,
+        density_kg_m3: float,
+        specific_heat_J_kgK: float,
+        emissivity: float,
+        irradiance_scale: float,
+        sim_time_s: float,
+        timestep_s: float,
+        domain: Literal["POINTS", "MESH"],
+        laplacian_backend: Literal["ROBUST", "IGL"],
+        irradiance_source: Literal["DIRECT_KERNEL", "CYCLES_BAKE"] = "DIRECT_KERNEL",
+        bake_samples: int = 1024,
+        irradiance_texture_size: int = 512,
+        device: Literal["cuda", "cpu"],
+        assignments: str | None = None,
+    ) -> tuple[dict, dict, Path, Any]:
+        """Shared ``defaults``/``solver_cfg``/``cache_root`` builder for every thermal-solve
+        entry point.
+
+        Factored out of :meth:`_thermal_solve` so the static solve
+        (``adapter.solve_scene``) and the animated solve (``adapter.solve_scene_animated``,
+        called from :meth:`exposed_prepare_thermal`'s animated branch) compute byte-identical
+        ``defaults``/``solver_cfg`` -- including the blend-authored ``irradiance_scale``
+        override -- and therefore share the same cache-key convention.
+
+        Returns:
+            tuple[dict, dict, Path, Any]: ``(defaults, solver_cfg, cache_root, assignment)``.
+        """
+        from visionsim.simulate.heatsim import adapter
+
+        defaults = {
+            "initial_temperature_K": initial_temperature_K,
+            "thermal_diffusivity_mm2_s": thermal_diffusivity_mm2_s,
+            "density_kg_m3": density_kg_m3,
+            "specific_heat_J_kgK": specific_heat_J_kgK,
+            "emissivity": emissivity,
+            "irradiance_scale": irradiance_scale,
+        }
+        # A heat-sim-authored .blend carries its own scene-level irradiance_scale
+        # (e.g. 1000). Let it override the ThermalConfig default so the scene
+        # renders identically to the addon without manual CLI tuning.
+        _authored_scale = adapter.read_authored_irradiance_scale(self.scene)
+        if _authored_scale is not None and _authored_scale != defaults["irradiance_scale"]:
+            server_log.info(
+                "thermal: using blend-authored irradiance_scale=%.3g (overrides configured %.3g)",
+                _authored_scale, defaults["irradiance_scale"],
+            )
+        if _authored_scale is not None:
+            defaults["irradiance_scale"] = _authored_scale
+        solver_cfg = {
+            "sim_time_s": sim_time_s,
+            "timestep_s": timestep_s,
+            "domain": domain,
+            "laplacian_backend": laplacian_backend,
+            "device": device,
+            "irradiance_source": irradiance_source,
+            "bake_samples": bake_samples,
+            "irradiance_texture_size": irradiance_texture_size,
+        }
+        scene_assignment = None
+        if assignments is not None:
+            from visionsim.simulate.heatsim import materials
+
+            assignment_path = Path(str(assignments))
+            scene_assignment = materials.load_assignments(assignment_path)
+            server_log.info(
+                "thermal: loaded %d material assignments from %s",
+                len(scene_assignment.materials), assignment_path,
+            )
+        cache_root = Path(str(self.blend_file) + ".heatsim")
+        return defaults, solver_cfg, cache_root, scene_assignment
+
+    def _thermal_solve(
+        self,
+        *,
+        initial_temperature_K: float,
+        thermal_diffusivity_mm2_s: float,
+        density_kg_m3: float,
+        specific_heat_J_kgK: float,
+        emissivity: float,
+        irradiance_scale: float,
+        sim_time_s: float,
+        timestep_s: float,
+        domain: Literal["POINTS", "MESH"],
+        laplacian_backend: Literal["ROBUST", "IGL"],
+        irradiance_source: Literal["DIRECT_KERNEL", "CYCLES_BAKE"] = "DIRECT_KERNEL",
+        bake_samples: int = 1024,
+        irradiance_texture_size: int = 512,
+        device: Literal["cuda", "cpu"],
+        assignments: str | None = None,
+        render_domain: Literal["VERTEX", "TEXEL"] = "VERTEX",
+        atlas_texel_density: float = 1500.0,
+        atlas_tile_min: int = 16,
+        atlas_tile_max: int = 512,
+        atlas_texel_soft_max: int = 500_000,
+    ) -> tuple[dict, Any, Path]:
+        """Shared FEM-solve core used by :meth:`exposed_prepare_thermal` and
+        :meth:`exposed_heatsim_solve`.
+
+        Builds the ``defaults`` and ``solver_cfg`` dicts (via :meth:`_thermal_config`),
+        derives ``cache_root`` from the always-set :attr:`blend_file` path (avoids
+        ``bpy.data.filepath`` which is empty for an unsaved scene), and delegates to
+        ``adapter.solve_scene``.  Both callers produce identical cache keys
+        because they share this single code path.
+
+        When ``render_domain="TEXEL"``, builds an ``adapter.AtlasPlan`` (``adapter.
+        build_atlas_plan``) from the 4 ``atlas_*`` knobs BEFORE solving and threads it
+        through to ``adapter.solve_scene``, which folds the plan's effective density/tile
+        bounds/layout digest into the solve cache key (Task 2's existing ``"atlas"`` key
+        field). ``render_domain="VERTEX"`` (the default) never builds a plan, so the solve
+        cache key and ``adapter.solve_scene``/``adapter._combine`` code path are exactly
+        what they were before the atlas existed.
+
+        Returns:
+            tuple[dict, Any, Path]: ``(history, atlas_plan, cache_root)`` -- ``atlas_plan``
+            is ``None`` in VERTEX mode (or when TEXEL mode found nothing eligible).
+        """
+        from visionsim.simulate.heatsim import adapter
+
+        defaults, solver_cfg, cache_root, assignment = self._thermal_config(
+            initial_temperature_K=initial_temperature_K,
+            thermal_diffusivity_mm2_s=thermal_diffusivity_mm2_s,
+            density_kg_m3=density_kg_m3,
+            specific_heat_J_kgK=specific_heat_J_kgK,
+            emissivity=emissivity,
+            irradiance_scale=irradiance_scale,
+            sim_time_s=sim_time_s,
+            timestep_s=timestep_s,
+            domain=domain,
+            laplacian_backend=laplacian_backend,
+            irradiance_source=irradiance_source,
+            bake_samples=bake_samples,
+            irradiance_texture_size=irradiance_texture_size,
+            device=device,
+            assignments=assignments,
+        )
+        self._thermal_assignment = assignment
+
+        atlas_plan = None
+        if render_domain == "TEXEL":
+            sim_objects = adapter.gather_meshes(self.scene)
+            atlas_cfg = {
+                "atlas_texel_density": atlas_texel_density,
+                "atlas_tile_min": atlas_tile_min,
+                "atlas_tile_max": atlas_tile_max,
+                "atlas_texel_soft_max": atlas_texel_soft_max,
+            }
+            atlas_plan = adapter.build_atlas_plan(self.scene, sim_objects, atlas_cfg)
+
+        history = adapter.solve_scene(
+            self.scene,
+            defaults=defaults,
+            solver_cfg=solver_cfg,
+            cache_root=cache_root,
+            assignment=assignment,
+            atlas_plan=atlas_plan,
+        )
+        return history, atlas_plan, cache_root
+
+    def _thermal_load_pack_atlas_image(self, atlas_path: Path) -> None:
+        """Load the EXR :func:`adapter.write_atlas` wrote and (re)register it as the
+        ``HeatSim_Temperature_Atlas`` Blender image, packed so the shader (built right
+        after this call, by ``thermal_shader.setup_temperature_aov``, and later at render
+        time by ``thermal_shader.enter_thermal_scene``) can find it by name -- and so it
+        keeps working even if the source EXR under the ``.heatsim`` cache directory later
+        moves or is cleaned up.
+        """
+        from visionsim.simulate.heatsim.constants import ATLAS_IMAGE_NAME
+
+        existing = bpy.data.images.get(ATLAS_IMAGE_NAME)
+        if existing is not None:
+            bpy.data.images.remove(existing)
+        image = bpy.data.images.load(str(atlas_path))
+        image.name = ATLAS_IMAGE_NAME
+        try:
+            image.colorspace_settings.name = "Non-Color"
+        except Exception:  # noqa: BLE001, S110 - see heatsim per-file-ignores in pyproject.toml
+            # pragma: no cover - defensive, mirrors irradiance.py's style
+            pass
+        image.pack()
+
+    @require_initialized_service
+    def exposed_prepare_thermal(
+        self,
+        radiance: bool = True,
+        preview: bool = True,
+        initial_temperature_K: float = 295.0,
+        thermal_diffusivity_mm2_s: float = 0.17,
+        density_kg_m3: float = 1330.0,
+        specific_heat_J_kgK: float = 880.0,
+        emissivity: float = 0.9,
+        irradiance_scale: float = 100.0,
+        sim_time_s: float = 1.0,
+        timestep_s: float = 0.05,
+        domain: Literal["POINTS", "MESH"] = "POINTS",
+        laplacian_backend: Literal["ROBUST", "IGL"] = "ROBUST",
+        irradiance_source: Literal["DIRECT_KERNEL", "CYCLES_BAKE"] = "DIRECT_KERNEL",
+        bake_samples: int = 1024,
+        irradiance_texture_size: int = 512,
+        device: Literal["cuda", "cpu"] = "cuda",
+        render_domain: Literal["VERTEX", "TEXEL"] = "VERTEX",
+        atlas_texel_density: float = 1500.0,
+        atlas_tile_min: int = 16,
+        atlas_tile_max: int = 512,
+        atlas_texel_soft_max: int = 500_000,
+        radiance_scale: float = 1.0,
+        exr_codec: EXR_CODECS = "DWAA",
+        bit_depth: Literal[16, 32] = 32,
+        animated: bool = False,
+        substeps_per_frame: int = 4,
+        frame_start: int | None = None,
+        frame_end: int | None = None,
+        every_n_frames: int = 1,
+        assignments: str | None = None,
+    ) -> None:
+        """Solve the scene's heat-transfer simulation and prepare it for thermal rendering.
+
+        Runs the (cache-aware) FEM solve, writes the solved per-vertex ``sim_temperature``
+        attribute onto every mesh, stamps a default temperature on any unsolved mesh, and
+        registers the ``temperature`` value AOV on the original materials.
+
+        Note:
+            This must be called before :meth:`include_thermal <visionsim.simulate.blender.BlenderService.exposed_include_thermal>`,
+            since the AOV is registered on the original materials and exposes the ``temperature`` render-layer
+            output socket that ``include_thermal`` wires into the compositor. The static solve produces one field, so the final
+            timestep (``timestep=-1``) is written to every frame. When ``animated`` is true (``domain="POINTS"``
+            only), a per-frame transient solve is run instead (``adapter.solve_scene_animated``): the per-object
+            frame history is stashed on the service and the first solved frame's field is written immediately so the
+            initial render is correct; subsequent frames are written by :meth:`exposed_render_frame`'s per-frame
+            hook. Requesting ``animated`` with ``domain="MESH"`` logs a warning and falls back to the static solve.
+            The full ``ThermalConfig`` field set is accepted so a single ``**asdict(config.thermal)`` dispatch can
+            drive this method; the output-only fields are ignored. When ``render_domain="TEXEL"``, atlas-eligible
+            objects (see ``atlas_texel_density``) are additionally solved at texel resolution and their final
+            temperatures are written to an EXR atlas image (``adapter.write_atlas``), loaded/packed as the
+            ``HeatSim_Temperature_Atlas`` Blender image before the AOV is registered so the shader can sample it;
+            those objects get only the OBJECT-level fallback temperature written to their mesh (their per-pixel
+            signal comes from the atlas at render time), not a per-vertex ``sim_temperature`` attribute. Requesting
+            ``animated`` with ``render_domain="TEXEL"`` logs a warning and falls back to ``render_domain="VERTEX"``
+            for that solve (the atlas is a static-solve-only feature; animated + TEXEL is out of scope).
+
+        Args:
+            radiance (bool, optional): Accepted for uniform thermal-config dispatch; not used by this method (consumed
+                by ``include_thermal`` / the radiance render). Defaults to True.
+            preview (bool, optional): Accepted for uniform thermal-config dispatch; not used by this method (consumed
+                by ``include_thermal`` / the radiance render). Defaults to True.
+            initial_temperature_K (float, optional): Default initial temperature, in Kelvin, for meshes without a
+                per-object value. Defaults to 295.0.
+            thermal_diffusivity_mm2_s (float, optional): Default thermal diffusivity in ``mm^2/s``. Defaults to 0.17.
+            density_kg_m3 (float, optional): Default material density in ``kg/m^3``. Defaults to 1330.0.
+            specific_heat_J_kgK (float, optional): Default specific heat in ``J/kg*K``. Defaults to 880.0.
+            emissivity (float, optional): Default surface emissivity in ``[0, 1]``. Defaults to 0.9.
+            irradiance_scale (float, optional): Scale factor applied to the computed irradiance (heating input).
+                Defaults to 100.0.
+            sim_time_s (float, optional): Total simulated time, in seconds, for the static scene solve. Defaults to 1.0.
+            timestep_s (float, optional): Solver timestep in seconds. Defaults to 0.05.
+            domain (str, optional): FEM domain, either ``"POINTS"`` (surface point cloud, recommended) or ``"MESH"``.
+                Defaults to ``"POINTS"``.
+            laplacian_backend (str, optional): Laplacian backend, either ``"ROBUST"`` or ``"IGL"``. Defaults to ``"ROBUST"``.
+            irradiance_source (str, optional): Where absorbed flux comes from. ``"DIRECT_KERNEL"`` is the
+                analytic path (lamp objects plus an SH sky, no indirect bounce); ``"CYCLES_BAKE"`` bakes
+                DIFFUSE DIRECT+INDIRECT per object, so emissive geometry and bounce contribute.
+                Defaults to ``"DIRECT_KERNEL"``.
+            bake_samples (int, optional): Cycles samples for the irradiance bake (``CYCLES_BAKE`` only), with
+                adaptive sampling disabled so this is a true per-texel count. Defaults to 1024.
+            irradiance_texture_size (int, optional): Resolution of the Cycles bakes, in pixels per side. Governs
+                the albedo bake and, under ``CYCLES_BAKE``, the irradiance bake. This is the bake's spatial
+                detail, as distinct from ``bake_samples``, which is its noise. Defaults to 512.
+            device (str, optional): Torch device for the solve, either ``"cuda"`` or ``"cpu"``; falls back to ``"cpu"``
+                if cuda is unavailable. Defaults to ``"cuda"``.
+            render_domain (str, optional): Where solved temperatures live for rendering: ``"VERTEX"`` (per-vertex,
+                byte-identical to before the atlas existed) or ``"TEXEL"`` (a shared texture atlas, sampled per-pixel
+                by the shader). Defaults to ``"VERTEX"``.
+            atlas_texel_density (float, optional): Target texels/m^2 for atlas-eligible objects (TEXEL mode only).
+                Defaults to 1500.0.
+            atlas_tile_min (int, optional): Minimum atlas tile side, in texels (TEXEL mode only). Defaults to 16.
+            atlas_tile_max (int, optional): Maximum atlas tile side, in texels (TEXEL mode only). Defaults to 512.
+            atlas_texel_soft_max (int, optional): Soft ceiling on total atlas texels + retained vertices (TEXEL mode
+                only); exceeding it rescales the effective density down uniformly and warns. Defaults to 500000.
+            radiance_scale (float, optional): Accepted for uniform thermal-config dispatch; not used by this method
+                (consumed by ``include_thermal`` / the radiance render). Defaults to 1.0.
+            exr_codec (str, optional): Accepted for uniform thermal-config dispatch; not used by this method (consumed
+                by ``include_thermal`` / the radiance render). Defaults to ``"DWAA"``.
+            bit_depth (int, optional): Accepted for uniform thermal-config dispatch; not used by this method (consumed
+                by ``include_thermal`` / the radiance render). Defaults to 32.
+            animated (bool, optional): Solve heat transfer per-frame as geometry animates (transient), instead of the
+                static solve. Requires ``domain="POINTS"``. Defaults to False.
+            substeps_per_frame (int, optional): Solver substeps per Blender frame in animated mode. Defaults to 4.
+            frame_start (int | None, optional): First frame of the animated solve; defaults to the scene's
+                ``frame_start`` when None. Defaults to None.
+            frame_end (int | None, optional): Last frame of the animated solve; defaults to the scene's
+                ``frame_end`` when None. Defaults to None.
+            every_n_frames (int, optional): Solve every Nth frame in animated mode (cost control); skipped frames
+                hold the last solved field. Defaults to 1.
+            assignments (str | None, optional): Path to a thermal material assignment sidecar
+                (``<scene>.thermal.json``). When set, thermal properties are resolved per material
+                slot; when unset the global defaults are used everywhere. Defaults to None.
+        """
+        from visionsim.simulate.heatsim import adapter, thermal_shader
+
+        self._thermal_animated_history = None
+        self._thermal_animated_frames = None
+        self._thermal_animated_defaults = None
+        self._thermal_atlas_plan = None
+
+        # Cycles' persistent data keeps the device-side scene alive between frames, but
+        # the thermal passes swap materials and AOV wiring on every frame. That
+        # combination intermittently renders a surface's temperature as 0 K: over a
+        # 50-frame classroom sequence it blanked whole objects in 6 frames on one run and
+        # 2 on the next (up to 31% of a frame), and which frames broke changed run to run.
+        # Turning it off for thermal runs drops the 0 K fraction from ~1.9% to ~0.03%
+        # (background only) and makes the sequence deterministic.
+        if self.scene.render.use_persistent_data:
+            self.log.info("thermal: disabling Cycles persistent data (stale AOV state between frames)")
+            self.scene.render.use_persistent_data = False
+
+        if animated and domain == "MESH":
+            self.log.warning(
+                "thermal: animated mode requires domain='POINTS' (got 'MESH'); falling back "
+                "to the static solve for this scene."
+            )
+            animated = False
+
+        if animated and render_domain == "TEXEL":
+            self.log.warning(
+                "thermal: the texel atlas is a static-solve-only feature (animated + TEXEL "
+                "is out of scope); falling back to render_domain='VERTEX' for this solve."
+            )
+            render_domain = "VERTEX"
+
+        if animated:
+            defaults, solver_cfg, cache_root, assignment = self._thermal_config(
+                initial_temperature_K=initial_temperature_K,
+                thermal_diffusivity_mm2_s=thermal_diffusivity_mm2_s,
+                density_kg_m3=density_kg_m3,
+                specific_heat_J_kgK=specific_heat_J_kgK,
+                emissivity=emissivity,
+                irradiance_scale=irradiance_scale,
+                sim_time_s=sim_time_s,
+                timestep_s=timestep_s,
+                domain=domain,
+                laplacian_backend=laplacian_backend,
+                irradiance_source=irradiance_source,
+                bake_samples=bake_samples,
+                irradiance_texture_size=irradiance_texture_size,
+                device=device,
+                assignments=assignments,
+            )
+            self._thermal_assignment = assignment
+            resolved_frame_start = self.scene.frame_start if frame_start is None else frame_start
+            resolved_frame_end = self.scene.frame_end if frame_end is None else frame_end
+            history, frames = adapter.solve_scene_animated(
+                self.scene,
+                defaults=defaults,
+                solver_cfg=solver_cfg,
+                cache_root=cache_root,
+                frame_start=resolved_frame_start,
+                frame_end=resolved_frame_end,
+                every_n=every_n_frames,
+                substeps_per_frame=substeps_per_frame,
+                assignment=assignment,
+            )
+            self._thermal_animated_history = history
+            self._thermal_animated_frames = frames
+            self._thermal_animated_defaults = defaults
+            # Colormap range spans EVERY solved frame (not just the last), since the
+            # animated field keeps evolving -- a final-frame-only range would clip the
+            # preview against later, hotter frames.
+            self._thermal_temp_range = adapter.global_temperature_range_animated(history, initial_temperature_K)
+            # Stamp/register BEFORE writing frame 0: stamp_default_temperatures blindly
+            # sets heatsim_default_temperature = ambient on every mesh, which would
+            # clobber the correct per-object Dirichlet-reservoir fallback that
+            # _thermal_write_frame -> write_frame_attributes just set for any
+            # DIRICHLET_SOURCE absent from the animated history (e.g. a topology-
+            # changing fluid). Running it first means frame 0's write wins.
+            thermal_shader.stamp_default_temperatures(self.scene, default_K=initial_temperature_K)
+            thermal_shader.setup_temperature_aov(self.scene, self.view_layer)
+            # Write the first solved frame immediately so a render taken before
+            # exposed_render_frame's per-frame hook runs still sees a correct field.
+            if frames:
+                self._thermal_write_frame(frames[0])
+            return
+
+        history, atlas_plan, cache_root = self._thermal_solve(
+            initial_temperature_K=initial_temperature_K,
+            thermal_diffusivity_mm2_s=thermal_diffusivity_mm2_s,
+            density_kg_m3=density_kg_m3,
+            specific_heat_J_kgK=specific_heat_J_kgK,
+            emissivity=emissivity,
+            irradiance_scale=irradiance_scale,
+            sim_time_s=sim_time_s,
+            timestep_s=timestep_s,
+            domain=domain,
+            laplacian_backend=laplacian_backend,
+            irradiance_source=irradiance_source,
+            bake_samples=bake_samples,
+            irradiance_texture_size=irradiance_texture_size,
+            device=device,
+            assignments=assignments,
+            render_domain=render_domain,
+            atlas_texel_density=atlas_texel_density,
+            atlas_tile_min=atlas_tile_min,
+            atlas_tile_max=atlas_tile_max,
+            atlas_texel_soft_max=atlas_texel_soft_max,
+        )
+        self._thermal_atlas_plan = atlas_plan
+        # Stamp BEFORE writing frame attributes: stamp_default_temperatures blindly sets
+        # heatsim_default_temperature = ambient on every mesh, which would clobber the
+        # correct per-object Dirichlet-reservoir fallback that write_frame_attributes is about
+        # to set below for any unsolved DIRICHLET_SOURCE object -- including atlas participants,
+        # whose fallback is the ONLY temperature ever written to their mesh. Running it first
+        # means write_frame_attributes's write wins (same fix/rationale as the animated branch
+        # above). setup_temperature_aov, unlike stamp, is NOT moved up here: its atlas-sampling
+        # node graph looks up the packed atlas image by name at call time, so it must stay
+        # after write_atlas/_thermal_load_pack_atlas_image below (where that image first exists).
+        thermal_shader.stamp_default_temperatures(self.scene, default_K=initial_temperature_K)
+
+        # Pass the FULL global material defaults: post-I1 ``resolve_material`` reads
+        # these as the fallback for any per-object property that was not explicitly
+        # set (e.g. emissivity), so a partial dict would KeyError on unset meshes.
+        adapter.write_frame_attributes(
+            self.scene,
+            history,
+            -1,
+            {
+                "initial_temperature_K": initial_temperature_K,
+                "thermal_diffusivity_mm2_s": thermal_diffusivity_mm2_s,
+                "density_kg_m3": density_kg_m3,
+                "specific_heat_J_kgK": specific_heat_J_kgK,
+                "emissivity": emissivity,
+            },
+            assignment=self._thermal_assignment,
+            atlas_plan=atlas_plan,
+        )
+        # Global temperature range for the preview colormap, spanning the solved
+        # scene's actual data instead of a fixed band -- already pools TEXEL objects'
+        # texel temperatures the same way as VERTEX objects' vertex temperatures, since
+        # `history` doesn't distinguish the two. Stashed on the service so
+        # ``include_thermal`` (a separate call on the same instance) can read it.
+        self._thermal_temp_range = adapter.global_temperature_range(history, initial_temperature_K)
+
+        if atlas_plan is not None and atlas_plan.texels:
+            atlas_path = adapter.write_atlas(history, atlas_plan, cache_root)
+            self._thermal_load_pack_atlas_image(atlas_path)
+
+        thermal_shader.setup_temperature_aov(self.scene, self.view_layer)
+
+    def _thermal_write_frame(self, frame_number: int) -> None:
+        """Write the animated thermal field for the render frame nearest a solved timestep.
+
+        Called once from :meth:`exposed_prepare_thermal`'s animated branch (frame 0, right
+        after the animated solve) and per-frame from :meth:`exposed_render_frame`. Looks up
+        the latest solved frame at or before ``frame_number`` (``every_n_frames`` may hold the
+        field across skipped frames), builds a single-row ``{obj: (1, n_verts)}`` history
+        slice for that frame, and delegates to ``adapter.write_frame_attributes``. Objects
+        absent from the animated history (e.g. ``DIRICHLET_SOURCE`` fluids with changing
+        topology) fall through to the reservoir-temperature fallback there.
+
+        Args:
+            frame_number (int): The (Blender) frame currently being written/rendered.
+        """
+        frames = self._thermal_animated_frames
+        history = self._thermal_animated_history
+        defaults = self._thermal_animated_defaults
+        if not frames or history is None or defaults is None:
+            return
+
+        from visionsim.simulate.heatsim import adapter
+
+        solved = max((f for f in frames if f <= frame_number), default=frames[0])
+        idx = frames.index(solved)
+        frame_history = {name: hist[idx][None, :] for name, hist in history.items()}
+        adapter.write_frame_attributes(self.scene, frame_history, 0, defaults, assignment=self._thermal_assignment)
+
+    @require_initialized_service
+    def exposed_heatsim_solve(
+        self,
+        radiance: bool = True,
+        preview: bool = True,
+        initial_temperature_K: float = 295.0,
+        thermal_diffusivity_mm2_s: float = 0.17,
+        density_kg_m3: float = 1330.0,
+        specific_heat_J_kgK: float = 880.0,
+        emissivity: float = 0.9,
+        irradiance_scale: float = 100.0,
+        sim_time_s: float = 1.0,
+        timestep_s: float = 0.05,
+        domain: Literal["POINTS", "MESH"] = "POINTS",
+        laplacian_backend: Literal["ROBUST", "IGL"] = "ROBUST",
+        irradiance_source: Literal["DIRECT_KERNEL", "CYCLES_BAKE"] = "DIRECT_KERNEL",
+        bake_samples: int = 1024,
+        irradiance_texture_size: int = 512,
+        device: Literal["cuda", "cpu"] = "cuda",
+        render_domain: Literal["VERTEX", "TEXEL"] = "VERTEX",
+        atlas_texel_density: float = 1500.0,
+        atlas_tile_min: int = 16,
+        atlas_tile_max: int = 512,
+        atlas_texel_soft_max: int = 500_000,
+        radiance_scale: float = 1.0,
+        exr_codec: EXR_CODECS = "DWAA",
+        bit_depth: Literal[16, 32] = 32,
+        animated: bool = False,
+        substeps_per_frame: int = 4,
+        frame_start: int | None = None,
+        frame_end: int | None = None,
+        every_n_frames: int = 1,
+        assignments: str | None = None,
+    ) -> None:
+        """Solve and cache the scene's heat-transfer simulation without preparing it for rendering.
+
+        This is the solve-and-cache half of
+        :meth:`prepare_thermal <visionsim.simulate.blender.BlenderService.exposed_prepare_thermal>`: it runs the
+        cache-aware FEM solve so the result is written to disk, but does not write the ``sim_temperature`` attribute,
+        stamp default temperatures, or register the ``temperature`` AOV. It exists for the optional standalone
+        solve command, letting an expensive solve be primed ahead of rendering. The full ``ThermalConfig`` field set
+        is accepted so a single ``**asdict(config.thermal)`` dispatch can drive this method; the output-only fields
+        are ignored. When ``render_domain="TEXEL"``, this also primes the atlas-eligible objects' texel solve (via
+        the same cache key ``prepare_thermal`` would use), but does NOT write the atlas EXR image -- that happens
+        in ``prepare_thermal``, which needs the loaded/packed image to wire the shader.
+
+        Note:
+            The ``animated``/``substeps_per_frame``/``frame_start``/``frame_end``/``every_n_frames`` fields are
+            accepted only to mirror ``ThermalConfig``; this standalone cache-priming path always runs the static
+            solve regardless of ``animated``.
+
+        Args:
+            radiance (bool, optional): Accepted for uniform thermal-config dispatch; not used by this method (consumed
+                by ``include_thermal`` / the radiance render). Defaults to True.
+            preview (bool, optional): Accepted for uniform thermal-config dispatch; not used by this method (consumed
+                by ``include_thermal`` / the radiance render). Defaults to True.
+            initial_temperature_K (float, optional): Default initial temperature, in Kelvin, for meshes without a
+                per-object value. Defaults to 295.0.
+            thermal_diffusivity_mm2_s (float, optional): Default thermal diffusivity in ``mm^2/s``. Defaults to 0.17.
+            density_kg_m3 (float, optional): Default material density in ``kg/m^3``. Defaults to 1330.0.
+            specific_heat_J_kgK (float, optional): Default specific heat in ``J/kg*K``. Defaults to 880.0.
+            emissivity (float, optional): Default surface emissivity in ``[0, 1]``. Defaults to 0.9.
+            irradiance_scale (float, optional): Scale factor applied to the computed irradiance (heating input).
+                Defaults to 100.0.
+            sim_time_s (float, optional): Total simulated time, in seconds, for the static scene solve. Defaults to 1.0.
+            timestep_s (float, optional): Solver timestep in seconds. Defaults to 0.05.
+            domain (str, optional): FEM domain, either ``"POINTS"`` (surface point cloud, recommended) or ``"MESH"``.
+                Defaults to ``"POINTS"``.
+            laplacian_backend (str, optional): Laplacian backend, either ``"ROBUST"`` or ``"IGL"``. Defaults to ``"ROBUST"``.
+            irradiance_source (str, optional): Where absorbed flux comes from. ``"DIRECT_KERNEL"`` is the
+                analytic path (lamp objects plus an SH sky, no indirect bounce); ``"CYCLES_BAKE"`` bakes
+                DIFFUSE DIRECT+INDIRECT per object, so emissive geometry and bounce contribute.
+                Defaults to ``"DIRECT_KERNEL"``.
+            bake_samples (int, optional): Cycles samples for the irradiance bake (``CYCLES_BAKE`` only), with
+                adaptive sampling disabled so this is a true per-texel count. Defaults to 1024.
+            irradiance_texture_size (int, optional): Resolution of the Cycles bakes, in pixels per side. Governs
+                the albedo bake and, under ``CYCLES_BAKE``, the irradiance bake. This is the bake's spatial
+                detail, as distinct from ``bake_samples``, which is its noise. Defaults to 512.
+            device (str, optional): Torch device for the solve, either ``"cuda"`` or ``"cpu"``; falls back to ``"cpu"``
+                if cuda is unavailable. Defaults to ``"cuda"``.
+            render_domain (str, optional): Where solved temperatures live for rendering: ``"VERTEX"`` (per-vertex,
+                byte-identical to before the atlas existed) or ``"TEXEL"`` (a shared texture atlas, sampled per-pixel
+                by the shader). Defaults to ``"VERTEX"``.
+            atlas_texel_density (float, optional): Target texels/m^2 for atlas-eligible objects (TEXEL mode only).
+                Defaults to 1500.0.
+            atlas_tile_min (int, optional): Minimum atlas tile side, in texels (TEXEL mode only). Defaults to 16.
+            atlas_tile_max (int, optional): Maximum atlas tile side, in texels (TEXEL mode only). Defaults to 512.
+            atlas_texel_soft_max (int, optional): Soft ceiling on total atlas texels + retained vertices (TEXEL mode
+                only); exceeding it rescales the effective density down uniformly and warns. Defaults to 500000.
+            radiance_scale (float, optional): Accepted for uniform thermal-config dispatch; not used by this method
+                (consumed by ``include_thermal`` / the radiance render). Defaults to 1.0.
+            exr_codec (str, optional): Accepted for uniform thermal-config dispatch; not used by this method (consumed
+                by ``include_thermal`` / the radiance render). Defaults to ``"DWAA"``.
+            bit_depth (int, optional): Accepted for uniform thermal-config dispatch; not used by this method (consumed
+                by ``include_thermal`` / the radiance render). Defaults to 32.
+            animated (bool, optional): Accepted for uniform thermal-config dispatch; not used by this method (see
+                Note above). Defaults to False.
+            substeps_per_frame (int, optional): Accepted for uniform thermal-config dispatch; not used by this method.
+                Defaults to 4.
+            frame_start (int | None, optional): Accepted for uniform thermal-config dispatch; not used by this method.
+                Defaults to None.
+            frame_end (int | None, optional): Accepted for uniform thermal-config dispatch; not used by this method.
+                Defaults to None.
+            every_n_frames (int, optional): Accepted for uniform thermal-config dispatch; not used by this method.
+                Defaults to 1.
+            assignments (str | None, optional): Path to a thermal material assignment sidecar
+                (``<scene>.thermal.json``). When set, thermal properties are resolved per material
+                slot; when unset the global defaults are used everywhere. Defaults to None.
+        """
+        self._thermal_solve(
+            initial_temperature_K=initial_temperature_K,
+            thermal_diffusivity_mm2_s=thermal_diffusivity_mm2_s,
+            density_kg_m3=density_kg_m3,
+            specific_heat_J_kgK=specific_heat_J_kgK,
+            emissivity=emissivity,
+            irradiance_scale=irradiance_scale,
+            sim_time_s=sim_time_s,
+            timestep_s=timestep_s,
+            domain=domain,
+            laplacian_backend=laplacian_backend,
+            irradiance_source=irradiance_source,
+            bake_samples=bake_samples,
+            irradiance_texture_size=irradiance_texture_size,
+            device=device,
+            assignments=assignments,
+            render_domain=render_domain,
+            atlas_texel_density=atlas_texel_density,
+            atlas_tile_min=atlas_tile_min,
+            atlas_tile_max=atlas_tile_max,
+            atlas_texel_soft_max=atlas_texel_soft_max,
+        )
+
+    @require_initialized_service
+    def exposed_include_thermal(
+        self,
+        radiance: bool = True,
+        preview: bool = True,
+        initial_temperature_K: float = 295.0,
+        thermal_diffusivity_mm2_s: float = 0.17,
+        density_kg_m3: float = 1330.0,
+        specific_heat_J_kgK: float = 880.0,
+        emissivity: float = 0.9,
+        irradiance_scale: float = 100.0,
+        sim_time_s: float = 1.0,
+        timestep_s: float = 0.05,
+        domain: Literal["POINTS", "MESH"] = "POINTS",
+        laplacian_backend: Literal["ROBUST", "IGL"] = "ROBUST",
+        irradiance_source: Literal["DIRECT_KERNEL", "CYCLES_BAKE"] = "DIRECT_KERNEL",
+        bake_samples: int = 1024,
+        irradiance_texture_size: int = 512,
+        device: Literal["cuda", "cpu"] = "cuda",
+        render_domain: Literal["VERTEX", "TEXEL"] = "VERTEX",
+        atlas_texel_density: float = 1500.0,
+        atlas_tile_min: int = 16,
+        atlas_tile_max: int = 512,
+        atlas_texel_soft_max: int = 500_000,
+        radiance_scale: float = 1.0,
+        exr_codec: EXR_CODECS = "DWAA",
+        bit_depth: Literal[16, 32] = 32,
+        animated: bool = False,
+        substeps_per_frame: int = 4,
+        frame_start: int | None = None,
+        frame_end: int | None = None,
+        every_n_frames: int = 1,
+        assignments: str | None = None,
+    ) -> None:
+        """Sets up Blender compositor to include thermal outputs for rendered images.
+
+        Wires the per-vertex temperature map (in Kelvin) from the ``temperature`` AOV registered by
+        :meth:`prepare_thermal <visionsim.simulate.blender.BlenderService.exposed_prepare_thermal>` into the
+        compositor, optionally adds an inferno-colormap preview, and optionally arms a second gray-body render pass
+        that produces a thermal-camera radiance image (emitted at render time by
+        :meth:`render_current_frame <visionsim.simulate.blender.BlenderService.exposed_render_current_frame>`).
+
+        Note:
+            This must be called after ``prepare_thermal``, which registers the ``temperature`` AOV (and, in TEXEL
+            mode, loads/packs the ``HeatSim_Temperature_Atlas`` image the shader samples) and exposes the matching
+            render-layer output socket. The solver and material parameters (``initial_temperature_K`` through
+            ``device``, the ``render_domain``/``atlas_*`` fields, ``assignments``, and the ``animated``/
+            ``substeps_per_frame``/``frame_start``/``frame_end``/``every_n_frames`` animated fields) are accepted only to
+            mirror ``ThermalConfig`` and are consumed by ``prepare_thermal``; ``include_thermal`` itself ignores them.
+            For animated scenes, the per-frame field update happens later, in
+            :meth:`render_frame <visionsim.simulate.blender.BlenderService.exposed_render_frame>`.
+
+        Args:
+            radiance (bool, optional): If true, arm the gray-body thermal-camera radiance image as a second render
+                pass and register its per-frame output. Defaults to True.
+            preview (bool, optional): If true, also save an inferno-colormap PNG preview of the temperature map.
+                Defaults to True.
+            initial_temperature_K (float, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and
+                ignored here. Default initial temperature, in Kelvin, for meshes without a per-object value.
+                Defaults to 295.0.
+            thermal_diffusivity_mm2_s (float, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal``
+                and ignored here. Default thermal diffusivity in ``mm^2/s``. Defaults to 0.17.
+            density_kg_m3 (float, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and ignored
+                here. Default material density in ``kg/m^3``. Defaults to 1330.0.
+            specific_heat_J_kgK (float, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and
+                ignored here. Default specific heat in ``J/kg*K``. Defaults to 880.0.
+            emissivity (float, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and ignored
+                here. Default surface emissivity in ``[0, 1]``. Defaults to 0.9.
+            irradiance_scale (float, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and
+                ignored here. Scale factor applied to the computed irradiance. Defaults to 100.0.
+            sim_time_s (float, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and ignored
+                here. Total simulated time in seconds. Defaults to 1.0.
+            timestep_s (float, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and ignored
+                here. Solver timestep in seconds. Defaults to 0.05.
+            domain (str, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and ignored here.
+                FEM domain, either ``"POINTS"`` or ``"MESH"``. Defaults to ``"POINTS"``.
+            laplacian_backend (str, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and
+                ignored here. Laplacian backend, either ``"ROBUST"`` or ``"IGL"``. Defaults to ``"ROBUST"``.
+            irradiance_source (str, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and
+                ignored here. Where absorbed flux comes from, either ``"DIRECT_KERNEL"`` or ``"CYCLES_BAKE"``.
+                Defaults to ``"DIRECT_KERNEL"``.
+            bake_samples (int, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and ignored
+                here. Cycles samples for the irradiance bake, adaptive sampling disabled. Defaults to 1024.
+            irradiance_texture_size (int, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal``
+                and ignored here. Resolution of the Cycles bakes in pixels per side. Defaults to 512.
+            device (str, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and ignored here.
+                Torch device, either ``"cuda"`` or ``"cpu"``. Defaults to ``"cuda"``.
+            render_domain (str, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and ignored
+                here. Where solved temperatures live for rendering, ``"VERTEX"`` or ``"TEXEL"``. Defaults to
+                ``"VERTEX"``.
+            atlas_texel_density (float, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and
+                ignored here. Target texels/m^2 for atlas-eligible objects. Defaults to 1500.0.
+            atlas_tile_min (int, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and ignored
+                here. Minimum atlas tile side, in texels. Defaults to 16.
+            atlas_tile_max (int, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and ignored
+                here. Maximum atlas tile side, in texels. Defaults to 512.
+            atlas_texel_soft_max (int, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and
+                ignored here. Soft ceiling on total atlas texels + retained vertices. Defaults to 500000.
+            radiance_scale (float, optional): Gray-body emission magnitude knob for the ``thermal_radiance`` render.
+                Defaults to 1.0.
+            exr_codec (str, optional): Codec used to compress the temperature and radiance EXR files. Options vary
+                depending on the version of Blender, with the following being broadly available:
+                ('NONE', 'PXR24', 'ZIP', 'PIZ', 'RLE', 'ZIPS', 'DWAA', 'DWAB'). Defaults to ``"DWAA"``.
+            bit_depth (int, optional): Bit depth per channel for the temperature and radiance EXRs, either 16 or 32.
+                Defaults to 32.
+            animated (bool, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and ignored
+                here. Defaults to False.
+            substeps_per_frame (int, optional): Mirrors ``ThermalConfig`` ; consumed by ``prepare_thermal`` and
+                ignored here. Defaults to 4.
+            frame_start (int | None, optional): Mirrors ``ThermalConfig`` ; consumed by ``prepare_thermal`` and
+                ignored here. Defaults to None.
+            frame_end (int | None, optional): Mirrors ``ThermalConfig`` ; consumed by ``prepare_thermal`` and
+                ignored here. Defaults to None.
+            every_n_frames (int, optional): Mirrors ``ThermalConfig`` ; consumed by ``prepare_thermal`` and
+                ignored here. Defaults to 1.
+            assignments (str | None, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and
+                ignored here. Path to a thermal material assignment sidecar (``<scene>.thermal.json``). Defaults
+                to None.
+        """
+        # Temperature ground-truth output (Kelvin), driven by the "temperature" AOV
+        # registered by prepare_thermal via setup_temperature_aov.
+        self._include_output(
+            "temperature",
+            self.render_layers.outputs["temperature"],
+            label="Temperature Output",
+            file_format="OPEN_EXR",
+            color_mode="BW",
+            exr_codec=exr_codec,
+            bit_depth=bit_depth,
+            c=1,
+        )
+
+        if preview:
+            from visionsim.simulate.nodes import thermal_preview_node_group
+
+            # Span the colormap over the solved scene's actual temperature range
+            # (computed in prepare_thermal) instead of the fixed 295-400 K default,
+            # so low-dT scenes are not crushed to the dark end of inferno.
+            rng = getattr(self, "_thermal_temp_range", None)
+            group = self.tree.nodes.new("CompositorNodeGroup")
+            group.label = "Thermal Preview"
+            group.node_tree = (
+                thermal_preview_node_group(tmin=rng[0], tmax=rng[1])
+                if rng is not None
+                else thermal_preview_node_group()
+            )
+            self.tree.links.new(self.render_layers.outputs["temperature"], group.inputs["Temperature"])
+            # heat-sim writes srgb_encode(inferno_lut) as its PNG; the compositor
+            # inferno output is scene-linear, so display-encode it with the
+            # Standard (sRGB) view transform instead of the preview default "Raw".
+            self._include_output(
+                "previews/temperature",
+                group.outputs["Image"],
+                label="Preview Temperature Output",
+                preview=True,
+                preview_view_transform="Standard",
+                color_mode="RGB",
+                c=3,
+            )
+
+        if radiance:
+            node, (socket,), (slot,) = file_output_node(
+                self.tree,
+                self.root_path / "thermal_radiance" / "0000",
+                label="Thermal Radiance Output",
+                color_mode="RGB",
+            )
+            node.format.color_management = "OVERRIDE"
+            node.format.linear_colorspace_settings.name = "Non-Color"
+            node.format.file_format = "OPEN_EXR"
+            node.format.color_mode = "RGB"
+            node.format.exr_codec = exr_codec
+            node.format.color_depth = str(bit_depth)
+            slot.name = str(Path(slot.name).with_suffix(FORMATS["OPEN_EXR"]))
+
+            self.tree.links.new(self.render_layers.outputs["Image"], socket)
+            self.register_output_type("thermal_radiance", node, slot, c=3)
+            # Arm the second render pass only after registration succeeds, so a raise
+            # mid-setup cannot leave the flag truthy with _outputs["thermal_radiance"] missing.
+            self._thermal_radiance = {
+                "radiance_scale": radiance_scale,
+                "exr_codec": exr_codec,
+                "bit_depth": bit_depth,
+            }
+
     @require_initialized_service
     def exposed_load_addons(self, *addons: str) -> None:
         """Load blender addons by name (case-insensitive).
@@ -1894,8 +2720,60 @@ class BlenderService(rpyc.Service):
         if not dry_run:  # noqa: SIM102
             # Render frame(s), skip the render iff all files exist and `allow_skips`
             if not allow_skips or any(not Path(self.root_path / p).exists() for p in paths.values()):
-                # If `write_still` is false, depth/normals/etc can be written but composites will be skipped
-                bpy.ops.render.render(animation=False, write_still="composites" in self._outputs)
+                # Snapshot original node mute states and pre-mute thermal_radiance so the
+                # main render does not write an incorrect (RGB-material) radiance file.
+                # The "composites" entry uses `object` as a placeholder (no real .mute),
+                # so we skip it; composites are suppressed in the second pass by write_still=False.
+                # `_orig_mute` is bound before the guard so the finally always restores cleanly,
+                # and a single outer try/finally covers BOTH render passes: if the main render
+                # raises, thermal_radiance.mute is still restored (otherwise it would stay muted
+                # permanently across subsequent frames, silently dropping radiance output).
+                _thermal_armed = getattr(self, "_thermal_radiance", None)
+                _orig_mute: dict[str, bool] = {}
+                _thermal_state = None
+                try:
+                    if _thermal_armed:
+                        from visionsim.simulate.heatsim import thermal_shader
+
+                        for _sp, _entry in self._outputs.items():
+                            if _sp != "composites":
+                                _orig_mute[_sp] = _entry[0].mute
+                        self._outputs["thermal_radiance"][0].mute = True
+
+                    # If `write_still` is false, depth/normals/etc can be written but composites will be skipped
+                    bpy.ops.render.render(animation=False, write_still="composites" in self._outputs)
+
+                    # Thermal radiance second render pass: swap to gray-body materials and re-render
+                    # so the `thermal_radiance` output node captures the emitted thermal-camera radiance
+                    # for this frame. The node path reuses the same per-frame indexing as the main loop.
+                    if _thermal_armed:
+                        node, slot, *_ = self._outputs["thermal_radiance"]
+                        if bpy.app.version >= (5, 0, 0):
+                            node.directory = str(self.root_path / "thermal_radiance" / folder_index)
+                        else:
+                            node.base_path = str(self.root_path / "thermal_radiance" / folder_index)
+                        slot.name = str(Path(slot.name).with_stem(frame_index).name)
+
+                        # Mute every real output-file node except thermal_radiance so only
+                        # the gray-body radiance EXR is written during this pass.
+                        for _sp, _entry in self._outputs.items():
+                            if _sp == "composites":
+                                continue
+                            _entry[0].mute = _sp != "thermal_radiance"
+
+                        _thermal_state = thermal_shader.enter_thermal_scene(
+                            self.scene, radiance_scale=self._thermal_radiance["radiance_scale"]
+                        )
+                        bpy.ops.render.render(animation=False, write_still=False)
+                finally:
+                    # Restore the thermal scene (if entered) and all node mute states to their
+                    # pre-render originals, regardless of which render pass (if any) raised.
+                    if _thermal_state is not None:
+                        from visionsim.simulate.heatsim import thermal_shader
+
+                        thermal_shader.restore_scene(self.scene, _thermal_state)
+                    for _sp, _was_muted in _orig_mute.items():
+                        self._outputs[_sp][0].mute = _was_muted
 
         # Before Blender 5.0 file output nodes ALWAYS appended the frame number
         # to the filename making our path incorrect, here we rename the file.
@@ -1921,6 +2799,13 @@ class BlenderService(rpyc.Service):
         Warning:
             Calling this has the side-effect of changing the current frame.
 
+        Note:
+            If :meth:`prepare_thermal <exposed_prepare_thermal>` ran an animated  solve,
+            this writes that frame's solved thermal field (via ``_thermal_write_frame``)
+            before rendering, so both the temperature AOV and the gray-body radiance pass
+            reflect the current frame -- Cycles reads ``sim_temperature`` live, so no
+            compositor changes are needed.
+
         Args:
             frame_number (int): frame to render
             allow_skips (bool, optional): if true, blender will not re-render and overwrite existing frames.
@@ -1928,6 +2813,8 @@ class BlenderService(rpyc.Service):
             dry_run (bool, optional): if true, nothing will be rendered at all. Defaults to False.
         """
         self.exposed_set_current_frame(frame_number)
+        if getattr(self, "_thermal_animated_history", None) is not None:
+            self._thermal_write_frame(frame_number)
         self.exposed_render_current_frame(allow_skips=allow_skips, dry_run=dry_run)
 
     @require_initialized_service

--- a/visionsim/simulate/blender.pyi
+++ b/visionsim/simulate/blender.pyi
@@ -213,6 +213,12 @@ class BlenderService(rpyc.Service):
     _warned_no_outputs: bool
     _outputs: dict[str, Any]
     _camera: bpy.types.Camera | None
+    _thermal_radiance: dict[str, Any] | None
+    _thermal_animated_history: dict[str, Any] | None
+    _thermal_animated_frames: list[int] | None
+    _thermal_animated_defaults: dict[str, Any] | None
+    _thermal_assignment: Any | None
+    _thermal_atlas_plan: Any | None
 
     def __init__(self) -> None:
         """Initialize render service.
@@ -284,6 +290,7 @@ class BlenderService(rpyc.Service):
         exr_codec: EXR_CODECS = "DWAA",
         bit_depth: int = 32,
         preview: bool = False,
+        preview_view_transform: str | None = None,
         c: int | None = None,
         denoise: bool = False,
     ) -> None:
@@ -298,6 +305,9 @@ class BlenderService(rpyc.Service):
             exr_codec (str, optional): EXR codec to use. Defaults to "DWAA".
             bit_depth (int, optional): Bit depth to use. Defaults to 32.
             preview (bool, optional): If true, output node will be configured for preview. Defaults to False.
+            preview_view_transform (str, optional): When set on a preview output, overrides the preview
+                default "Raw" view transform (e.g. "Standard" to sRGB-encode a colormapped image).
+                Ignored for non-preview outputs. Defaults to None (leave the preview default "Raw").
             c (int, optional): Number of channels for registration. Defaults to None (inferred from color_mode).
             denoise (bool, optional): If true, insert a denoise compositor node before the file output.
                 This enables the Cycles denoising data view layer passes (albedo and normal) and connects
@@ -691,6 +701,422 @@ class BlenderService(rpyc.Service):
         .. [2] `DUSt3R: Geometric 3D Vision Made Easy with Unconstrained Image Collections <https://arxiv.org/abs/2312.14132>`_
         """
 
+    def _thermal_config(
+        self,
+        *,
+        initial_temperature_K: float,
+        thermal_diffusivity_mm2_s: float,
+        density_kg_m3: float,
+        specific_heat_J_kgK: float,
+        emissivity: float,
+        irradiance_scale: float,
+        sim_time_s: float,
+        timestep_s: float,
+        domain: Literal["POINTS", "MESH"],
+        laplacian_backend: Literal["ROBUST", "IGL"],
+        irradiance_source: Literal["DIRECT_KERNEL", "CYCLES_BAKE"] = "DIRECT_KERNEL",
+        bake_samples: int = 1024,
+        irradiance_texture_size: int = 512,
+        device: Literal["cuda", "cpu"],
+        assignments: str | None = None,
+    ) -> tuple[dict, dict, Path, Any]:
+        """Shared ``defaults``/``solver_cfg``/``cache_root`` builder for every thermal-solve
+        entry point.
+
+        Factored out of :meth:`_thermal_solve` (M2) so the static solve
+        (``adapter.solve_scene``) and the animated solve (``adapter.solve_scene_animated``,
+        called from :meth:`exposed_prepare_thermal`'s animated branch) compute byte-identical
+        ``defaults``/``solver_cfg`` -- including the blend-authored ``irradiance_scale``
+        override -- and therefore share the same cache-key convention.
+
+        Returns:
+            tuple[dict, dict, Path, Any]: ``(defaults, solver_cfg, cache_root, assignment)``.
+        """
+
+    def _thermal_solve(
+        self,
+        *,
+        initial_temperature_K: float,
+        thermal_diffusivity_mm2_s: float,
+        density_kg_m3: float,
+        specific_heat_J_kgK: float,
+        emissivity: float,
+        irradiance_scale: float,
+        sim_time_s: float,
+        timestep_s: float,
+        domain: Literal["POINTS", "MESH"],
+        laplacian_backend: Literal["ROBUST", "IGL"],
+        irradiance_source: Literal["DIRECT_KERNEL", "CYCLES_BAKE"] = "DIRECT_KERNEL",
+        bake_samples: int = 1024,
+        irradiance_texture_size: int = 512,
+        device: Literal["cuda", "cpu"],
+        assignments: str | None = None,
+        render_domain: Literal["VERTEX", "TEXEL"] = "VERTEX",
+        atlas_texel_density: float = 1500.0,
+        atlas_tile_min: int = 16,
+        atlas_tile_max: int = 512,
+        atlas_texel_soft_max: int = 500000,
+    ) -> tuple[dict, Any, Path]:
+        """Shared FEM-solve core used by :meth:`exposed_prepare_thermal` and
+        :meth:`exposed_heatsim_solve`.
+
+        Builds the ``defaults`` and ``solver_cfg`` dicts (via :meth:`_thermal_config`),
+        derives ``cache_root`` from the always-set :attr:`blend_file` path (avoids
+        ``bpy.data.filepath`` which is empty for an unsaved scene), and delegates to
+        ``adapter.solve_scene``.  Both callers produce identical cache keys
+        because they share this single code path.
+
+        When ``render_domain="TEXEL"``, builds an ``adapter.AtlasPlan`` (``adapter.
+        build_atlas_plan``) from the 4 ``atlas_*`` knobs BEFORE solving and threads it
+        through to ``adapter.solve_scene``, which folds the plan's effective density/tile
+        bounds/layout digest into the solve cache key (Task 2's existing ``"atlas"`` key
+        field). ``render_domain="VERTEX"`` (the default) never builds a plan, so the solve
+        cache key and ``adapter.solve_scene``/``adapter._combine`` code path are exactly
+        what they were before the atlas existed.
+
+        Returns:
+            tuple[dict, Any, Path]: ``(history, atlas_plan, cache_root)`` -- ``atlas_plan``
+            is ``None`` in VERTEX mode (or when TEXEL mode found nothing eligible).
+        """
+
+    def _thermal_load_pack_atlas_image(self, atlas_path: Path) -> None:
+        """Load the EXR :func:`adapter.write_atlas` wrote and (re)register it as the
+        ``HeatSim_Temperature_Atlas`` Blender image, packed so the shader (built right
+        after this call, by ``thermal_shader.setup_temperature_aov``, and later at render
+        time by ``thermal_shader.enter_thermal_scene``) can find it by name -- and so it
+        keeps working even if the source EXR under the ``.heatsim`` cache directory later
+        moves or is cleaned up.
+        """
+    _thermal_temp_range: Incomplete
+
+    @require_initialized_service
+    def exposed_prepare_thermal(
+        self,
+        radiance: bool = True,
+        preview: bool = True,
+        initial_temperature_K: float = 295.0,
+        thermal_diffusivity_mm2_s: float = 0.17,
+        density_kg_m3: float = 1330.0,
+        specific_heat_J_kgK: float = 880.0,
+        emissivity: float = 0.9,
+        irradiance_scale: float = 100.0,
+        sim_time_s: float = 1.0,
+        timestep_s: float = 0.05,
+        domain: Literal["POINTS", "MESH"] = "POINTS",
+        laplacian_backend: Literal["ROBUST", "IGL"] = "ROBUST",
+        device: Literal["cuda", "cpu"] = "cuda",
+        render_domain: Literal["VERTEX", "TEXEL"] = "VERTEX",
+        atlas_texel_density: float = 1500.0,
+        atlas_tile_min: int = 16,
+        atlas_tile_max: int = 512,
+        atlas_texel_soft_max: int = 500000,
+        radiance_scale: float = 1.0,
+        exr_codec: EXR_CODECS = "DWAA",
+        bit_depth: Literal[16, 32] = 32,
+        animated: bool = False,
+        substeps_per_frame: int = 4,
+        frame_start: int | None = None,
+        frame_end: int | None = None,
+        every_n_frames: int = 1,
+        assignments: str | None = None,
+    ) -> None:
+        """Solve the scene's heat-transfer simulation and prepare it for thermal rendering.
+
+        Runs the (cache-aware) FEM solve, writes the solved per-vertex ``sim_temperature``
+        attribute onto every mesh, stamps a default temperature on any unsolved mesh, and
+        registers the ``temperature`` value AOV on the original materials.
+
+        Note:
+            This must be called before :meth:`include_thermal <visionsim.simulate.blender.BlenderService.exposed_include_thermal>`,
+            since the AOV is registered on the original materials and exposes the ``temperature`` render-layer
+            output socket that ``include_thermal`` wires into the compositor. M1 is a static solve, so the final
+            timestep (``timestep=-1``) is written to every frame. When ``animated`` is true (M2, ``domain="POINTS"``
+            only), a per-frame transient solve is run instead (``adapter.solve_scene_animated``): the per-object
+            frame history is stashed on the service and the first solved frame's field is written immediately so the
+            initial render is correct; subsequent frames are written by :meth:`exposed_render_frame`'s per-frame
+            hook. Requesting ``animated`` with ``domain="MESH"`` logs a warning and falls back to the static solve.
+            The full ``ThermalConfig`` field set is accepted so a single ``**asdict(config.thermal)`` dispatch can
+            drive this method; the output-only fields are ignored. When ``render_domain="TEXEL"``, atlas-eligible
+            objects (see ``atlas_texel_density``) are additionally solved at texel resolution and their final
+            temperatures are written to an EXR atlas image (``adapter.write_atlas``), loaded/packed as the
+            ``HeatSim_Temperature_Atlas`` Blender image before the AOV is registered so the shader can sample it;
+            those objects get only the OBJECT-level fallback temperature written to their mesh (their per-pixel
+            signal comes from the atlas at render time), not a per-vertex ``sim_temperature`` attribute. Requesting
+            ``animated`` with ``render_domain="TEXEL"`` logs a warning and falls back to ``render_domain="VERTEX"``
+            for that solve (the atlas is a static-solve-only feature; M2/TEXEL is out of scope).
+
+        Args:
+            radiance (bool, optional): Accepted for uniform thermal-config dispatch; not used by this method (consumed
+                by ``include_thermal`` / the radiance render). Defaults to True.
+            preview (bool, optional): Accepted for uniform thermal-config dispatch; not used by this method (consumed
+                by ``include_thermal`` / the radiance render). Defaults to True.
+            initial_temperature_K (float, optional): Default initial temperature, in Kelvin, for meshes without a
+                per-object value. Defaults to 295.0.
+            thermal_diffusivity_mm2_s (float, optional): Default thermal diffusivity in ``mm^2/s``. Defaults to 0.17.
+            density_kg_m3 (float, optional): Default material density in ``kg/m^3``. Defaults to 1330.0.
+            specific_heat_J_kgK (float, optional): Default specific heat in ``J/kg*K``. Defaults to 880.0.
+            emissivity (float, optional): Default surface emissivity in ``[0, 1]``. Defaults to 0.9.
+            irradiance_scale (float, optional): Scale factor applied to the computed irradiance (heating input).
+                Defaults to 100.0.
+            sim_time_s (float, optional): Total simulated time, in seconds, for the static scene solve. Defaults to 1.0.
+            timestep_s (float, optional): Solver timestep in seconds. Defaults to 0.05.
+            domain (str, optional): FEM domain, either ``"POINTS"`` (surface point cloud, recommended) or ``"MESH"``.
+                Defaults to ``"POINTS"``.
+            laplacian_backend (str, optional): Laplacian backend, either ``"ROBUST"`` or ``"IGL"``. Defaults to ``"ROBUST"``.
+            device (str, optional): Torch device for the solve, either ``"cuda"`` or ``"cpu"``; falls back to ``"cpu"``
+                if cuda is unavailable. Defaults to ``"cuda"``.
+            render_domain (str, optional): Where solved temperatures live for rendering: ``"VERTEX"`` (per-vertex,
+                byte-identical to before the atlas existed) or ``"TEXEL"`` (a shared texture atlas, sampled per-pixel
+                by the shader). Defaults to ``"VERTEX"``.
+            atlas_texel_density (float, optional): Target texels/m^2 for atlas-eligible objects (TEXEL mode only).
+                Defaults to 1500.0.
+            atlas_tile_min (int, optional): Minimum atlas tile side, in texels (TEXEL mode only). Defaults to 16.
+            atlas_tile_max (int, optional): Maximum atlas tile side, in texels (TEXEL mode only). Defaults to 512.
+            atlas_texel_soft_max (int, optional): Soft ceiling on total atlas texels + retained vertices (TEXEL mode
+                only); exceeding it rescales the effective density down uniformly and warns. Defaults to 500000.
+            radiance_scale (float, optional): Accepted for uniform thermal-config dispatch; not used by this method
+                (consumed by ``include_thermal`` / the radiance render). Defaults to 1.0.
+            exr_codec (str, optional): Accepted for uniform thermal-config dispatch; not used by this method (consumed
+                by ``include_thermal`` / the radiance render). Defaults to ``"DWAA"``.
+            bit_depth (int, optional): Accepted for uniform thermal-config dispatch; not used by this method (consumed
+                by ``include_thermal`` / the radiance render). Defaults to 32.
+            animated (bool, optional): Solve heat transfer per-frame as geometry animates (transient), instead of the
+                static M1 solve. Requires ``domain="POINTS"``. Defaults to False.
+            substeps_per_frame (int, optional): Solver substeps per Blender frame in animated mode. Defaults to 4.
+            frame_start (int | None, optional): First frame of the animated solve; defaults to the scene's
+                ``frame_start`` when None. Defaults to None.
+            frame_end (int | None, optional): Last frame of the animated solve; defaults to the scene's
+                ``frame_end`` when None. Defaults to None.
+            every_n_frames (int, optional): Solve every Nth frame in animated mode (cost control); skipped frames
+                hold the last solved field. Defaults to 1.
+            assignments (str | None, optional): Path to a thermal material assignment sidecar
+                (``<scene>.thermal.json``). When set, thermal properties are resolved per material
+                slot; when unset the global defaults are used everywhere. Defaults to None.
+        """
+
+    def _thermal_write_frame(self, frame_number: int) -> None:
+        """Write the animated (M2) thermal field for the render frame nearest a solved timestep.
+
+        Called once from :meth:`exposed_prepare_thermal`'s animated branch (frame 0, right
+        after the animated solve) and per-frame from :meth:`exposed_render_frame`. Looks up
+        the latest solved frame at or before ``frame_number`` (``every_n_frames`` may hold the
+        field across skipped frames), builds a single-row ``{obj: (1, n_verts)}`` history
+        slice for that frame, and delegates to ``adapter.write_frame_attributes``. Objects
+        absent from the animated history (e.g. ``DIRICHLET_SOURCE`` fluids with changing
+        topology) fall through to the reservoir-temperature fallback there.
+
+        Args:
+            frame_number (int): The (Blender) frame currently being written/rendered.
+        """
+
+    @require_initialized_service
+    def exposed_heatsim_solve(
+        self,
+        radiance: bool = True,
+        preview: bool = True,
+        initial_temperature_K: float = 295.0,
+        thermal_diffusivity_mm2_s: float = 0.17,
+        density_kg_m3: float = 1330.0,
+        specific_heat_J_kgK: float = 880.0,
+        emissivity: float = 0.9,
+        irradiance_scale: float = 100.0,
+        sim_time_s: float = 1.0,
+        timestep_s: float = 0.05,
+        domain: Literal["POINTS", "MESH"] = "POINTS",
+        laplacian_backend: Literal["ROBUST", "IGL"] = "ROBUST",
+        device: Literal["cuda", "cpu"] = "cuda",
+        render_domain: Literal["VERTEX", "TEXEL"] = "VERTEX",
+        atlas_texel_density: float = 1500.0,
+        atlas_tile_min: int = 16,
+        atlas_tile_max: int = 512,
+        atlas_texel_soft_max: int = 500000,
+        radiance_scale: float = 1.0,
+        exr_codec: EXR_CODECS = "DWAA",
+        bit_depth: Literal[16, 32] = 32,
+        animated: bool = False,
+        substeps_per_frame: int = 4,
+        frame_start: int | None = None,
+        frame_end: int | None = None,
+        every_n_frames: int = 1,
+        assignments: str | None = None,
+    ) -> None:
+        """Solve and cache the scene's heat-transfer simulation without preparing it for rendering.
+
+        This is the solve-and-cache half of
+        :meth:`prepare_thermal <visionsim.simulate.blender.BlenderService.exposed_prepare_thermal>`: it runs the
+        cache-aware FEM solve so the result is written to disk, but does not write the ``sim_temperature`` attribute,
+        stamp default temperatures, or register the ``temperature`` AOV. It exists for the optional standalone
+        solve command, letting an expensive solve be primed ahead of rendering. The full ``ThermalConfig`` field set
+        is accepted so a single ``**asdict(config.thermal)`` dispatch can drive this method; the output-only fields
+        are ignored. When ``render_domain="TEXEL"``, this also primes the atlas-eligible objects' texel solve (via
+        the same cache key ``prepare_thermal`` would use), but does NOT write the atlas EXR image -- that happens
+        in ``prepare_thermal``, which needs the loaded/packed image to wire the shader.
+
+        Note:
+            The ``animated``/``substeps_per_frame``/``frame_start``/``frame_end``/``every_n_frames`` fields (M2) are
+            accepted only to mirror ``ThermalConfig``; this standalone cache-priming path always runs the static M1
+            solve regardless of ``animated``.
+
+        Args:
+            radiance (bool, optional): Accepted for uniform thermal-config dispatch; not used by this method (consumed
+                by ``include_thermal`` / the radiance render). Defaults to True.
+            preview (bool, optional): Accepted for uniform thermal-config dispatch; not used by this method (consumed
+                by ``include_thermal`` / the radiance render). Defaults to True.
+            initial_temperature_K (float, optional): Default initial temperature, in Kelvin, for meshes without a
+                per-object value. Defaults to 295.0.
+            thermal_diffusivity_mm2_s (float, optional): Default thermal diffusivity in ``mm^2/s``. Defaults to 0.17.
+            density_kg_m3 (float, optional): Default material density in ``kg/m^3``. Defaults to 1330.0.
+            specific_heat_J_kgK (float, optional): Default specific heat in ``J/kg*K``. Defaults to 880.0.
+            emissivity (float, optional): Default surface emissivity in ``[0, 1]``. Defaults to 0.9.
+            irradiance_scale (float, optional): Scale factor applied to the computed irradiance (heating input).
+                Defaults to 100.0.
+            sim_time_s (float, optional): Total simulated time, in seconds, for the static scene solve. Defaults to 1.0.
+            timestep_s (float, optional): Solver timestep in seconds. Defaults to 0.05.
+            domain (str, optional): FEM domain, either ``"POINTS"`` (surface point cloud, recommended) or ``"MESH"``.
+                Defaults to ``"POINTS"``.
+            laplacian_backend (str, optional): Laplacian backend, either ``"ROBUST"`` or ``"IGL"``. Defaults to ``"ROBUST"``.
+            device (str, optional): Torch device for the solve, either ``"cuda"`` or ``"cpu"``; falls back to ``"cpu"``
+                if cuda is unavailable. Defaults to ``"cuda"``.
+            render_domain (str, optional): Where solved temperatures live for rendering: ``"VERTEX"`` (per-vertex,
+                byte-identical to before the atlas existed) or ``"TEXEL"`` (a shared texture atlas, sampled per-pixel
+                by the shader). Defaults to ``"VERTEX"``.
+            atlas_texel_density (float, optional): Target texels/m^2 for atlas-eligible objects (TEXEL mode only).
+                Defaults to 1500.0.
+            atlas_tile_min (int, optional): Minimum atlas tile side, in texels (TEXEL mode only). Defaults to 16.
+            atlas_tile_max (int, optional): Maximum atlas tile side, in texels (TEXEL mode only). Defaults to 512.
+            atlas_texel_soft_max (int, optional): Soft ceiling on total atlas texels + retained vertices (TEXEL mode
+                only); exceeding it rescales the effective density down uniformly and warns. Defaults to 500000.
+            radiance_scale (float, optional): Accepted for uniform thermal-config dispatch; not used by this method
+                (consumed by ``include_thermal`` / the radiance render). Defaults to 1.0.
+            exr_codec (str, optional): Accepted for uniform thermal-config dispatch; not used by this method (consumed
+                by ``include_thermal`` / the radiance render). Defaults to ``"DWAA"``.
+            bit_depth (int, optional): Accepted for uniform thermal-config dispatch; not used by this method (consumed
+                by ``include_thermal`` / the radiance render). Defaults to 32.
+            animated (bool, optional): Accepted for uniform thermal-config dispatch; not used by this method (see
+                Note above). Defaults to False.
+            substeps_per_frame (int, optional): Accepted for uniform thermal-config dispatch; not used by this method.
+                Defaults to 4.
+            frame_start (int | None, optional): Accepted for uniform thermal-config dispatch; not used by this method.
+                Defaults to None.
+            frame_end (int | None, optional): Accepted for uniform thermal-config dispatch; not used by this method.
+                Defaults to None.
+            every_n_frames (int, optional): Accepted for uniform thermal-config dispatch; not used by this method.
+                Defaults to 1.
+            assignments (str | None, optional): Path to a thermal material assignment sidecar
+                (``<scene>.thermal.json``). When set, thermal properties are resolved per material
+                slot; when unset the global defaults are used everywhere. Defaults to None.
+        """
+
+    @require_initialized_service
+    def exposed_include_thermal(
+        self,
+        radiance: bool = True,
+        preview: bool = True,
+        initial_temperature_K: float = 295.0,
+        thermal_diffusivity_mm2_s: float = 0.17,
+        density_kg_m3: float = 1330.0,
+        specific_heat_J_kgK: float = 880.0,
+        emissivity: float = 0.9,
+        irradiance_scale: float = 100.0,
+        sim_time_s: float = 1.0,
+        timestep_s: float = 0.05,
+        domain: Literal["POINTS", "MESH"] = "POINTS",
+        laplacian_backend: Literal["ROBUST", "IGL"] = "ROBUST",
+        device: Literal["cuda", "cpu"] = "cuda",
+        render_domain: Literal["VERTEX", "TEXEL"] = "VERTEX",
+        atlas_texel_density: float = 1500.0,
+        atlas_tile_min: int = 16,
+        atlas_tile_max: int = 512,
+        atlas_texel_soft_max: int = 500000,
+        radiance_scale: float = 1.0,
+        exr_codec: EXR_CODECS = "DWAA",
+        bit_depth: Literal[16, 32] = 32,
+        animated: bool = False,
+        substeps_per_frame: int = 4,
+        frame_start: int | None = None,
+        frame_end: int | None = None,
+        every_n_frames: int = 1,
+        assignments: str | None = None,
+    ) -> None:
+        """Sets up Blender compositor to include thermal outputs for rendered images.
+
+        Wires the per-vertex temperature map (in Kelvin) from the ``temperature`` AOV registered by
+        :meth:`prepare_thermal <visionsim.simulate.blender.BlenderService.exposed_prepare_thermal>` into the
+        compositor, optionally adds an inferno-colormap preview, and optionally arms a second gray-body render pass
+        that produces a thermal-camera radiance image (emitted at render time by
+        :meth:`render_current_frame <visionsim.simulate.blender.BlenderService.exposed_render_current_frame>`).
+
+        Note:
+            This must be called after ``prepare_thermal``, which registers the ``temperature`` AOV (and, in TEXEL
+            mode, loads/packs the ``HeatSim_Temperature_Atlas`` image the shader samples) and exposes the matching
+            render-layer output socket. The solver and material parameters (``initial_temperature_K`` through
+            ``device``, the ``render_domain``/``atlas_*`` fields, ``assignments``, and the ``animated``/
+            ``substeps_per_frame``/``frame_start``/``frame_end``/``every_n_frames`` M2 fields) are accepted only to
+            mirror ``ThermalConfig`` and are consumed by ``prepare_thermal``; ``include_thermal`` itself ignores them.
+            For animated scenes, the per-frame field update happens later, in
+            :meth:`render_frame <visionsim.simulate.blender.BlenderService.exposed_render_frame>`.
+
+        Args:
+            radiance (bool, optional): If true, arm the gray-body thermal-camera radiance image as a second render
+                pass and register its per-frame output. Defaults to True.
+            preview (bool, optional): If true, also save an inferno-colormap PNG preview of the temperature map.
+                Defaults to True.
+            initial_temperature_K (float, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and
+                ignored here. Default initial temperature, in Kelvin, for meshes without a per-object value.
+                Defaults to 295.0.
+            thermal_diffusivity_mm2_s (float, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal``
+                and ignored here. Default thermal diffusivity in ``mm^2/s``. Defaults to 0.17.
+            density_kg_m3 (float, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and ignored
+                here. Default material density in ``kg/m^3``. Defaults to 1330.0.
+            specific_heat_J_kgK (float, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and
+                ignored here. Default specific heat in ``J/kg*K``. Defaults to 880.0.
+            emissivity (float, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and ignored
+                here. Default surface emissivity in ``[0, 1]``. Defaults to 0.9.
+            irradiance_scale (float, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and
+                ignored here. Scale factor applied to the computed irradiance. Defaults to 100.0.
+            sim_time_s (float, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and ignored
+                here. Total simulated time in seconds. Defaults to 1.0.
+            timestep_s (float, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and ignored
+                here. Solver timestep in seconds. Defaults to 0.05.
+            domain (str, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and ignored here.
+                FEM domain, either ``"POINTS"`` or ``"MESH"``. Defaults to ``"POINTS"``.
+            laplacian_backend (str, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and
+                ignored here. Laplacian backend, either ``"ROBUST"`` or ``"IGL"``. Defaults to ``"ROBUST"``.
+            device (str, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and ignored here.
+                Torch device, either ``"cuda"`` or ``"cpu"``. Defaults to ``"cuda"``.
+            render_domain (str, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and ignored
+                here. Where solved temperatures live for rendering, ``"VERTEX"`` or ``"TEXEL"``. Defaults to
+                ``"VERTEX"``.
+            atlas_texel_density (float, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and
+                ignored here. Target texels/m^2 for atlas-eligible objects. Defaults to 1500.0.
+            atlas_tile_min (int, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and ignored
+                here. Minimum atlas tile side, in texels. Defaults to 16.
+            atlas_tile_max (int, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and ignored
+                here. Maximum atlas tile side, in texels. Defaults to 512.
+            atlas_texel_soft_max (int, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and
+                ignored here. Soft ceiling on total atlas texels + retained vertices. Defaults to 500000.
+            radiance_scale (float, optional): Gray-body emission magnitude knob for the ``thermal_radiance`` render.
+                Defaults to 1.0.
+            exr_codec (str, optional): Codec used to compress the temperature and radiance EXR files. Options vary
+                depending on the version of Blender, with the following being broadly available:
+                ('NONE', 'PXR24', 'ZIP', 'PIZ', 'RLE', 'ZIPS', 'DWAA', 'DWAB'). Defaults to ``"DWAA"``.
+            bit_depth (int, optional): Bit depth per channel for the temperature and radiance EXRs, either 16 or 32.
+                Defaults to 32.
+            animated (bool, optional): Mirrors ``ThermalConfig`` (M2); consumed by ``prepare_thermal`` and ignored
+                here. Defaults to False.
+            substeps_per_frame (int, optional): Mirrors ``ThermalConfig`` (M2); consumed by ``prepare_thermal`` and
+                ignored here. Defaults to 4.
+            frame_start (int | None, optional): Mirrors ``ThermalConfig`` (M2); consumed by ``prepare_thermal`` and
+                ignored here. Defaults to None.
+            frame_end (int | None, optional): Mirrors ``ThermalConfig`` (M2); consumed by ``prepare_thermal`` and
+                ignored here. Defaults to None.
+            every_n_frames (int, optional): Mirrors ``ThermalConfig`` (M2); consumed by ``prepare_thermal`` and
+                ignored here. Defaults to 1.
+            assignments (str | None, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and
+                ignored here. Path to a thermal material assignment sidecar (``<scene>.thermal.json``). Defaults
+                to None.
+        """
+
     @require_initialized_service
     def exposed_load_addons(self, *addons: str) -> None:
         """Load blender addons by name (case-insensitive).
@@ -905,6 +1331,13 @@ class BlenderService(rpyc.Service):
 
         Warning:
             Calling this has the side-effect of changing the current frame.
+
+        Note:
+            If :meth:`prepare_thermal <exposed_prepare_thermal>` ran an animated (M2) solve,
+            this writes that frame's solved thermal field (via ``_thermal_write_frame``)
+            before rendering, so both the temperature AOV and the gray-body radiance pass
+            reflect the current frame -- Cycles reads ``sim_temperature`` live, so no
+            compositor changes are needed.
 
         Args:
             frame_number (int): frame to render
@@ -1453,6 +1886,319 @@ class BlenderClient:
         """
 
     @type_check_only
+    def prepare_thermal(
+        self,
+        radiance: bool = True,
+        preview: bool = True,
+        initial_temperature_K: float = 295.0,
+        thermal_diffusivity_mm2_s: float = 0.17,
+        density_kg_m3: float = 1330.0,
+        specific_heat_J_kgK: float = 880.0,
+        emissivity: float = 0.9,
+        irradiance_scale: float = 100.0,
+        sim_time_s: float = 1.0,
+        timestep_s: float = 0.05,
+        domain: Literal["POINTS", "MESH"] = "POINTS",
+        laplacian_backend: Literal["ROBUST", "IGL"] = "ROBUST",
+        device: Literal["cuda", "cpu"] = "cuda",
+        render_domain: Literal["VERTEX", "TEXEL"] = "VERTEX",
+        atlas_texel_density: float = 1500.0,
+        atlas_tile_min: int = 16,
+        atlas_tile_max: int = 512,
+        atlas_texel_soft_max: int = 500000,
+        radiance_scale: float = 1.0,
+        exr_codec: EXR_CODECS = "DWAA",
+        bit_depth: Literal[16, 32] = 32,
+        animated: bool = False,
+        substeps_per_frame: int = 4,
+        frame_start: int | None = None,
+        frame_end: int | None = None,
+        every_n_frames: int = 1,
+        assignments: str | None = None,
+    ) -> None:
+        """Solve the scene's heat-transfer simulation and prepare it for thermal rendering.
+
+        Runs the (cache-aware) FEM solve, writes the solved per-vertex ``sim_temperature``
+        attribute onto every mesh, stamps a default temperature on any unsolved mesh, and
+        registers the ``temperature`` value AOV on the original materials.
+
+        Note:
+            This must be called before :meth:`include_thermal <visionsim.simulate.blender.BlenderService.exposed_include_thermal>`,
+            since the AOV is registered on the original materials and exposes the ``temperature`` render-layer
+            output socket that ``include_thermal`` wires into the compositor. M1 is a static solve, so the final
+            timestep (``timestep=-1``) is written to every frame. When ``animated`` is true (M2, ``domain="POINTS"``
+            only), a per-frame transient solve is run instead (``adapter.solve_scene_animated``): the per-object
+            frame history is stashed on the service and the first solved frame's field is written immediately so the
+            initial render is correct; subsequent frames are written by :meth:`exposed_render_frame`'s per-frame
+            hook. Requesting ``animated`` with ``domain="MESH"`` logs a warning and falls back to the static solve.
+            The full ``ThermalConfig`` field set is accepted so a single ``**asdict(config.thermal)`` dispatch can
+            drive this method; the output-only fields are ignored. When ``render_domain="TEXEL"``, atlas-eligible
+            objects (see ``atlas_texel_density``) are additionally solved at texel resolution and their final
+            temperatures are written to an EXR atlas image (``adapter.write_atlas``), loaded/packed as the
+            ``HeatSim_Temperature_Atlas`` Blender image before the AOV is registered so the shader can sample it;
+            those objects get only the OBJECT-level fallback temperature written to their mesh (their per-pixel
+            signal comes from the atlas at render time), not a per-vertex ``sim_temperature`` attribute. Requesting
+            ``animated`` with ``render_domain="TEXEL"`` logs a warning and falls back to ``render_domain="VERTEX"``
+            for that solve (the atlas is a static-solve-only feature; M2/TEXEL is out of scope).
+
+        Args:
+            radiance (bool, optional): Accepted for uniform thermal-config dispatch; not used by this method (consumed
+                by ``include_thermal`` / the radiance render). Defaults to True.
+            preview (bool, optional): Accepted for uniform thermal-config dispatch; not used by this method (consumed
+                by ``include_thermal`` / the radiance render). Defaults to True.
+            initial_temperature_K (float, optional): Default initial temperature, in Kelvin, for meshes without a
+                per-object value. Defaults to 295.0.
+            thermal_diffusivity_mm2_s (float, optional): Default thermal diffusivity in ``mm^2/s``. Defaults to 0.17.
+            density_kg_m3 (float, optional): Default material density in ``kg/m^3``. Defaults to 1330.0.
+            specific_heat_J_kgK (float, optional): Default specific heat in ``J/kg*K``. Defaults to 880.0.
+            emissivity (float, optional): Default surface emissivity in ``[0, 1]``. Defaults to 0.9.
+            irradiance_scale (float, optional): Scale factor applied to the computed irradiance (heating input).
+                Defaults to 100.0.
+            sim_time_s (float, optional): Total simulated time, in seconds, for the static scene solve. Defaults to 1.0.
+            timestep_s (float, optional): Solver timestep in seconds. Defaults to 0.05.
+            domain (str, optional): FEM domain, either ``"POINTS"`` (surface point cloud, recommended) or ``"MESH"``.
+                Defaults to ``"POINTS"``.
+            laplacian_backend (str, optional): Laplacian backend, either ``"ROBUST"`` or ``"IGL"``. Defaults to ``"ROBUST"``.
+            device (str, optional): Torch device for the solve, either ``"cuda"`` or ``"cpu"``; falls back to ``"cpu"``
+                if cuda is unavailable. Defaults to ``"cuda"``.
+            render_domain (str, optional): Where solved temperatures live for rendering: ``"VERTEX"`` (per-vertex,
+                byte-identical to before the atlas existed) or ``"TEXEL"`` (a shared texture atlas, sampled per-pixel
+                by the shader). Defaults to ``"VERTEX"``.
+            atlas_texel_density (float, optional): Target texels/m^2 for atlas-eligible objects (TEXEL mode only).
+                Defaults to 1500.0.
+            atlas_tile_min (int, optional): Minimum atlas tile side, in texels (TEXEL mode only). Defaults to 16.
+            atlas_tile_max (int, optional): Maximum atlas tile side, in texels (TEXEL mode only). Defaults to 512.
+            atlas_texel_soft_max (int, optional): Soft ceiling on total atlas texels + retained vertices (TEXEL mode
+                only); exceeding it rescales the effective density down uniformly and warns. Defaults to 500000.
+            radiance_scale (float, optional): Accepted for uniform thermal-config dispatch; not used by this method
+                (consumed by ``include_thermal`` / the radiance render). Defaults to 1.0.
+            exr_codec (str, optional): Accepted for uniform thermal-config dispatch; not used by this method (consumed
+                by ``include_thermal`` / the radiance render). Defaults to ``"DWAA"``.
+            bit_depth (int, optional): Accepted for uniform thermal-config dispatch; not used by this method (consumed
+                by ``include_thermal`` / the radiance render). Defaults to 32.
+            animated (bool, optional): Solve heat transfer per-frame as geometry animates (transient), instead of the
+                static M1 solve. Requires ``domain="POINTS"``. Defaults to False.
+            substeps_per_frame (int, optional): Solver substeps per Blender frame in animated mode. Defaults to 4.
+            frame_start (int | None, optional): First frame of the animated solve; defaults to the scene's
+                ``frame_start`` when None. Defaults to None.
+            frame_end (int | None, optional): Last frame of the animated solve; defaults to the scene's
+                ``frame_end`` when None. Defaults to None.
+            every_n_frames (int, optional): Solve every Nth frame in animated mode (cost control); skipped frames
+                hold the last solved field. Defaults to 1.
+            assignments (str | None, optional): Path to a thermal material assignment sidecar
+                (``<scene>.thermal.json``). When set, thermal properties are resolved per material
+                slot; when unset the global defaults are used everywhere. Defaults to None.
+        """
+
+    @type_check_only
+    def heatsim_solve(
+        self,
+        radiance: bool = True,
+        preview: bool = True,
+        initial_temperature_K: float = 295.0,
+        thermal_diffusivity_mm2_s: float = 0.17,
+        density_kg_m3: float = 1330.0,
+        specific_heat_J_kgK: float = 880.0,
+        emissivity: float = 0.9,
+        irradiance_scale: float = 100.0,
+        sim_time_s: float = 1.0,
+        timestep_s: float = 0.05,
+        domain: Literal["POINTS", "MESH"] = "POINTS",
+        laplacian_backend: Literal["ROBUST", "IGL"] = "ROBUST",
+        device: Literal["cuda", "cpu"] = "cuda",
+        render_domain: Literal["VERTEX", "TEXEL"] = "VERTEX",
+        atlas_texel_density: float = 1500.0,
+        atlas_tile_min: int = 16,
+        atlas_tile_max: int = 512,
+        atlas_texel_soft_max: int = 500000,
+        radiance_scale: float = 1.0,
+        exr_codec: EXR_CODECS = "DWAA",
+        bit_depth: Literal[16, 32] = 32,
+        animated: bool = False,
+        substeps_per_frame: int = 4,
+        frame_start: int | None = None,
+        frame_end: int | None = None,
+        every_n_frames: int = 1,
+        assignments: str | None = None,
+    ) -> None:
+        """Solve and cache the scene's heat-transfer simulation without preparing it for rendering.
+
+        This is the solve-and-cache half of
+        :meth:`prepare_thermal <visionsim.simulate.blender.BlenderService.exposed_prepare_thermal>`: it runs the
+        cache-aware FEM solve so the result is written to disk, but does not write the ``sim_temperature`` attribute,
+        stamp default temperatures, or register the ``temperature`` AOV. It exists for the optional standalone
+        solve command, letting an expensive solve be primed ahead of rendering. The full ``ThermalConfig`` field set
+        is accepted so a single ``**asdict(config.thermal)`` dispatch can drive this method; the output-only fields
+        are ignored. When ``render_domain="TEXEL"``, this also primes the atlas-eligible objects' texel solve (via
+        the same cache key ``prepare_thermal`` would use), but does NOT write the atlas EXR image -- that happens
+        in ``prepare_thermal``, which needs the loaded/packed image to wire the shader.
+
+        Note:
+            The ``animated``/``substeps_per_frame``/``frame_start``/``frame_end``/``every_n_frames`` fields (M2) are
+            accepted only to mirror ``ThermalConfig``; this standalone cache-priming path always runs the static M1
+            solve regardless of ``animated``.
+
+        Args:
+            radiance (bool, optional): Accepted for uniform thermal-config dispatch; not used by this method (consumed
+                by ``include_thermal`` / the radiance render). Defaults to True.
+            preview (bool, optional): Accepted for uniform thermal-config dispatch; not used by this method (consumed
+                by ``include_thermal`` / the radiance render). Defaults to True.
+            initial_temperature_K (float, optional): Default initial temperature, in Kelvin, for meshes without a
+                per-object value. Defaults to 295.0.
+            thermal_diffusivity_mm2_s (float, optional): Default thermal diffusivity in ``mm^2/s``. Defaults to 0.17.
+            density_kg_m3 (float, optional): Default material density in ``kg/m^3``. Defaults to 1330.0.
+            specific_heat_J_kgK (float, optional): Default specific heat in ``J/kg*K``. Defaults to 880.0.
+            emissivity (float, optional): Default surface emissivity in ``[0, 1]``. Defaults to 0.9.
+            irradiance_scale (float, optional): Scale factor applied to the computed irradiance (heating input).
+                Defaults to 100.0.
+            sim_time_s (float, optional): Total simulated time, in seconds, for the static scene solve. Defaults to 1.0.
+            timestep_s (float, optional): Solver timestep in seconds. Defaults to 0.05.
+            domain (str, optional): FEM domain, either ``"POINTS"`` (surface point cloud, recommended) or ``"MESH"``.
+                Defaults to ``"POINTS"``.
+            laplacian_backend (str, optional): Laplacian backend, either ``"ROBUST"`` or ``"IGL"``. Defaults to ``"ROBUST"``.
+            device (str, optional): Torch device for the solve, either ``"cuda"`` or ``"cpu"``; falls back to ``"cpu"``
+                if cuda is unavailable. Defaults to ``"cuda"``.
+            render_domain (str, optional): Where solved temperatures live for rendering: ``"VERTEX"`` (per-vertex,
+                byte-identical to before the atlas existed) or ``"TEXEL"`` (a shared texture atlas, sampled per-pixel
+                by the shader). Defaults to ``"VERTEX"``.
+            atlas_texel_density (float, optional): Target texels/m^2 for atlas-eligible objects (TEXEL mode only).
+                Defaults to 1500.0.
+            atlas_tile_min (int, optional): Minimum atlas tile side, in texels (TEXEL mode only). Defaults to 16.
+            atlas_tile_max (int, optional): Maximum atlas tile side, in texels (TEXEL mode only). Defaults to 512.
+            atlas_texel_soft_max (int, optional): Soft ceiling on total atlas texels + retained vertices (TEXEL mode
+                only); exceeding it rescales the effective density down uniformly and warns. Defaults to 500000.
+            radiance_scale (float, optional): Accepted for uniform thermal-config dispatch; not used by this method
+                (consumed by ``include_thermal`` / the radiance render). Defaults to 1.0.
+            exr_codec (str, optional): Accepted for uniform thermal-config dispatch; not used by this method (consumed
+                by ``include_thermal`` / the radiance render). Defaults to ``"DWAA"``.
+            bit_depth (int, optional): Accepted for uniform thermal-config dispatch; not used by this method (consumed
+                by ``include_thermal`` / the radiance render). Defaults to 32.
+            animated (bool, optional): Accepted for uniform thermal-config dispatch; not used by this method (see
+                Note above). Defaults to False.
+            substeps_per_frame (int, optional): Accepted for uniform thermal-config dispatch; not used by this method.
+                Defaults to 4.
+            frame_start (int | None, optional): Accepted for uniform thermal-config dispatch; not used by this method.
+                Defaults to None.
+            frame_end (int | None, optional): Accepted for uniform thermal-config dispatch; not used by this method.
+                Defaults to None.
+            every_n_frames (int, optional): Accepted for uniform thermal-config dispatch; not used by this method.
+                Defaults to 1.
+            assignments (str | None, optional): Path to a thermal material assignment sidecar
+                (``<scene>.thermal.json``). When set, thermal properties are resolved per material
+                slot; when unset the global defaults are used everywhere. Defaults to None.
+        """
+
+    @type_check_only
+    def include_thermal(
+        self,
+        radiance: bool = True,
+        preview: bool = True,
+        initial_temperature_K: float = 295.0,
+        thermal_diffusivity_mm2_s: float = 0.17,
+        density_kg_m3: float = 1330.0,
+        specific_heat_J_kgK: float = 880.0,
+        emissivity: float = 0.9,
+        irradiance_scale: float = 100.0,
+        sim_time_s: float = 1.0,
+        timestep_s: float = 0.05,
+        domain: Literal["POINTS", "MESH"] = "POINTS",
+        laplacian_backend: Literal["ROBUST", "IGL"] = "ROBUST",
+        device: Literal["cuda", "cpu"] = "cuda",
+        render_domain: Literal["VERTEX", "TEXEL"] = "VERTEX",
+        atlas_texel_density: float = 1500.0,
+        atlas_tile_min: int = 16,
+        atlas_tile_max: int = 512,
+        atlas_texel_soft_max: int = 500000,
+        radiance_scale: float = 1.0,
+        exr_codec: EXR_CODECS = "DWAA",
+        bit_depth: Literal[16, 32] = 32,
+        animated: bool = False,
+        substeps_per_frame: int = 4,
+        frame_start: int | None = None,
+        frame_end: int | None = None,
+        every_n_frames: int = 1,
+        assignments: str | None = None,
+    ) -> None:
+        """Sets up Blender compositor to include thermal outputs for rendered images.
+
+        Wires the per-vertex temperature map (in Kelvin) from the ``temperature`` AOV registered by
+        :meth:`prepare_thermal <visionsim.simulate.blender.BlenderService.exposed_prepare_thermal>` into the
+        compositor, optionally adds an inferno-colormap preview, and optionally arms a second gray-body render pass
+        that produces a thermal-camera radiance image (emitted at render time by
+        :meth:`render_current_frame <visionsim.simulate.blender.BlenderService.exposed_render_current_frame>`).
+
+        Note:
+            This must be called after ``prepare_thermal``, which registers the ``temperature`` AOV (and, in TEXEL
+            mode, loads/packs the ``HeatSim_Temperature_Atlas`` image the shader samples) and exposes the matching
+            render-layer output socket. The solver and material parameters (``initial_temperature_K`` through
+            ``device``, the ``render_domain``/``atlas_*`` fields, ``assignments``, and the ``animated``/
+            ``substeps_per_frame``/``frame_start``/``frame_end``/``every_n_frames`` M2 fields) are accepted only to
+            mirror ``ThermalConfig`` and are consumed by ``prepare_thermal``; ``include_thermal`` itself ignores them.
+            For animated scenes, the per-frame field update happens later, in
+            :meth:`render_frame <visionsim.simulate.blender.BlenderService.exposed_render_frame>`.
+
+        Args:
+            radiance (bool, optional): If true, arm the gray-body thermal-camera radiance image as a second render
+                pass and register its per-frame output. Defaults to True.
+            preview (bool, optional): If true, also save an inferno-colormap PNG preview of the temperature map.
+                Defaults to True.
+            initial_temperature_K (float, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and
+                ignored here. Default initial temperature, in Kelvin, for meshes without a per-object value.
+                Defaults to 295.0.
+            thermal_diffusivity_mm2_s (float, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal``
+                and ignored here. Default thermal diffusivity in ``mm^2/s``. Defaults to 0.17.
+            density_kg_m3 (float, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and ignored
+                here. Default material density in ``kg/m^3``. Defaults to 1330.0.
+            specific_heat_J_kgK (float, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and
+                ignored here. Default specific heat in ``J/kg*K``. Defaults to 880.0.
+            emissivity (float, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and ignored
+                here. Default surface emissivity in ``[0, 1]``. Defaults to 0.9.
+            irradiance_scale (float, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and
+                ignored here. Scale factor applied to the computed irradiance. Defaults to 100.0.
+            sim_time_s (float, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and ignored
+                here. Total simulated time in seconds. Defaults to 1.0.
+            timestep_s (float, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and ignored
+                here. Solver timestep in seconds. Defaults to 0.05.
+            domain (str, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and ignored here.
+                FEM domain, either ``"POINTS"`` or ``"MESH"``. Defaults to ``"POINTS"``.
+            laplacian_backend (str, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and
+                ignored here. Laplacian backend, either ``"ROBUST"`` or ``"IGL"``. Defaults to ``"ROBUST"``.
+            device (str, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and ignored here.
+                Torch device, either ``"cuda"`` or ``"cpu"``. Defaults to ``"cuda"``.
+            render_domain (str, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and ignored
+                here. Where solved temperatures live for rendering, ``"VERTEX"`` or ``"TEXEL"``. Defaults to
+                ``"VERTEX"``.
+            atlas_texel_density (float, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and
+                ignored here. Target texels/m^2 for atlas-eligible objects. Defaults to 1500.0.
+            atlas_tile_min (int, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and ignored
+                here. Minimum atlas tile side, in texels. Defaults to 16.
+            atlas_tile_max (int, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and ignored
+                here. Maximum atlas tile side, in texels. Defaults to 512.
+            atlas_texel_soft_max (int, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and
+                ignored here. Soft ceiling on total atlas texels + retained vertices. Defaults to 500000.
+            radiance_scale (float, optional): Gray-body emission magnitude knob for the ``thermal_radiance`` render.
+                Defaults to 1.0.
+            exr_codec (str, optional): Codec used to compress the temperature and radiance EXR files. Options vary
+                depending on the version of Blender, with the following being broadly available:
+                ('NONE', 'PXR24', 'ZIP', 'PIZ', 'RLE', 'ZIPS', 'DWAA', 'DWAB'). Defaults to ``"DWAA"``.
+            bit_depth (int, optional): Bit depth per channel for the temperature and radiance EXRs, either 16 or 32.
+                Defaults to 32.
+            animated (bool, optional): Mirrors ``ThermalConfig`` (M2); consumed by ``prepare_thermal`` and ignored
+                here. Defaults to False.
+            substeps_per_frame (int, optional): Mirrors ``ThermalConfig`` (M2); consumed by ``prepare_thermal`` and
+                ignored here. Defaults to 4.
+            frame_start (int | None, optional): Mirrors ``ThermalConfig`` (M2); consumed by ``prepare_thermal`` and
+                ignored here. Defaults to None.
+            frame_end (int | None, optional): Mirrors ``ThermalConfig`` (M2); consumed by ``prepare_thermal`` and
+                ignored here. Defaults to None.
+            every_n_frames (int, optional): Mirrors ``ThermalConfig`` (M2); consumed by ``prepare_thermal`` and
+                ignored here. Defaults to 1.
+            assignments (str | None, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and
+                ignored here. Path to a thermal material assignment sidecar (``<scene>.thermal.json``). Defaults
+                to None.
+        """
+
+    @type_check_only
     def load_addons(self, *addons: str) -> None:
         """Load blender addons by name (case-insensitive).
 
@@ -1661,6 +2407,13 @@ class BlenderClient:
 
         Warning:
             Calling this has the side-effect of changing the current frame.
+
+        Note:
+            If :meth:`prepare_thermal <exposed_prepare_thermal>` ran an animated (M2) solve,
+            this writes that frame's solved thermal field (via ``_thermal_write_frame``)
+            before rendering, so both the temperature AOV and the gray-body radiance pass
+            reflect the current frame -- Cycles reads ``sim_temperature`` live, so no
+            compositor changes are needed.
 
         Args:
             frame_number (int): frame to render
@@ -2287,6 +3040,319 @@ class BlenderClients(tuple):
         """
 
     @type_check_only
+    def prepare_thermal(
+        self,
+        radiance: bool = True,
+        preview: bool = True,
+        initial_temperature_K: float = 295.0,
+        thermal_diffusivity_mm2_s: float = 0.17,
+        density_kg_m3: float = 1330.0,
+        specific_heat_J_kgK: float = 880.0,
+        emissivity: float = 0.9,
+        irradiance_scale: float = 100.0,
+        sim_time_s: float = 1.0,
+        timestep_s: float = 0.05,
+        domain: Literal["POINTS", "MESH"] = "POINTS",
+        laplacian_backend: Literal["ROBUST", "IGL"] = "ROBUST",
+        device: Literal["cuda", "cpu"] = "cuda",
+        render_domain: Literal["VERTEX", "TEXEL"] = "VERTEX",
+        atlas_texel_density: float = 1500.0,
+        atlas_tile_min: int = 16,
+        atlas_tile_max: int = 512,
+        atlas_texel_soft_max: int = 500000,
+        radiance_scale: float = 1.0,
+        exr_codec: EXR_CODECS = "DWAA",
+        bit_depth: Literal[16, 32] = 32,
+        animated: bool = False,
+        substeps_per_frame: int = 4,
+        frame_start: int | None = None,
+        frame_end: int | None = None,
+        every_n_frames: int = 1,
+        assignments: str | None = None,
+    ) -> None:
+        """Solve the scene's heat-transfer simulation and prepare it for thermal rendering.
+
+        Runs the (cache-aware) FEM solve, writes the solved per-vertex ``sim_temperature``
+        attribute onto every mesh, stamps a default temperature on any unsolved mesh, and
+        registers the ``temperature`` value AOV on the original materials.
+
+        Note:
+            This must be called before :meth:`include_thermal <visionsim.simulate.blender.BlenderService.exposed_include_thermal>`,
+            since the AOV is registered on the original materials and exposes the ``temperature`` render-layer
+            output socket that ``include_thermal`` wires into the compositor. M1 is a static solve, so the final
+            timestep (``timestep=-1``) is written to every frame. When ``animated`` is true (M2, ``domain="POINTS"``
+            only), a per-frame transient solve is run instead (``adapter.solve_scene_animated``): the per-object
+            frame history is stashed on the service and the first solved frame's field is written immediately so the
+            initial render is correct; subsequent frames are written by :meth:`exposed_render_frame`'s per-frame
+            hook. Requesting ``animated`` with ``domain="MESH"`` logs a warning and falls back to the static solve.
+            The full ``ThermalConfig`` field set is accepted so a single ``**asdict(config.thermal)`` dispatch can
+            drive this method; the output-only fields are ignored. When ``render_domain="TEXEL"``, atlas-eligible
+            objects (see ``atlas_texel_density``) are additionally solved at texel resolution and their final
+            temperatures are written to an EXR atlas image (``adapter.write_atlas``), loaded/packed as the
+            ``HeatSim_Temperature_Atlas`` Blender image before the AOV is registered so the shader can sample it;
+            those objects get only the OBJECT-level fallback temperature written to their mesh (their per-pixel
+            signal comes from the atlas at render time), not a per-vertex ``sim_temperature`` attribute. Requesting
+            ``animated`` with ``render_domain="TEXEL"`` logs a warning and falls back to ``render_domain="VERTEX"``
+            for that solve (the atlas is a static-solve-only feature; M2/TEXEL is out of scope).
+
+        Args:
+            radiance (bool, optional): Accepted for uniform thermal-config dispatch; not used by this method (consumed
+                by ``include_thermal`` / the radiance render). Defaults to True.
+            preview (bool, optional): Accepted for uniform thermal-config dispatch; not used by this method (consumed
+                by ``include_thermal`` / the radiance render). Defaults to True.
+            initial_temperature_K (float, optional): Default initial temperature, in Kelvin, for meshes without a
+                per-object value. Defaults to 295.0.
+            thermal_diffusivity_mm2_s (float, optional): Default thermal diffusivity in ``mm^2/s``. Defaults to 0.17.
+            density_kg_m3 (float, optional): Default material density in ``kg/m^3``. Defaults to 1330.0.
+            specific_heat_J_kgK (float, optional): Default specific heat in ``J/kg*K``. Defaults to 880.0.
+            emissivity (float, optional): Default surface emissivity in ``[0, 1]``. Defaults to 0.9.
+            irradiance_scale (float, optional): Scale factor applied to the computed irradiance (heating input).
+                Defaults to 100.0.
+            sim_time_s (float, optional): Total simulated time, in seconds, for the static scene solve. Defaults to 1.0.
+            timestep_s (float, optional): Solver timestep in seconds. Defaults to 0.05.
+            domain (str, optional): FEM domain, either ``"POINTS"`` (surface point cloud, recommended) or ``"MESH"``.
+                Defaults to ``"POINTS"``.
+            laplacian_backend (str, optional): Laplacian backend, either ``"ROBUST"`` or ``"IGL"``. Defaults to ``"ROBUST"``.
+            device (str, optional): Torch device for the solve, either ``"cuda"`` or ``"cpu"``; falls back to ``"cpu"``
+                if cuda is unavailable. Defaults to ``"cuda"``.
+            render_domain (str, optional): Where solved temperatures live for rendering: ``"VERTEX"`` (per-vertex,
+                byte-identical to before the atlas existed) or ``"TEXEL"`` (a shared texture atlas, sampled per-pixel
+                by the shader). Defaults to ``"VERTEX"``.
+            atlas_texel_density (float, optional): Target texels/m^2 for atlas-eligible objects (TEXEL mode only).
+                Defaults to 1500.0.
+            atlas_tile_min (int, optional): Minimum atlas tile side, in texels (TEXEL mode only). Defaults to 16.
+            atlas_tile_max (int, optional): Maximum atlas tile side, in texels (TEXEL mode only). Defaults to 512.
+            atlas_texel_soft_max (int, optional): Soft ceiling on total atlas texels + retained vertices (TEXEL mode
+                only); exceeding it rescales the effective density down uniformly and warns. Defaults to 500000.
+            radiance_scale (float, optional): Accepted for uniform thermal-config dispatch; not used by this method
+                (consumed by ``include_thermal`` / the radiance render). Defaults to 1.0.
+            exr_codec (str, optional): Accepted for uniform thermal-config dispatch; not used by this method (consumed
+                by ``include_thermal`` / the radiance render). Defaults to ``"DWAA"``.
+            bit_depth (int, optional): Accepted for uniform thermal-config dispatch; not used by this method (consumed
+                by ``include_thermal`` / the radiance render). Defaults to 32.
+            animated (bool, optional): Solve heat transfer per-frame as geometry animates (transient), instead of the
+                static M1 solve. Requires ``domain="POINTS"``. Defaults to False.
+            substeps_per_frame (int, optional): Solver substeps per Blender frame in animated mode. Defaults to 4.
+            frame_start (int | None, optional): First frame of the animated solve; defaults to the scene's
+                ``frame_start`` when None. Defaults to None.
+            frame_end (int | None, optional): Last frame of the animated solve; defaults to the scene's
+                ``frame_end`` when None. Defaults to None.
+            every_n_frames (int, optional): Solve every Nth frame in animated mode (cost control); skipped frames
+                hold the last solved field. Defaults to 1.
+            assignments (str | None, optional): Path to a thermal material assignment sidecar
+                (``<scene>.thermal.json``). When set, thermal properties are resolved per material
+                slot; when unset the global defaults are used everywhere. Defaults to None.
+        """
+
+    @type_check_only
+    def heatsim_solve(
+        self,
+        radiance: bool = True,
+        preview: bool = True,
+        initial_temperature_K: float = 295.0,
+        thermal_diffusivity_mm2_s: float = 0.17,
+        density_kg_m3: float = 1330.0,
+        specific_heat_J_kgK: float = 880.0,
+        emissivity: float = 0.9,
+        irradiance_scale: float = 100.0,
+        sim_time_s: float = 1.0,
+        timestep_s: float = 0.05,
+        domain: Literal["POINTS", "MESH"] = "POINTS",
+        laplacian_backend: Literal["ROBUST", "IGL"] = "ROBUST",
+        device: Literal["cuda", "cpu"] = "cuda",
+        render_domain: Literal["VERTEX", "TEXEL"] = "VERTEX",
+        atlas_texel_density: float = 1500.0,
+        atlas_tile_min: int = 16,
+        atlas_tile_max: int = 512,
+        atlas_texel_soft_max: int = 500000,
+        radiance_scale: float = 1.0,
+        exr_codec: EXR_CODECS = "DWAA",
+        bit_depth: Literal[16, 32] = 32,
+        animated: bool = False,
+        substeps_per_frame: int = 4,
+        frame_start: int | None = None,
+        frame_end: int | None = None,
+        every_n_frames: int = 1,
+        assignments: str | None = None,
+    ) -> None:
+        """Solve and cache the scene's heat-transfer simulation without preparing it for rendering.
+
+        This is the solve-and-cache half of
+        :meth:`prepare_thermal <visionsim.simulate.blender.BlenderService.exposed_prepare_thermal>`: it runs the
+        cache-aware FEM solve so the result is written to disk, but does not write the ``sim_temperature`` attribute,
+        stamp default temperatures, or register the ``temperature`` AOV. It exists for the optional standalone
+        solve command, letting an expensive solve be primed ahead of rendering. The full ``ThermalConfig`` field set
+        is accepted so a single ``**asdict(config.thermal)`` dispatch can drive this method; the output-only fields
+        are ignored. When ``render_domain="TEXEL"``, this also primes the atlas-eligible objects' texel solve (via
+        the same cache key ``prepare_thermal`` would use), but does NOT write the atlas EXR image -- that happens
+        in ``prepare_thermal``, which needs the loaded/packed image to wire the shader.
+
+        Note:
+            The ``animated``/``substeps_per_frame``/``frame_start``/``frame_end``/``every_n_frames`` fields (M2) are
+            accepted only to mirror ``ThermalConfig``; this standalone cache-priming path always runs the static M1
+            solve regardless of ``animated``.
+
+        Args:
+            radiance (bool, optional): Accepted for uniform thermal-config dispatch; not used by this method (consumed
+                by ``include_thermal`` / the radiance render). Defaults to True.
+            preview (bool, optional): Accepted for uniform thermal-config dispatch; not used by this method (consumed
+                by ``include_thermal`` / the radiance render). Defaults to True.
+            initial_temperature_K (float, optional): Default initial temperature, in Kelvin, for meshes without a
+                per-object value. Defaults to 295.0.
+            thermal_diffusivity_mm2_s (float, optional): Default thermal diffusivity in ``mm^2/s``. Defaults to 0.17.
+            density_kg_m3 (float, optional): Default material density in ``kg/m^3``. Defaults to 1330.0.
+            specific_heat_J_kgK (float, optional): Default specific heat in ``J/kg*K``. Defaults to 880.0.
+            emissivity (float, optional): Default surface emissivity in ``[0, 1]``. Defaults to 0.9.
+            irradiance_scale (float, optional): Scale factor applied to the computed irradiance (heating input).
+                Defaults to 100.0.
+            sim_time_s (float, optional): Total simulated time, in seconds, for the static scene solve. Defaults to 1.0.
+            timestep_s (float, optional): Solver timestep in seconds. Defaults to 0.05.
+            domain (str, optional): FEM domain, either ``"POINTS"`` (surface point cloud, recommended) or ``"MESH"``.
+                Defaults to ``"POINTS"``.
+            laplacian_backend (str, optional): Laplacian backend, either ``"ROBUST"`` or ``"IGL"``. Defaults to ``"ROBUST"``.
+            device (str, optional): Torch device for the solve, either ``"cuda"`` or ``"cpu"``; falls back to ``"cpu"``
+                if cuda is unavailable. Defaults to ``"cuda"``.
+            render_domain (str, optional): Where solved temperatures live for rendering: ``"VERTEX"`` (per-vertex,
+                byte-identical to before the atlas existed) or ``"TEXEL"`` (a shared texture atlas, sampled per-pixel
+                by the shader). Defaults to ``"VERTEX"``.
+            atlas_texel_density (float, optional): Target texels/m^2 for atlas-eligible objects (TEXEL mode only).
+                Defaults to 1500.0.
+            atlas_tile_min (int, optional): Minimum atlas tile side, in texels (TEXEL mode only). Defaults to 16.
+            atlas_tile_max (int, optional): Maximum atlas tile side, in texels (TEXEL mode only). Defaults to 512.
+            atlas_texel_soft_max (int, optional): Soft ceiling on total atlas texels + retained vertices (TEXEL mode
+                only); exceeding it rescales the effective density down uniformly and warns. Defaults to 500000.
+            radiance_scale (float, optional): Accepted for uniform thermal-config dispatch; not used by this method
+                (consumed by ``include_thermal`` / the radiance render). Defaults to 1.0.
+            exr_codec (str, optional): Accepted for uniform thermal-config dispatch; not used by this method (consumed
+                by ``include_thermal`` / the radiance render). Defaults to ``"DWAA"``.
+            bit_depth (int, optional): Accepted for uniform thermal-config dispatch; not used by this method (consumed
+                by ``include_thermal`` / the radiance render). Defaults to 32.
+            animated (bool, optional): Accepted for uniform thermal-config dispatch; not used by this method (see
+                Note above). Defaults to False.
+            substeps_per_frame (int, optional): Accepted for uniform thermal-config dispatch; not used by this method.
+                Defaults to 4.
+            frame_start (int | None, optional): Accepted for uniform thermal-config dispatch; not used by this method.
+                Defaults to None.
+            frame_end (int | None, optional): Accepted for uniform thermal-config dispatch; not used by this method.
+                Defaults to None.
+            every_n_frames (int, optional): Accepted for uniform thermal-config dispatch; not used by this method.
+                Defaults to 1.
+            assignments (str | None, optional): Path to a thermal material assignment sidecar
+                (``<scene>.thermal.json``). When set, thermal properties are resolved per material
+                slot; when unset the global defaults are used everywhere. Defaults to None.
+        """
+
+    @type_check_only
+    def include_thermal(
+        self,
+        radiance: bool = True,
+        preview: bool = True,
+        initial_temperature_K: float = 295.0,
+        thermal_diffusivity_mm2_s: float = 0.17,
+        density_kg_m3: float = 1330.0,
+        specific_heat_J_kgK: float = 880.0,
+        emissivity: float = 0.9,
+        irradiance_scale: float = 100.0,
+        sim_time_s: float = 1.0,
+        timestep_s: float = 0.05,
+        domain: Literal["POINTS", "MESH"] = "POINTS",
+        laplacian_backend: Literal["ROBUST", "IGL"] = "ROBUST",
+        device: Literal["cuda", "cpu"] = "cuda",
+        render_domain: Literal["VERTEX", "TEXEL"] = "VERTEX",
+        atlas_texel_density: float = 1500.0,
+        atlas_tile_min: int = 16,
+        atlas_tile_max: int = 512,
+        atlas_texel_soft_max: int = 500000,
+        radiance_scale: float = 1.0,
+        exr_codec: EXR_CODECS = "DWAA",
+        bit_depth: Literal[16, 32] = 32,
+        animated: bool = False,
+        substeps_per_frame: int = 4,
+        frame_start: int | None = None,
+        frame_end: int | None = None,
+        every_n_frames: int = 1,
+        assignments: str | None = None,
+    ) -> None:
+        """Sets up Blender compositor to include thermal outputs for rendered images.
+
+        Wires the per-vertex temperature map (in Kelvin) from the ``temperature`` AOV registered by
+        :meth:`prepare_thermal <visionsim.simulate.blender.BlenderService.exposed_prepare_thermal>` into the
+        compositor, optionally adds an inferno-colormap preview, and optionally arms a second gray-body render pass
+        that produces a thermal-camera radiance image (emitted at render time by
+        :meth:`render_current_frame <visionsim.simulate.blender.BlenderService.exposed_render_current_frame>`).
+
+        Note:
+            This must be called after ``prepare_thermal``, which registers the ``temperature`` AOV (and, in TEXEL
+            mode, loads/packs the ``HeatSim_Temperature_Atlas`` image the shader samples) and exposes the matching
+            render-layer output socket. The solver and material parameters (``initial_temperature_K`` through
+            ``device``, the ``render_domain``/``atlas_*`` fields, ``assignments``, and the ``animated``/
+            ``substeps_per_frame``/``frame_start``/``frame_end``/``every_n_frames`` M2 fields) are accepted only to
+            mirror ``ThermalConfig`` and are consumed by ``prepare_thermal``; ``include_thermal`` itself ignores them.
+            For animated scenes, the per-frame field update happens later, in
+            :meth:`render_frame <visionsim.simulate.blender.BlenderService.exposed_render_frame>`.
+
+        Args:
+            radiance (bool, optional): If true, arm the gray-body thermal-camera radiance image as a second render
+                pass and register its per-frame output. Defaults to True.
+            preview (bool, optional): If true, also save an inferno-colormap PNG preview of the temperature map.
+                Defaults to True.
+            initial_temperature_K (float, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and
+                ignored here. Default initial temperature, in Kelvin, for meshes without a per-object value.
+                Defaults to 295.0.
+            thermal_diffusivity_mm2_s (float, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal``
+                and ignored here. Default thermal diffusivity in ``mm^2/s``. Defaults to 0.17.
+            density_kg_m3 (float, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and ignored
+                here. Default material density in ``kg/m^3``. Defaults to 1330.0.
+            specific_heat_J_kgK (float, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and
+                ignored here. Default specific heat in ``J/kg*K``. Defaults to 880.0.
+            emissivity (float, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and ignored
+                here. Default surface emissivity in ``[0, 1]``. Defaults to 0.9.
+            irradiance_scale (float, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and
+                ignored here. Scale factor applied to the computed irradiance. Defaults to 100.0.
+            sim_time_s (float, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and ignored
+                here. Total simulated time in seconds. Defaults to 1.0.
+            timestep_s (float, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and ignored
+                here. Solver timestep in seconds. Defaults to 0.05.
+            domain (str, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and ignored here.
+                FEM domain, either ``"POINTS"`` or ``"MESH"``. Defaults to ``"POINTS"``.
+            laplacian_backend (str, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and
+                ignored here. Laplacian backend, either ``"ROBUST"`` or ``"IGL"``. Defaults to ``"ROBUST"``.
+            device (str, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and ignored here.
+                Torch device, either ``"cuda"`` or ``"cpu"``. Defaults to ``"cuda"``.
+            render_domain (str, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and ignored
+                here. Where solved temperatures live for rendering, ``"VERTEX"`` or ``"TEXEL"``. Defaults to
+                ``"VERTEX"``.
+            atlas_texel_density (float, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and
+                ignored here. Target texels/m^2 for atlas-eligible objects. Defaults to 1500.0.
+            atlas_tile_min (int, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and ignored
+                here. Minimum atlas tile side, in texels. Defaults to 16.
+            atlas_tile_max (int, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and ignored
+                here. Maximum atlas tile side, in texels. Defaults to 512.
+            atlas_texel_soft_max (int, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and
+                ignored here. Soft ceiling on total atlas texels + retained vertices. Defaults to 500000.
+            radiance_scale (float, optional): Gray-body emission magnitude knob for the ``thermal_radiance`` render.
+                Defaults to 1.0.
+            exr_codec (str, optional): Codec used to compress the temperature and radiance EXR files. Options vary
+                depending on the version of Blender, with the following being broadly available:
+                ('NONE', 'PXR24', 'ZIP', 'PIZ', 'RLE', 'ZIPS', 'DWAA', 'DWAB'). Defaults to ``"DWAA"``.
+            bit_depth (int, optional): Bit depth per channel for the temperature and radiance EXRs, either 16 or 32.
+                Defaults to 32.
+            animated (bool, optional): Mirrors ``ThermalConfig`` (M2); consumed by ``prepare_thermal`` and ignored
+                here. Defaults to False.
+            substeps_per_frame (int, optional): Mirrors ``ThermalConfig`` (M2); consumed by ``prepare_thermal`` and
+                ignored here. Defaults to 4.
+            frame_start (int | None, optional): Mirrors ``ThermalConfig`` (M2); consumed by ``prepare_thermal`` and
+                ignored here. Defaults to None.
+            frame_end (int | None, optional): Mirrors ``ThermalConfig`` (M2); consumed by ``prepare_thermal`` and
+                ignored here. Defaults to None.
+            every_n_frames (int, optional): Mirrors ``ThermalConfig`` (M2); consumed by ``prepare_thermal`` and
+                ignored here. Defaults to 1.
+            assignments (str | None, optional): Mirrors ``ThermalConfig``; consumed by ``prepare_thermal`` and
+                ignored here. Path to a thermal material assignment sidecar (``<scene>.thermal.json``). Defaults
+                to None.
+        """
+
+    @type_check_only
     def load_addons(self, *addons: str) -> None:
         """Load blender addons by name (case-insensitive).
 
@@ -2495,6 +3561,13 @@ class BlenderClients(tuple):
 
         Warning:
             Calling this has the side-effect of changing the current frame.
+
+        Note:
+            If :meth:`prepare_thermal <exposed_prepare_thermal>` ran an animated (M2) solve,
+            this writes that frame's solved thermal field (via ``_thermal_write_frame``)
+            before rendering, so both the temperature AOV and the gray-body radiance pass
+            reflect the current frame -- Cycles reads ``sim_temperature`` live, so no
+            compositor changes are needed.
 
         Args:
             frame_number (int): frame to render

--- a/visionsim/simulate/config.py
+++ b/visionsim/simulate/config.py
@@ -154,6 +154,118 @@ class PointsConfig:
 
 
 @dataclass
+class ThermalConfig:
+    # --- outputs ---
+    radiance: bool = True
+    """If true, also render the gray-body thermal-camera radiance image (second render pass)"""
+    preview: bool = True
+    """Also save an inferno-colormap PNG preview of the temperature map"""
+    assignments: Path | None = None
+    """Path to a thermal material assignment sidecar (``<scene>.thermal.json``). When set, thermal properties
+    are resolved per material slot from the sidecar; when unset the global defaults below are used for every
+    surface. Sidecars are authored offline by ``scripts/thermal_assign.py`` and committed."""
+    # --- per-object override hook (else globals below) ---
+    # overrides: dict[str, ...]  # (future: per-object params by object name; today, globals + obj.heat_sim_material)
+    # --- global material defaults (used where no per-object value is set) ---
+    initial_temperature_K: float = 295.0
+    """Default initial temperature for meshes without a per-object value"""
+    thermal_diffusivity_mm2_s: float = 0.17
+    """Default thermal diffusivity (mm^2/s)"""
+    density_kg_m3: float = 1330.0
+    """Default material density (kg/m^3)"""
+    specific_heat_J_kgK: float = 880.0
+    """Default specific heat (J/kg*K)"""
+    emissivity: float = 0.9
+    """Default surface emissivity in [0, 1]"""
+    # --- solver ---
+    irradiance_scale: float = 100.0
+    """Scale factor applied to computed irradiance (heating input)"""
+    sim_time_s: float = 1.0
+    """Total simulated time in seconds (static scene mode)"""
+    timestep_s: float = 0.05
+    """Solver timestep in seconds"""
+    domain: Literal["POINTS", "MESH"] = "POINTS"
+    """FEM domain: surface point cloud (recommended) or mesh"""
+    laplacian_backend: Literal["ROBUST", "IGL"] = "ROBUST"
+    """Laplacian backend"""
+    irradiance_source: Literal["DIRECT_KERNEL", "CYCLES_BAKE"] = "DIRECT_KERNEL"
+    """Where absorbed flux comes from.
+
+    ``DIRECT_KERNEL`` (default) is analytic: per-light form factors, Embree shadow rays
+    and a 9-coefficient SH sky. Fast, but it counts only objects of type ``LIGHT`` plus
+    the world sky, and models no indirect bounce -- so a scene lit by emissive geometry
+    (window planes, light portals, emissive fixture panels) receives no flux from its
+    actual light source.
+
+    ``CYCLES_BAKE`` bakes DIFFUSE DIRECT+INDIRECT per object instead, resolving emissive
+    meshes, indirect bounce, portals and HDRI transport. Prefer it whenever the scene's
+    real light source is not a lamp object. The symptom of the wrong choice is a room
+    that renders flat at its initial temperature while its RGB render is well lit.
+    """
+    bake_samples: int = 1024
+    """Cycles bake samples for the irradiance map (``CYCLES_BAKE`` only).
+
+    Adaptive sampling is disabled for the bake, so this is a true per-texel sample count
+    rather than a cap. It is set here rather than inherited from the blend because
+    production blends are tuned for a look, often with a loose adaptive threshold that
+    terminates texels well below the nominal cap -- fine for an image, not for a physical
+    input, since baked irradiance noise propagates into the temperature field.
+
+    A steady-state surface sits at ``T ~ (E/(eps*sigma))**0.25``, so a relative error in
+    irradiance appears as roughly a quarter of that in temperature. Noise falls as
+    ``1/sqrt(N)``, so quadrupling this buys a little under half the noise. Denoising does
+    not apply to a bake; sample count is the only lever.
+    """
+    irradiance_texture_size: int = 512
+    """Resolution of the Cycles bakes, in pixels per side (square).
+
+    Governs both the albedo bake and, under ``CYCLES_BAKE``, the irradiance bake. This is
+    the *spatial detail* of the baked flux, as distinct from ``bake_samples``, which is its
+    *noise*: more samples make a smoother bake at the same resolution, and cannot recover
+    detail the resolution never captured. A large surface unwrapped into one 512px tile
+    gets few texels per square metre however many samples you throw at it, so raise this
+    for scenes with big floors, walls or ceilings. Cost is quadratic in this value.
+    """
+    device: Literal["cuda", "cpu"] = "cuda"
+    """Torch device for the solve; falls back to cpu if cuda is unavailable"""
+    # --- thermal atlas (texel-domain render) ---
+    render_domain: Literal["VERTEX", "TEXEL"] = "VERTEX"
+    """Where solved temperatures live for rendering: per-vertex (today's behavior, byte-identical)
+    or in a shared texture atlas sampled per-pixel by the shader (denser surfaces, no reliance on
+    mesh vertex density)."""
+    atlas_texel_density: float = 1500.0
+    """Target texels/m^2 for atlas-eligible objects (those whose native vertex density is below
+    this). Provisional default pending an in-render timing benchmark (see the design spec's
+    validation plan); tune down for large/slow scenes."""
+    atlas_tile_min: int = 16
+    """Minimum atlas tile side, in texels (per object)."""
+    atlas_tile_max: int = 512
+    """Maximum atlas tile side, in texels (per object)."""
+    atlas_texel_soft_max: int = 500_000
+    """Soft ceiling on total atlas texels + retained vertices; exceeding it rescales the
+    effective density down uniformly and warns, rather than allocating an unbounded solve."""
+    # --- radiance render ---
+    radiance_scale: float = 1.0
+    """Gray-body emission magnitude knob for the thermal_radiance render"""
+    # --- file formats (mirror DepthsConfig) ---
+    exr_codec: EXR_CODECS = "DWAA"
+    """Encoding used to compress EXRs"""
+    bit_depth: Literal[16, 32] = 32
+    """Bit depth for temperature/radiance EXRs"""
+    # --- animated (transient) ---
+    animated: bool = False
+    """Solve heat transfer per-frame as geometry animates (transient). When False, the static single-shot solve is used."""
+    substeps_per_frame: int = 4
+    """Solver substeps per Blender frame in animated mode (dt = (1/fps)/substeps_per_frame)."""
+    frame_start: int | None = None
+    """First frame of the animated solve; defaults to the scene frame_start."""
+    frame_end: int | None = None
+    """Last frame of the animated solve; defaults to the scene frame_end."""
+    every_n_frames: int = 1
+    """Solve every Nth frame (cost control); skipped frames hold the last solved field."""
+
+
+@dataclass
 class RenderConfig:
     executable: Path | None = None
     """Path to blender executable"""
@@ -203,6 +315,10 @@ class RenderConfig:
     """If true, enable world-space point map outputs"""
     points: PointsConfig = field(default_factory=PointsConfig)
     """Point maps configuration options"""
+    include_thermal: bool = False
+    """If true, enable thermal outputs (temperature map + thermal-camera radiance)"""
+    thermal: ThermalConfig = field(default_factory=ThermalConfig)
+    """Thermal modality configuration options"""
     include_all: bool = False
     """If true, enable all ground truth outputs"""
     previews: bool = True
@@ -259,6 +375,7 @@ class RenderConfig:
             self.include_diffuse_pass = True
             self.include_specular_pass = True
             self.include_points = True
+            self.include_thermal = True
 
         self.depths.preview &= self.previews
         self.normals.preview &= self.previews
@@ -266,3 +383,4 @@ class RenderConfig:
         self.segmentations.preview &= self.previews
         self.materials.preview &= self.previews
         self.points.preview &= self.previews
+        self.thermal.preview &= self.previews

--- a/visionsim/simulate/heatsim/__init__.py
+++ b/visionsim/simulate/heatsim/__init__.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from visionsim.simulate.heatsim import constants, laplacian, properties, solver
+
+__all__ = ["constants", "laplacian", "properties", "solver"]
+
+
+def register() -> None:
+    """Register the per-object thermal material PropertyGroup on ``bpy.types.Object``."""
+    properties.register()
+
+
+def unregister() -> None:
+    """Unregister the thermal material PropertyGroup."""
+    properties.unregister()

--- a/visionsim/simulate/heatsim/adapter.py
+++ b/visionsim/simulate/heatsim/adapter.py
@@ -1,0 +1,1948 @@
+"""Scene adapter: Blender scene -> solver inputs -> per-vertex temperatures.
+
+Hand-written glue that distils the data-shaping core of heat-sim-blender's
+``addon/lib/fem_adapter.py`` (@ 543ee81) into four functions:
+
+* :func:`gather_meshes`         - select the meshes that participate in the solve.
+* :func:`resolve_material`      - per-object thermal params (``heat_sim_material`` -> ``defaults``).
+* :func:`solve_scene`           - cache-aware geometry -> irradiance -> FEM solve -> per-object history.
+* :func:`write_frame_attributes`- stamp ``sim_temperature`` / ``emissivity`` (and a fallback temp).
+
+Unit / sign / dt conventions are preserved verbatim from upstream because the
+wrong units silently corrupt the physics:
+
+* geometry in **millimetres** (world coords x 1000),
+* irradiance W/m^2 -> W/mm^2 (/1e6) then x ``irradiance_scale``,
+* density kg/m^3 -> kg/mm^3 (/1e9) wherever the solver consumes it,
+* the FEM solver is driven exactly as ``tests/test_heatsim_solver.py`` drives it
+  (``NUM_FRAME_DELTA = timestep_s * 60`` so ``dt = NUM_FRAME_DELTA / 60``;
+  ``record_time == sim_time`` records every step).
+
+The module imports ``bpy`` defensively so it stays importable (for
+linting / type-checking) outside Blender; the bpy-coupled solver and Direct-Kernel
+irradiance modules are imported lazily inside :func:`solve_scene`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import numpy as np
+
+from visionsim.simulate.heatsim import atlas, cache, materials
+from visionsim.simulate.heatsim.constants import (
+    ATLAS_COVERAGE_PROP,
+    ATLAS_UV_LAYER_NAME,
+    BAKE_UV_LAYER_NAME,
+    CYCLES_LOUT_TO_IRRADIANCE,
+)
+
+try:
+    import bpy  # type: ignore
+except ImportError:  # pragma: no cover - only hit outside Blender
+    bpy = None  # type: ignore
+
+_log = logging.getLogger("rich")
+
+# Unit conversions (everything the solver sees is in mm-based units).
+_M_TO_MM = 1000.0
+_KGM3_TO_KGMM3 = 1.0e9  # divide: kg/m^3 -> kg/mm^3  (1000**3)
+_WM2_TO_WMM2 = 1.0e6    # divide: W/m^2 -> W/mm^2     (1000**2)
+
+
+# ---------------------------------------------------------------------------
+# Object selection + material resolution
+# ---------------------------------------------------------------------------
+
+
+def gather_meshes(scene: Any) -> list:
+    """Return the MESH objects that take part in the heat solve.
+
+    A mesh participates when it is visible, renderable and (per-object) heat
+    simulation is enabled. Mirrors the filter at ``fem_adapter.py:2867,2875``;
+    a missing ``heat_simulation_enabled`` attribute defaults to ``True``.
+
+    Also un-shares each returned object's mesh datablock (see
+    :func:`_ensure_single_user_meshes`). This is the single choke point every
+    solve/atlas entry point pulls its object list from (:func:`solve_scene`,
+    :func:`solve_scene_animated`, and the adapter's TEXEL atlas-plan caller), so doing
+    it here guarantees it happens once, early, before any per-vertex attribute or atlas
+    UV layer is ever written for these objects - regardless of which of those three
+    paths runs first in a given ``prepare_thermal`` call.
+    """
+    out: list = []
+    for obj in scene.objects:
+        if getattr(obj, "type", None) != "MESH":
+            continue
+        if not obj.visible_get() or obj.hide_render:
+            continue
+        if not bool(getattr(obj, "heat_simulation_enabled", True)):
+            continue
+        out.append(obj)
+    _ensure_single_user_meshes(out)
+    return out
+
+
+def _ensure_single_user_meshes(sim_objects: list) -> None:
+    """Give every object in ``sim_objects`` its own single-user mesh datablock.
+
+    Linked duplicates (multiple objects pointing at the same ``Mesh`` datablock, e.g.
+    Blender's Alt-D) share per-vertex attributes AND UV layers on that one datablock, so
+    writing ``sim_temperature``/the atlas UV layer for one object silently overwrites --
+    or is overwritten by -- every other object sharing it (last write wins). Copying the
+    mesh (``obj.data = obj.data.copy()``) whenever ``obj.data.users > 1`` makes each
+    object's write target independent.
+
+    Idempotent: once an object's mesh is single-user, ``users`` stays 1 on every later
+    call (e.g. repeated ``prepare_thermal`` calls on a long-lived RPyC service), so a
+    second pass over the same objects is a no-op.
+    """
+    unshared = 0
+    for obj in sim_objects:
+        mesh = getattr(obj, "data", None)
+        if mesh is None or getattr(mesh, "users", 1) <= 1:
+            continue
+        obj.data = mesh.copy()
+        unshared += 1
+    if unshared:
+        # Extra memory for heavily-instanced scenes (each un-shared copy is a full mesh
+        # datablock) - worth a visible log line, not a warning (this is expected/correct
+        # behavior for any scene using linked duplicates, not a misconfiguration).
+        _log.info(
+            "[heatsim.adapter] un-shared %d mesh datablock(s) referenced by multiple "
+            "simulated objects (linked duplicates) so each object's solved field/atlas "
+            "UVs write independently instead of colliding.", unshared,
+        )
+
+
+def _is_set(mat: Any, attr: str) -> bool:
+    """True iff *attr* was explicitly set on the per-object PropertyGroup *mat*.
+
+    ``obj.heat_sim_material`` is a ``PointerProperty`` registered on every object,
+    so ``mat`` is never ``None`` and a ``FloatProperty`` always returns its group
+    default - the global ``defaults`` (``--config.thermal.*``) would otherwise be
+    unreachable.  Blender's ``bpy_struct.is_property_set`` distinguishes an
+    explicitly-authored value from the registered default, restoring the locked
+    "per-object overrides, globals as fallback" contract.  Non-Blender fakes that
+    expose ``is_property_set`` are honoured too; anything else is treated as unset.
+    """
+    if mat is None:
+        return False
+    checker = getattr(mat, "is_property_set", None)
+    if checker is None:
+        return False
+    try:
+        return bool(checker(attr))
+    except Exception:  # pragma: no cover - defensive
+        return False
+
+
+def resolve_material(obj: Any, defaults: dict) -> dict:
+    """Resolve per-object thermal parameters.
+
+    Priority: an *explicitly set* per-object value on ``obj.heat_sim_material``
+    (detected via :func:`_is_set`), else the global ``defaults`` dict.  Because the
+    PropertyGroup is registered on every object, only ``is_property_set`` can tell a
+    user-authored override from the registered group default; without that gate the
+    global ``--config.thermal.*`` knobs would be silently inert.  SI units throughout
+    (``thermal_diffusivity`` in mm^2/s, ``density`` in kg/m^3, ``specific_heat`` in
+    J/(kg.K)).
+    """
+    mat = getattr(obj, "heat_sim_material", None)
+
+    def _pick(attr: str, key: str) -> float:
+        if _is_set(mat, attr):
+            return float(getattr(mat, attr))
+        return float(defaults[key])
+
+    role = "FEM_PARTICIPANT"
+    dirichlet_T = 0.0
+    if mat is not None and _is_set(mat, "thermal_role"):
+        role = str(mat.thermal_role or "FEM_PARTICIPANT").upper()
+    if mat is not None and _is_set(mat, "dirichlet_temperature_K"):
+        dirichlet_T = float(mat.dirichlet_temperature_K or 0.0)
+
+    return {
+        "initial_temperature_K": _pick("initial_temperature_K", "initial_temperature_K"),
+        "thermal_diffusivity_mm2_s": _pick("thermal_diffusivity_mm2_s", "thermal_diffusivity_mm2_s"),
+        "density_kg_m3": _pick("density_kg_m3", "density_kg_m3"),
+        "specific_heat_J_kgK": _pick("specific_heat_J_kgK", "specific_heat_J_kgK"),
+        "emissivity": float(np.clip(_pick("emissivity", "emissivity"), 0.0, 1.0)),
+        "thermal_role": role,
+        "dirichlet_temperature_K": dirichlet_T,
+    }
+
+
+def read_authored_irradiance_scale(scene: Any) -> float | None:
+    """Return the heat-sim addon's authored scene-level ``irradiance_scale``.
+
+    The addon stores it under ``scene.heat_sim_settings.irradiance_scale``.
+    VisionSim does not register that scene-level PropertyGroup, so the value is
+    read from the raw ID-property (``scene.get("heat_sim_settings")`` returns an
+    ``IDPropertyGroup``). Returns ``None`` when the blend has no authored
+    heat-sim scene settings, so the caller keeps its own default.
+    """
+    try:
+        raw = scene.get("heat_sim_settings")
+        if raw is None:
+            return None
+        val = raw.get("irradiance_scale")
+        return None if val is None else float(val)
+    except Exception:
+        return None
+
+
+# Robust percentile bounds for the preview colormap. Raw min/max lets a handful
+# of runaway/artifact vertices (low heat-capacity materials or coarse-mesh spikes
+# under an aggressive irradiance_scale) stretch tmax to thousands of Kelvin, which
+# crushes the entire ambient scene to the cool/black end of inferno and leaves
+# only the outlier blob visible. Clipping to P1..P99 discards those tails so the
+# colormap spans the temperatures the bulk of the scene actually occupies.
+_PREVIEW_PCT_LOW = 1.0
+_PREVIEW_PCT_HIGH = 99.0
+
+
+def global_temperature_range(history: dict[str, Any], default_K: float) -> tuple[float, float]:
+    """Robust global colormap range ``(tmin, tmax)`` in Kelvin over the solved scene.
+
+    Spans the **final-timestep** temperatures of every solved object (M1 renders
+    the final state on every frame), so the thermal preview colormap covers the
+    actual data instead of a fixed 295-400 K band. To keep a few artifact-hot
+    vertices from destroying the exposure, the bounds are the **1st and 99th
+    percentiles** of the pooled final-timestep temperatures rather than the raw
+    min/max. The lower bound is floored at ``default_K`` — unsolved meshes are
+    stamped at that temperature — and the span is widened to at least 1 K so a
+    near-uniform field does not collapse to a single colour.
+
+    Args:
+        history: ``{obj_name: (timesteps, vertices) array}`` from :func:`solve_scene`.
+        default_K: Default initial temperature stamped on unsolved meshes.
+
+    Returns:
+        ``(tmin, tmax)`` with ``tmax - tmin >= 1.0``.
+    """
+    finals = []
+    for arr in history.values():
+        a = np.asarray(arr, dtype=float)
+        if a.size:
+            row = a[-1] if a.ndim >= 2 else a
+            finals.append(np.asarray(row, dtype=float).reshape(-1))
+    if not finals:
+        return float(default_K), float(default_K) + 1.0
+    pooled = np.concatenate(finals)
+    pooled = pooled[np.isfinite(pooled)]
+    if pooled.size == 0:
+        return float(default_K), float(default_K) + 1.0
+    tmin = float(np.percentile(pooled, _PREVIEW_PCT_LOW))
+    tmax = float(np.percentile(pooled, _PREVIEW_PCT_HIGH))
+    tmin = min(tmin, float(default_K))
+    if tmax - tmin < 1.0:
+        tmax = tmin + 1.0
+    return tmin, tmax
+
+
+def global_temperature_range_animated(history: dict[str, Any], default_K: float) -> tuple[float, float]:
+    """Global colormap range ``(tmin, tmax)`` in Kelvin spanning EVERY frame of an animated solve.
+
+    Like :func:`global_temperature_range`, but folds in the full per-frame history instead
+    of only the final timestep. The animated (M2) field keeps evolving frame to frame, so a
+    final-frame-only range would clip the preview colormap against later (typically hotter)
+    frames -- this instead gives a single, stable scale for the whole sequence.
+
+    Args:
+        history: ``{obj_name: (n_frames, n_verts) array}`` from :func:`solve_scene_animated`.
+        default_K: Default initial temperature stamped on unsolved meshes.
+
+    Returns:
+        ``(tmin, tmax)`` with ``tmax - tmin >= 1.0``.
+    """
+    arrays = [np.asarray(arr, dtype=float) for arr in history.values() if np.asarray(arr).size]
+    if not arrays:
+        return float(default_K), float(default_K) + 1.0
+    tmin = min(float(np.min(a)) for a in arrays)
+    tmax = max(float(np.max(a)) for a in arrays)
+    tmin = min(tmin, float(default_K))
+    if tmax - tmin < 1.0:
+        tmax = tmin + 1.0
+    return tmin, tmax
+
+
+# ---------------------------------------------------------------------------
+# Geometry extraction (evaluated mesh -> world mm + triangulated faces)
+# ---------------------------------------------------------------------------
+
+
+def _extract_geometry(obj: Any) -> tuple | None:
+    """``(verts_mm (N,3) float64, faces (M,3) int32, n_verts)`` for the evaluated
+    mesh, or ``None`` if it has no geometry. Verts are world-space x 1000 (mm)
+    and quads are triangulated, matching ``fem_adapter._extract_mesh_data``.
+
+    The evaluated mesh's vertex order/count matches the Direct-Kernel irradiance
+    extraction (it uses the same ``foreach_get('co')`` path), so the returned
+    flux aligns index-for-index with these vertices.
+    """
+    depsgraph = bpy.context.evaluated_depsgraph_get()
+    mesh = obj.evaluated_get(depsgraph).data
+    n_verts = len(mesh.vertices)
+    if n_verts == 0 or len(mesh.polygons) == 0:
+        return None
+
+    flat: np.ndarray = np.zeros(n_verts * 3, dtype=np.float64)
+    mesh.vertices.foreach_get("co", flat)
+    verts: np.ndarray = flat.reshape(n_verts, 3)
+    mw = np.array(obj.matrix_world, dtype=np.float64)
+    verts = (verts @ mw[:3, :3].T) + mw[:3, 3]
+    verts = verts * _M_TO_MM  # world metres -> mm
+
+    poly_count = len(mesh.polygons)
+    loop_starts: np.ndarray = np.zeros(poly_count, dtype=np.int32)
+    loop_totals: np.ndarray = np.zeros(poly_count, dtype=np.int32)
+    mesh.polygons.foreach_get("loop_start", loop_starts)
+    mesh.polygons.foreach_get("loop_total", loop_totals)
+    loop_vidx: np.ndarray = np.zeros(len(mesh.loops), dtype=np.int32)
+    mesh.loops.foreach_get("vertex_index", loop_vidx)
+
+    face_arrays = []
+    tri_starts = loop_starts[loop_totals == 3]
+    if tri_starts.size:
+        face_arrays.append(
+            np.column_stack([loop_vidx[tri_starts], loop_vidx[tri_starts + 1], loop_vidx[tri_starts + 2]])
+        )
+    quad_starts = loop_starts[loop_totals == 4]
+    if quad_starts.size:
+        v0 = loop_vidx[quad_starts]
+        v1 = loop_vidx[quad_starts + 1]
+        v2 = loop_vidx[quad_starts + 2]
+        v3 = loop_vidx[quad_starts + 3]
+        face_arrays.append(np.column_stack([v0, v1, v2]))
+        face_arrays.append(np.column_stack([v0, v2, v3]))
+    if not face_arrays:
+        return None
+
+    faces = np.vstack(face_arrays).astype(np.int32)
+    return verts, faces, n_verts
+
+
+# ---------------------------------------------------------------------------
+# Thermal atlas (texel-sim) build
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AtlasPlan:
+    """The output of :func:`build_atlas_plan`: per-object texel tables ready for
+    :func:`_combine`'s TEXEL branch, plus the shared tile layout and the allocator
+    settings that produced it (kept around so :func:`solve_scene` can fold them into
+    the solve cache key).
+
+    ``texels`` maps object name -> ``{"position_mm" (K,3), "normal" (K,3), "uv" (K,2),
+    "xy" (K,2) int64, "face" (K,) int64, "face_material_index" (M,) int32}``. ``"xy"`` is
+    the tile-LOCAL integer texel coordinate (before the tile's ``AtlasLayout`` offset is
+    added) - :func:`write_atlas` (Task 3) uses it together with ``layout.tiles[name].offset``
+    to scatter this object's solved texel temperatures into the shared atlas image. Only
+    objects that made it all the way through selection, UV prep and rasterization appear
+    here; every other sim object (excluded by :func:`atlas.select_for_atlas`, or demoted
+    after a UV/vertex-count failure) is simply absent and keeps the per-vertex path in
+    ``_combine``.
+    """
+
+    layout: atlas.AtlasLayout
+    texels: dict[str, dict[str, np.ndarray]] = field(default_factory=dict)
+    density: float = 0.0
+    tile_min: int = 16
+    tile_max: int = 512
+    soft_max: int = 500_000
+    digest: str = ""
+
+
+def _atlas_digest(
+    layout: atlas.AtlasLayout,
+    tile_min: int,
+    tile_max: int,
+    soft_max: int,
+    texels: dict[str, dict[str, np.ndarray]],
+) -> str:
+    """Stable digest of an atlas allocation, for the solve cache key.
+
+    Must be computed from the FINISHED :class:`AtlasPlan`, not from ``atlas.allocate``'s
+    output alone: tiles are allocated for every object :func:`atlas.select_for_atlas`
+    admits, but the per-object rasterization loop in :func:`build_atlas_plan` can still
+    drop an object afterwards (UV unavailable, zero texels rasterized, evaluated mesh
+    missing the atlas UV layer). An object that is allocated a tile but never
+    contributes texels must NOT hash identically to one that fully participates - that
+    previously let a change which promoted dropped objects into the atlas leave the
+    cache key unchanged, silently reusing a stale solve. ``texels`` (``AtlasPlan.texels``)
+    is keyed only by objects that actually rasterized, so folding in each one's realized
+    texel count (sorted, for iteration-order stability) captures real participation on
+    top of the existing tile geometry.
+    """
+    payload = {
+        "density": round(float(layout.effective_density), 6),
+        "tile_min": int(tile_min),
+        "tile_max": int(tile_max),
+        "soft_max": int(soft_max),
+        "atlas_size": list(layout.atlas_size),
+        "tiles": sorted(
+            (name, list(spec.size), list(spec.offset)) for name, spec in layout.tiles.items()
+        ),
+        "texel_counts": sorted(
+            (name, int(obj_texels["xy"].shape[0])) for name, obj_texels in texels.items()
+        ),
+    }
+    return hashlib.sha1(json.dumps(payload, sort_keys=True).encode()).hexdigest()[:16]
+
+
+def _prepare_bake_uv(obj: Any) -> None:
+    """Lazy-import wrapper around ``irradiance.prepare_object_bake_uv``.
+
+    Keeps this module importable without ``bpy`` (mirrors :func:`_compute_irradiance`'s
+    lazy import of ``irradiance_kernel``); tests monkeypatch this function directly.
+    """
+    from visionsim.simulate.heatsim import irradiance
+
+    irradiance.prepare_object_bake_uv(obj)
+
+
+def _face_uv_and_slots_from_mesh(mesh: Any, uv_layer_name: str) -> tuple | None:
+    """``(loop_uv (M,3,2) float64 in [0,1], face_material_index (M,) int32)`` for an
+    arbitrary Blender mesh datablock, triangulated identically to
+    :func:`_extract_geometry` (all triangle-polygons first, then each quad's two
+    triangles in ``(v0,v1,v2)`` / ``(v0,v2,v3)`` order) so a texel's ``face`` index
+    from ``atlas.rasterize_tile`` lines up with the same triangle in both this
+    function's output and :func:`_extract_geometry`'s ``faces`` (when both are read
+    from the SAME mesh - base or evaluated). Reads UVs from the named UV layer on
+    ``mesh.loops``. Returns ``None`` if the mesh has no polygons or lacks that UV layer.
+
+    Shared core for :func:`_extract_evaluated_face_uv_and_slots`, which reads the
+    :func:`_extract_evaluated_face_uv_and_slots` (evaluated mesh).
+    """
+    if mesh is None:
+        return None
+    uv_layers = getattr(mesh, "uv_layers", None)
+    uv_layer = uv_layers.get(uv_layer_name) if uv_layers is not None else None
+    if uv_layer is None:
+        return None
+    poly_count = len(mesh.polygons)
+    if poly_count == 0:
+        return None
+
+    loop_starts: np.ndarray = np.zeros(poly_count, dtype=np.int32)
+    loop_totals: np.ndarray = np.zeros(poly_count, dtype=np.int32)
+    mesh.polygons.foreach_get("loop_start", loop_starts)
+    mesh.polygons.foreach_get("loop_total", loop_totals)
+    mat_index: np.ndarray = np.zeros(poly_count, dtype=np.int32)
+    mesh.polygons.foreach_get("material_index", mat_index)
+
+    uv_flat: np.ndarray = np.zeros(len(mesh.loops) * 2, dtype=np.float64)
+    uv_layer.data.foreach_get("uv", uv_flat)
+    loop_uv_all = uv_flat.reshape(-1, 2)
+
+    uv_parts = []
+    slot_parts = []
+    tri_mask = loop_totals == 3
+    tri_starts = loop_starts[tri_mask]
+    if tri_starts.size:
+        uv_parts.append(
+            np.stack([loop_uv_all[tri_starts], loop_uv_all[tri_starts + 1], loop_uv_all[tri_starts + 2]], axis=1)
+        )
+        slot_parts.append(mat_index[tri_mask])
+    quad_mask = loop_totals == 4
+    quad_starts = loop_starts[quad_mask]
+    if quad_starts.size:
+        u0 = loop_uv_all[quad_starts]
+        u1 = loop_uv_all[quad_starts + 1]
+        u2 = loop_uv_all[quad_starts + 2]
+        u3 = loop_uv_all[quad_starts + 3]
+        uv_parts.append(np.stack([u0, u1, u2], axis=1))
+        uv_parts.append(np.stack([u0, u2, u3], axis=1))
+        slot_parts.append(mat_index[quad_mask])
+        slot_parts.append(mat_index[quad_mask])
+    if not uv_parts:
+        return None
+
+    loop_uv = np.vstack(uv_parts).astype(np.float64)
+    face_material_index = np.concatenate(slot_parts).astype(np.int32)
+    return loop_uv, face_material_index
+
+
+def _extract_evaluated_face_uv_and_slots(obj: Any, uv_layer_name: str) -> tuple | None:
+    """:func:`_face_uv_and_slots_from_mesh` for ``obj``'s EVALUATED mesh (post-modifier).
+
+    Used to read back a UV layer (e.g. ``ATLAS_UV_LAYER_NAME``) that was written to the
+    base mesh and has since propagated through the modifier stack - Bevel interpolates
+    named UV layers onto new geometry, EdgeSplit duplicates them, and most Geometry
+    Nodes setups preserve them, so this is how atlas participants with topology-changing
+    modifiers get UVs that correspond 1:1 with :func:`_extract_geometry`'s evaluated
+    ``faces`` for the SAME object. Returns ``None`` if the evaluated mesh has no polygons
+    or the modifier stack dropped the named layer (some Geometry Nodes setups do).
+    """
+    depsgraph = bpy.context.evaluated_depsgraph_get()
+    mesh = obj.evaluated_get(depsgraph).data
+    return _face_uv_and_slots_from_mesh(mesh, uv_layer_name)
+
+
+def _write_atlas_uv_layer(obj: Any, tile: atlas.TileSpec, atlas_size: tuple, src_layer_name: str) -> None:
+    """Remap ``src_layer_name``'s per-loop UVs into ``tile``'s placement inside the
+    shared atlas image and store the result as a fresh ``ATLAS_UV_LAYER_NAME`` UV layer
+    on ``obj``'s BASE mesh (per spec ``4.1`` - the thermal AOV shader samples the atlas
+    image through this layer at render time). It must land on the base mesh, not a
+    to_mesh() copy, so the modifier stack propagates it (Bevel interpolates named UV
+    layers onto new geometry, EdgeSplit duplicates them, most Geometry Nodes setups
+    preserve them) - :func:`build_atlas_plan` then forces a depsgraph update and reads
+    it back via :func:`_extract_evaluated_face_uv_and_slots` to rasterize from geometry
+    that matches what the solver actually used. Best-effort: never raises, since a
+    failure here must not abort the solve - it degrades to the per-vertex path via the
+    caller's own "evaluated mesh lacks the atlas UV layer" check.
+    """
+    mesh = getattr(obj, "data", None)
+    if mesh is None:
+        return
+    uv_layers = getattr(mesh, "uv_layers", None)
+    if uv_layers is None:
+        return
+    src = uv_layers.get(src_layer_name)
+    if src is None:
+        return
+    aw, ah = atlas_size
+    if aw <= 0 or ah <= 0:
+        return
+    try:
+        n_loops = len(mesh.loops)
+        flat: np.ndarray = np.zeros(n_loops * 2, dtype=np.float64)
+        src.data.foreach_get("uv", flat)
+        uv = flat.reshape(-1, 2)
+
+        tw, th = tile.size
+        tx, ty = tile.offset
+        atlas_uv = np.empty_like(uv)
+        atlas_uv[:, 0] = (tx + uv[:, 0] * tw) / aw
+        atlas_uv[:, 1] = (ty + uv[:, 1] * th) / ah
+
+        if ATLAS_UV_LAYER_NAME in uv_layers:
+            uv_layers.remove(uv_layers[ATLAS_UV_LAYER_NAME])
+        dst = uv_layers.new(name=ATLAS_UV_LAYER_NAME)
+        dst.data.foreach_set("uv", atlas_uv.ravel())
+        mesh.update()
+        # Force the depsgraph to re-evaluate the modifier stack with the new UV layer
+        # in place, so the very next evaluated-mesh access (build_atlas_plan's read-back)
+        # sees it instead of a stale cached evaluation from before this write.
+        if bpy is not None:
+            bpy.context.view_layer.update()
+    except Exception as exc:  # pragma: no cover - defensive, mirrors irradiance.py's style
+        _log.warning("[heatsim.adapter] '%s': failed to write %s: %s", obj.name, ATLAS_UV_LAYER_NAME, exc)
+
+
+def build_atlas_plan(scene: Any, sim_objects: list, cfg: dict) -> AtlasPlan:
+    """Select, size and rasterize the thermal atlas for ``sim_objects``.
+
+    Per §4.1-4.2 of the design spec: an object joins the atlas iff its native vertex
+    density is below ``cfg['atlas_texel_density']`` (:func:`atlas.select_for_atlas`);
+    joining objects get a tile sized by surface area (:func:`atlas.allocate`) and
+    rasterized into texel sample points (:func:`atlas.rasterize_tile`) using the
+    object's bake UV (created/unwrapped by the existing hardened
+    ``irradiance.prepare_object_bake_uv`` machinery).
+
+    Rasterization is fully EVALUATED-mesh based: the atlas UV layer is written to the
+    BASE mesh (so Bevel/EdgeSplit/Geometry-Nodes modifier stacks propagate it), the
+    depsgraph is forced to re-evaluate, and both the triangle geometry (from
+    :func:`_extract_geometry`) and the UVs/material indices used to rasterize (from
+    :func:`_extract_evaluated_face_uv_and_slots`) are read from that SAME evaluated
+    mesh - so a mismatch between the base mesh's vertex count and the evaluated
+    geometry's (Bevel, Geometry Nodes, EdgeSplit, ...) is no longer meaningful and no
+    longer demotes the object. A temperature atlas is UV-addressed, not
+    vertex-addressed, so it does not care how many vertices the base mesh has.
+
+    An object is demoted to the vertex path (excluded from the returned plan's
+    ``texels``, with a warning - never raised) when: its bake-UV prep fails to produce
+    a usable UV layer, the modifier stack drops the atlas UV layer entirely (some
+    Geometry Nodes setups do), or its UV triangulation doesn't match the evaluated
+    geometry's triangle count. Every check degrades gracefully; this function never
+    raises for a per-object failure.
+    """
+    density = float(cfg.get("atlas_texel_density", 1500.0))  # keep in sync with ThermalConfig.atlas_texel_density
+    tile_min = int(cfg.get("atlas_tile_min", 16))
+    tile_max = int(cfg.get("atlas_tile_max", 512))
+    soft_max = int(cfg.get("atlas_texel_soft_max", 500_000))
+
+    geoms: dict[str, tuple] = {}
+    areas: dict[str, float] = {}
+    retained_vertex_count = 0
+    for obj in sim_objects:
+        geom = _extract_geometry(obj)
+        if geom is None:
+            continue
+        verts, faces, n = geom
+        geoms[obj.name] = (obj, verts, faces, n)
+        area_m2 = atlas.surface_area_m2(verts, faces)
+        # `n` is the EVALUATED vertex count `_extract_geometry` just read; the per-vertex
+        # write-back path (`write_frame_attributes`) can only write onto the BASE mesh
+        # (`obj.data.vertices`). When a topology-changing modifier (Bevel, Subdivision,
+        # Geometry Nodes, ...) makes those counts differ, write-back is structurally
+        # impossible regardless of how dense the object already looks, so the density
+        # rule doesn't apply - force atlas participation instead of silently discarding
+        # the solved field later.
+        writeback_possible = len(obj.data.vertices) == n
+        if atlas.select_for_atlas(n, area_m2, density, writeback_possible=writeback_possible):
+            areas[obj.name] = area_m2
+        else:
+            retained_vertex_count += n
+
+    layout = atlas.allocate(
+        areas, density, tile_min=tile_min, tile_max=tile_max, soft_max=soft_max,
+        retained_vertex_count=retained_vertex_count, padding=_ATLAS_PACKING_PADDING,
+    )
+
+    texels: dict[str, dict[str, np.ndarray]] = {}
+    for name in areas:
+        obj, verts, faces, _n = geoms[name]
+        tile = layout.tiles.get(name)
+        if tile is None:
+            continue
+
+        # Write the atlas UV layer onto the BASE mesh first (so Bevel/EdgeSplit/GN
+        # modifiers propagate it) and force a depsgraph update, then read triangles'
+        # UVs + material indices back from the EVALUATED mesh - the same mesh
+        # `verts`/`faces` above came from - so face indices line up 1:1 regardless of
+        # whether the base and evaluated vertex counts agree.
+        _prepare_bake_uv(obj)
+        _write_atlas_uv_layer(obj, tile, layout.atlas_size, BAKE_UV_LAYER_NAME)
+        uv_result = _extract_evaluated_face_uv_and_slots(obj, ATLAS_UV_LAYER_NAME)
+        if uv_result is None:
+            _log.warning(
+                "[heatsim.adapter] '%s': %s unavailable on the evaluated mesh (bake-UV unwrap "
+                "failed, or the modifier stack dropped the named layer); demoted from the atlas "
+                "to the per-vertex path.", name, ATLAS_UV_LAYER_NAME,
+            )
+            continue
+        atlas_loop_uv, face_material_index = uv_result
+        if atlas_loop_uv.shape[0] != faces.shape[0]:
+            _log.warning(
+                "[heatsim.adapter] '%s': UV triangulation (%d tris) does not match evaluated "
+                "geometry (%d tris); demoted from the atlas to the per-vertex path.",
+                name, atlas_loop_uv.shape[0], faces.shape[0],
+            )
+            continue
+
+        # `atlas_loop_uv` is already atlas-global [0,1] (written by _write_atlas_uv_layer
+        # as `(tile.offset + bake_uv * tile.size) / atlas_size`); invert that remap back to
+        # tile-local [0,1] here so `atlas.rasterize_tile` keeps its existing tile-local
+        # contract unchanged.
+        tw, th = tile.size
+        tx, ty = tile.offset
+        aw, ah = layout.atlas_size
+        loop_uv = np.empty_like(atlas_loop_uv)
+        loop_uv[..., 0] = (atlas_loop_uv[..., 0] * aw - tx) / tw
+        loop_uv[..., 1] = (atlas_loop_uv[..., 1] * ah - ty) / th
+
+        raster = atlas.rasterize_tile(verts, faces, loop_uv, tile.size)
+        if raster["xy"].shape[0] == 0:
+            _log.warning(
+                "[heatsim.adapter] '%s': atlas tile rasterized zero texels; "
+                "demoted from the atlas to the per-vertex path.", name,
+            )
+            continue
+
+        uv_at_texel = np.empty((raster["xy"].shape[0], 2), dtype=np.float64)
+        uv_at_texel[:, 0] = (raster["xy"][:, 0].astype(np.float64) + 0.5) / tw
+        uv_at_texel[:, 1] = (raster["xy"][:, 1].astype(np.float64) + 0.5) / th
+
+        texels[name] = {
+            "position_mm": raster["position_mm"],
+            "normal": raster["normal"],
+            "uv": uv_at_texel,
+            "xy": raster["xy"],
+            "face": raster["face"],
+            "face_material_index": face_material_index,
+        }
+
+    digest = _atlas_digest(layout, tile_min, tile_max, soft_max, texels)
+    return AtlasPlan(
+        layout=layout, texels=texels, density=layout.effective_density,
+        tile_min=tile_min, tile_max=tile_max, soft_max=soft_max, digest=digest,
+    )
+
+
+# Push-out margin dilation, in texels. Invariant: 2 * iterations <= the packing
+# `padding` (see build_atlas_plan's atlas.allocate(..., padding=_ATLAS_PACKING_PADDING)
+# call). Each dilate pass grows a tile's valid region by at most 1px, and TWO adjacent
+# tiles dilate toward each other from both sides of the gap -- so the gap must be wide
+# enough for both expansions with no meeting point, or the middle gap texels would be
+# filled with the MEAN of two unrelated objects' temperatures. The assert below enforces
+# it; see the design spec's "seam bleeding" risk note.
+#
+# One iteration is not enough. A single pass protects only a 1-texel ring, but the atlas
+# also contains INTERIOR holes -- texels inside a tile that no solved element scattered
+# into. Measured on visionsim50/kitchen1: 25 invalid components inside/near tile interiors
+# sized 1-462 texels, far beyond a one-texel margin. Render-time bilinear filtering then
+# straddles those valid/invalid edges and drags T_effective under the solve floor (2665
+# sub-295 K pixels in a single frame; they disappear under render_domain=VERTEX).
+#
+# 8 passes fill a hole of radius <= 8 texels outright, and the shader thresholds the atlas
+# alpha so anything still unfilled falls back to the object-level default rather than
+# blending a half-zeroed colour (see thermal_shader._build_temperature_source_chain).
+# Padding grows in lockstep to keep neighbouring tiles from meeting; the cost is a modest
+# increase in packed atlas area.
+_ATLAS_DILATE_ITERATIONS = 8
+_ATLAS_PACKING_PADDING = 17
+assert 2 * _ATLAS_DILATE_ITERATIONS <= _ATLAS_PACKING_PADDING, "dilation would bridge tile padding"
+
+
+def _scatter_atlas_arrays(history: dict, atlas_plan: AtlasPlan) -> tuple[np.ndarray, np.ndarray]:
+    """Pure-numpy core of :func:`write_atlas`: scatter + dilate, no ``bpy``.
+
+    Returns ``(temperature, alpha)``, both ``(H, W)`` float64/bool-as-float64 arrays sized
+    to ``atlas_plan.layout.atlas_size``. ``temperature`` is dilated so bilinear sampling
+    never reads an untouched (zero) texel; ``alpha`` is 1.0 wherever the dilation actually
+    reached (originally-solved texels AND their filled margin), 0.0 everywhere else
+    (never-covered tile interior, inter-tile padding, and any unused atlas margin).
+    """
+    width, height = atlas_plan.layout.atlas_size
+    temp: np.ndarray = np.zeros((height, width), dtype=np.float64)
+    valid: np.ndarray = np.zeros((height, width), dtype=bool)
+
+    for name, tex in atlas_plan.texels.items():
+        tile = atlas_plan.layout.tiles.get(name)
+        hist = history.get(name)
+        if tile is None or hist is None:
+            continue
+        arr = np.asarray(hist, dtype=np.float64)
+        xy = tex.get("xy")
+        xy = np.asarray(xy, dtype=np.int64) if xy is not None else None
+        if arr.ndim != 2 or arr.shape[0] == 0 or xy is None or xy.shape[0] != arr.shape[1]:
+            _log.warning(
+                "[heatsim.adapter] write_atlas: '%s' history shape %s does not match its "
+                "texel table (%s); skipped -- that object's tile stays unsolved (dilated "
+                "from neighbours, or zero/invalid if isolated).",
+                name, arr.shape, None if xy is None else xy.shape,
+            )
+            continue
+
+        final = arr[-1]
+        tx, ty = tile.offset
+        px = xy[:, 0] + tx
+        py = xy[:, 1] + ty
+        temp[py, px] = final
+        valid[py, px] = True
+
+    # Dilate the temperature field, then dilate a {0,1} "alpha image" seeded with the SAME
+    # `valid` mask and iteration count: every fillable pixel there is a weighted mean of
+    # neighbours that are each exactly 1.0 (valid texels always hold 1.0 in this second
+    # array), so the result is exactly 1.0 wherever the real dilation above reached, and
+    # exactly 0.0 wherever it didn't -- i.e. the post-dilation validity mask, with no new
+    # atlas.py API needed.
+    temp_dilated = atlas.dilate(temp, valid, iterations=_ATLAS_DILATE_ITERATIONS)
+    alpha_dilated = atlas.dilate(valid.astype(np.float64), valid, iterations=_ATLAS_DILATE_ITERATIONS)
+    alpha = (alpha_dilated > 0.5).astype(np.float64)
+    return temp_dilated, alpha
+
+
+def write_atlas(history: dict, atlas_plan: AtlasPlan, cache_root: Path) -> Path:
+    """Write the final-timestep texel temperatures to a 32-bit float EXR atlas image.
+
+    Scatters every atlas-participating object's LAST solved timestep into the shared atlas
+    array at its tile's texels (:func:`_scatter_atlas_arrays`), push-out dilates across the
+    invalid margin so render-time bilinear filtering never samples an untouched texel, and
+    saves an RGBA float EXR (R=G=B=temperature in Kelvin, A=1 where valid/dilated coverage
+    exists, 0 elsewhere) to ``<cache_root>/atlas_<digest>/atlas_temperature.exr``. The caller
+    (``blender.py``) is expected to load and pack the result as the ``HeatSim_Temperature_Atlas``
+    Blender image before wiring the shader (:mod:`thermal_shader`) or rendering.
+
+    Args:
+        history: ``{obj_name: (timesteps, K) array}`` as returned by :func:`solve_scene`
+            (called with this same ``atlas_plan``); ``K`` must match each atlas object's
+            texel count for its temperatures to be scattered (a mismatch is logged and that
+            object's tile is left to dilation/zero).
+        atlas_plan: The plan from :func:`build_atlas_plan` that produced ``history``'s
+            TEXEL-mode objects.
+        cache_root: Root directory for thermal caches (same one passed to :func:`solve_scene`).
+
+    Returns:
+        Path to the written EXR file.
+    """
+    cache_root = Path(cache_root)
+    out_dir = cache_root / f"atlas_{atlas_plan.digest or 'noatlas'}"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "atlas_temperature.exr"
+
+    width, height = atlas_plan.layout.atlas_size
+    width, height = max(int(width), 1), max(int(height), 1)
+    if atlas_plan.layout.atlas_size == (0, 0) or not atlas_plan.texels:
+        temp_dilated: np.ndarray = np.zeros((height, width), dtype=np.float64)
+        alpha: np.ndarray = np.zeros((height, width), dtype=np.float64)
+    else:
+        temp_dilated, alpha = _scatter_atlas_arrays(history, atlas_plan)
+
+    rgba: np.ndarray = np.zeros((height, width, 4), dtype=np.float32)
+    rgba[..., 0] = temp_dilated
+    rgba[..., 1] = temp_dilated
+    rgba[..., 2] = temp_dilated
+    rgba[..., 3] = alpha
+
+    write_image_name = "HeatSim_Temperature_Atlas_Write"
+    existing = bpy.data.images.get(write_image_name)
+    if existing is not None:
+        bpy.data.images.remove(existing)
+    image = bpy.data.images.new(write_image_name, width=width, height=height, alpha=True, float_buffer=True)
+    # Temperatures are data, not color: bpy.data.images.new()'s default colorspace tag
+    # (here, effectively a non-identity "Linear Rec.709" role under this OCIO config --
+    # empirically confirmed to apply the sRGB-like OETF on save) makes Image.save() treat
+    # the raw Kelvin values as scene-linear color and re-encode them, corrupting the
+    # written EXR's absolute values (295.0 K -> ~11.23 in the file). Tag Non-Color so
+    # save()/load() are the identity transform and the file holds the literal float value.
+    try:
+        image.colorspace_settings.name = "Non-Color"
+    except Exception:  # pragma: no cover - defensive, mirrors irradiance.py's style
+        pass
+    image.pixels.foreach_set(rgba.ravel())
+    image.filepath_raw = str(out_path)
+    image.file_format = "OPEN_EXR"
+    image.save()
+    bpy.data.images.remove(image)
+
+    _log.debug(
+        "[heatsim.adapter] write_atlas: wrote %s (%dx%d, %d object(s))",
+        out_path, width, height, len(atlas_plan.texels),
+    )
+    return out_path
+
+
+def _sample_bilinear(pixels: np.ndarray, width: int, height: int, uv: np.ndarray) -> np.ndarray:
+    """Vectorized bilinear luminance sample from an ``(H, W, 3)`` image at ``(K, 2)``
+    UV coordinates in ``[0, 1]``. Mirrors ``irradiance._bilinear_sample`` (same
+    clamp/floor/lerp math and Rec.709 luma weights) but for many points at once."""
+    u = np.clip(uv[:, 0], 0.0, 1.0)
+    v = np.clip(uv[:, 1], 0.0, 1.0)
+    x = u * (width - 1)
+    y = v * (height - 1)
+    x0 = np.floor(x).astype(np.int64)
+    y0 = np.floor(y).astype(np.int64)
+    x1 = np.minimum(x0 + 1, width - 1)
+    y1 = np.minimum(y0 + 1, height - 1)
+    tx = (x - x0)[:, np.newaxis]
+    ty = (y - y0)[:, np.newaxis]
+
+    c00 = pixels[y0, x0]
+    c10 = pixels[y0, x1]
+    c01 = pixels[y1, x0]
+    c11 = pixels[y1, x1]
+    c0 = c00 * (1 - tx) + c10 * tx
+    c1 = c01 * (1 - tx) + c11 * tx
+    rgb = c0 * (1 - ty) + c1 * ty
+    return rgb @ np.array((0.2126, 0.7152, 0.0722), dtype=np.float64)
+
+
+def _texel_albedo(scene: Any, obj: Any, uv_at_texel: np.ndarray, texture_size: int) -> np.ndarray:
+    """Bilinear-sample ``obj``'s Cycles albedo bake at texel UV centers.
+
+    Reuses ``irradiance.bake_albedo_map`` - the same bake primitive
+    ``irradiance_kernel.get_or_bake_vertex_albedo`` reduces to per-vertex values - but
+    samples its ``(H, W, 3)`` pixel grid directly instead of averaging it down, so the
+    texel gets its own native-resolution albedo. On any bake failure every texel gets
+    albedo=0 (full absorption), the same fallback the per-vertex kernel path uses for a
+    missing bake.
+    """
+    k = int(uv_at_texel.shape[0])
+    if k == 0:
+        return np.zeros(0, dtype=np.float64)
+    try:
+        from visionsim.simulate.heatsim import irradiance
+
+        baked = irradiance.bake_albedo_map(scene, obj, texture_size)
+    except Exception as exc:  # pragma: no cover - defensive, mirrors irradiance.py's style
+        _log.warning("[heatsim.adapter] '%s': albedo bake failed for texel sampling: %s", obj.name, exc)
+        baked = None
+    if baked is None or getattr(baked, "pixels", None) is None:
+        return np.zeros(k, dtype=np.float64)
+    luma = _sample_bilinear(baked.pixels, int(baked.width), int(baked.height), uv_at_texel)
+    return np.clip(luma, 0.0, 1.0)
+
+
+def _texel_irradiance_cycles(
+    scene: Any, obj: Any, uv_at_texel: np.ndarray, texture_size: int, samples: int | None = None
+) -> np.ndarray:
+    """Bilinear-sample ``obj``'s Cycles irradiance bake at texel UV centers.
+
+    The Cycles counterpart to :func:`_texel_albedo`, sampling the same UVs from the
+    DIFFUSE DIRECT+INDIRECT bake instead of the COLOR bake. Returns *incident* W/m^2;
+    the caller applies (1 - albedo) to get absorbed flux.
+
+    On bake failure every texel gets 0 W/m^2 - the surface then simply holds its
+    initial temperature, which is the same failure mode as a missing Direct-Kernel
+    contribution and is preferable to inventing flux.
+    """
+    k = int(uv_at_texel.shape[0])
+    if k == 0:
+        return np.zeros(0, dtype=np.float64)
+    try:
+        from visionsim.simulate.heatsim import irradiance
+
+        baked = irradiance.bake_irradiance_map(scene, obj, texture_size, samples=samples)
+    except Exception as exc:  # pragma: no cover - defensive, mirrors irradiance.py's style
+        _log.warning("[heatsim.adapter] '%s': irradiance bake failed for texel sampling: %s", obj.name, exc)
+        baked = None
+    if baked is None or getattr(baked, "pixels", None) is None:
+        return np.zeros(k, dtype=np.float64)
+    lum = _sample_bilinear(baked.pixels, int(baked.width), int(baked.height), uv_at_texel)
+    return np.maximum(np.asarray(lum, dtype=np.float64) * CYCLES_LOUT_TO_IRRADIANCE, 0.0)
+
+
+def _compute_irradiance_cycles(scene: Any, sim_objects: list, solver_cfg: dict, defaults: dict) -> dict:
+    """Per-vertex irradiance from a Cycles bake -> ``{obj: (N,) float64 W/m^2 absorbed}``.
+
+    Drop-in alternative to :func:`_compute_irradiance` (the analytic Direct Kernel),
+    selected by ``solver_cfg["irradiance_source"] == "CYCLES_BAKE"``.
+
+    The Direct Kernel counts only ``LIGHT`` objects plus an unshadowed SH9 sky and
+    models no indirect bounce, so a scene lit by emissive geometry gets no flux at all
+    (visionsim50/classroom: 6.17 m^2 of emissive windows contributing exactly zero).
+    Cycles resolves emissive meshes, bounce and portals because it is a path tracer.
+
+    The bake yields *incident* irradiance, so (1 - albedo) is applied here to match the
+    Direct Kernel's absorbed-flux contract. Albedo comes from the bake that already runs
+    for the kernel path, so no extra Cycles work is introduced by the conversion.
+    """
+    from visionsim.simulate.heatsim import irradiance, irradiance_kernel
+
+    texture_size = int(solver_cfg.get("irradiance_texture_size", 512))
+    bake_samples = int(solver_cfg.get("bake_samples", 1024))
+    out: dict = {}
+    for obj in sim_objects:
+        if resolve_material(obj, defaults)["thermal_role"] == "DIRICHLET_SOURCE":
+            continue  # mirrors compute_per_vertex_irradiance's own Dirichlet skip
+        try:
+            baked = irradiance.bake_irradiance_map(scene, obj, texture_size, samples=bake_samples)
+        except Exception as exc:  # pragma: no cover - defensive
+            _log.warning("[heatsim.adapter] '%s': irradiance bake failed: %s", obj.name, exc)
+            baked = None
+        if baked is None or getattr(baked, "vertex_flux", None) is None:
+            continue
+        incident = np.asarray(baked.vertex_flux, dtype=np.float64).reshape(-1)
+        # `get_or_bake_vertex_albedo` takes a LIST and returns {name: (N,) array}; its
+        # `texture_size` is keyword-only. Getting either wrong raises TypeError, and a
+        # bare `except` here would turn that into albedo=0 -- i.e. full absorption, up to
+        # ~4x the correct flux on a light surface -- with no way to notice. Both
+        # degradation paths below therefore log.
+        albedo = None
+        try:
+            albedo_by_name = irradiance_kernel.get_or_bake_vertex_albedo(
+                scene, [obj], texture_size=texture_size
+            )
+            raw = albedo_by_name.get(obj.name)
+            if raw is not None:
+                albedo = np.clip(np.asarray(raw, dtype=np.float64).reshape(-1), 0.0, 1.0)
+        except Exception as exc:  # pragma: no cover - defensive
+            _log.warning(
+                "[heatsim.adapter] '%s': vertex albedo bake failed (%s); assuming full "
+                "absorption, which OVERESTIMATES absorbed flux.", obj.name, exc,
+            )
+        if albedo is None:
+            albedo = np.zeros_like(incident)
+        elif albedo.shape != incident.shape:
+            _log.warning(
+                "[heatsim.adapter] '%s': albedo has %d entries but irradiance has %d "
+                "(the two bakes disagree about which mesh they sampled); assuming full "
+                "absorption, which OVERESTIMATES absorbed flux.",
+                obj.name, albedo.shape[0], incident.shape[0],
+            )
+            albedo = np.zeros_like(incident)
+        out[obj] = np.maximum(incident * (1.0 - albedo), 0.0)
+    return out
+
+
+def _compute_texel_irradiance(
+    scene: Any, sim_objects: list, atlas_plan: AtlasPlan, solver_cfg: dict, defaults: dict
+) -> dict:
+    """Per-texel Direct-Kernel irradiance for every atlas-participating object.
+
+    Returns ``{obj: (K,) float64 W/m^2 absorbed}``, keyed the same way as
+    :func:`_compute_irradiance`'s return value so both can feed the same
+    ``flux_by_obj`` dict into :func:`_combine`.
+
+    Builds the scene BVH backend exactly **once** per call (not once per atlas
+    object) and reuses it across every ``compute_irradiance_at_points`` call below
+    via that function's optional ``backend`` parameter -- with N atlas objects this
+    was previously N full scene BVH rebuilds. Also threads the same
+    ``direct_kernel_soft_shadow_rays`` knob :func:`_compute_irradiance` reads from
+    ``solver_cfg`` through to the texel kernel, so both irradiance paths use the
+    same shadow-ray sample count instead of the kernel's hardcoded default.
+    """
+    from visionsim.simulate.heatsim import bvh_backend, irradiance_kernel
+
+    texture_size = int(solver_cfg.get("irradiance_texture_size", 512))
+    n_samples_for_area = int(solver_cfg.get("direct_kernel_soft_shadow_rays", 8))
+    use_cycles = str(solver_cfg.get("irradiance_source", "DIRECT_KERNEL")).upper() == "CYCLES_BAKE"
+    bake_samples = int(solver_cfg.get("bake_samples", 1024))
+    by_name = {o.name: o for o in sim_objects}
+
+    # Only the Direct Kernel traces shadow rays; building a whole-scene BVH for the
+    # Cycles path costs a full build that is then never queried. Still built exactly
+    # once (pre-loop), not per object.
+    backend = None
+    if not use_cycles:
+        backend = bvh_backend.best_available()
+        backend.build_for_meshes(irradiance_kernel._collect_scene_meshes_world(scene))
+
+    out: dict = {}
+    for name, tex in atlas_plan.texels.items():
+        obj = by_name.get(name)
+        if obj is None:
+            continue
+        if resolve_material(obj, defaults)["thermal_role"] == "DIRICHLET_SOURCE":
+            continue  # mirrors compute_per_vertex_irradiance's own Dirichlet skip
+        positions = np.asarray(tex["position_mm"], dtype=np.float64)
+        normals = np.asarray(tex["normal"], dtype=np.float64)
+        uv = np.asarray(tex["uv"], dtype=np.float64)
+        albedo = _texel_albedo(scene, obj, uv, texture_size)
+        if use_cycles:
+            # Cycles bake gives INCIDENT irradiance; apply (1 - albedo) to match the
+            # Direct Kernel's absorbed-flux contract.
+            flux = _texel_irradiance_cycles(scene, obj, uv, texture_size, samples=bake_samples) * (1.0 - albedo)
+        else:
+            flux = irradiance_kernel.compute_irradiance_at_points(
+                scene, positions, normals, albedo, backend=backend, n_samples_for_area=n_samples_for_area
+            )
+        out[obj] = np.asarray(flux, dtype=np.float64).reshape(-1)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Direct-Kernel irradiance
+# ---------------------------------------------------------------------------
+
+
+def _compute_irradiance(scene: Any, sim_objects: list, solver_cfg: dict, defaults: dict) -> dict:
+    """Run the Direct-Kernel and return ``{obj: (N,) float64 W/m^2 absorbed}``."""
+    if str(solver_cfg.get("irradiance_source", "DIRECT_KERNEL")).upper() == "CYCLES_BAKE":
+        return _compute_irradiance_cycles(scene, sim_objects, solver_cfg, defaults)
+
+    from visionsim.simulate.heatsim import irradiance_kernel
+
+    # SimpleNamespace surrogate for the addon's scene PropertyGroup (the kernel
+    # only reads these via getattr(..., default)). Sky occlusion defaults off so
+    # the kernel takes the unoccluded SH9 sky path (no per-vertex AO bake).
+    settings = SimpleNamespace(
+        irradiance_texture_size=int(solver_cfg.get("irradiance_texture_size", 512)),
+        enable_sky_occlusion=bool(solver_cfg.get("enable_sky_occlusion", False)),
+        sky_ao_min_for_bent=float(solver_cfg.get("sky_ao_min_for_bent", 0.02)),
+        direct_kernel_soft_shadow_rays=int(solver_cfg.get("direct_kernel_soft_shadow_rays", 8)),
+    )
+    raw = irradiance_kernel.compute_per_vertex_irradiance(scene, list(sim_objects), settings)
+    out: dict = {}
+    for obj, payload in raw.items():
+        flux = payload.get("vertex_flux") if isinstance(payload, dict) else payload
+        if flux is not None:
+            out[obj] = np.asarray(flux, dtype=np.float64).reshape(-1)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Combine objects into one FEM system
+# ---------------------------------------------------------------------------
+
+
+def _combine_texel_object(
+    obj: Any,
+    tex: dict[str, np.ndarray],
+    flux_by_obj: dict,
+    defaults: dict,
+    assignment: Any | None,
+    irradiance_scale: float,
+    verts_l: list,
+    irr_l: list,
+    t0_l: list,
+    alpha_l: list,
+    rho_l: list,
+    c_l: list,
+    eps_l: list,
+    bmask_l: list,
+    layout: list,
+    offset: int,
+) -> int:
+    """Append one atlas-participating object's texel points to :func:`_combine`'s
+    per-array accumulators and return the updated ``offset``.
+
+    Mirrors the per-vertex branch's material/Dirichlet-pinning logic exactly, just at
+    per-FACE resolution (:func:`materials.resolve_face_materials`, no seam averaging)
+    instead of per vertex, and reading position/normal from the rasterized tile instead
+    of :func:`_extract_geometry`.
+    """
+    positions = np.asarray(tex["position_mm"], dtype=np.float64).reshape(-1, 3)
+    k = int(positions.shape[0])
+    if k == 0:
+        return offset
+
+    mat = resolve_material(obj, defaults)
+    face_idx = np.asarray(tex["face"], dtype=np.int64)
+
+    per_face = None
+    if assignment is not None:
+        per_face = materials.resolve_face_materials(
+            obj, assignment, mat, np.asarray(tex["face_material_index"], dtype=np.int64)
+        )
+
+    flux = flux_by_obj.get(obj)
+    if flux is not None and int(np.asarray(flux).reshape(-1).shape[0]) == k:
+        irr = (np.asarray(flux, dtype=np.float64).reshape(-1) / _WM2_TO_WMM2) * irradiance_scale
+    else:
+        irr = np.zeros(k, dtype=np.float64)
+
+    if per_face is not None:
+        # Per-face resolution: every field is already (K,) via `face_idx` lookup.
+        # Dirichlet texels are pinned individually - alpha=0, no incident flux,
+        # excluded from the radiation/convection boundary - exactly what the
+        # per-vertex/object-level branches do. T0 for a non-pinned texel is the
+        # simulation's ambient initial condition, not resolve_face_materials'
+        # per-face value (which, for a face on a Dirichlet slot, IS the reservoir
+        # temperature) - mirrors the per-vertex branch's same reasoning.
+        rho = per_face["rho"][face_idx]
+        c_vec = per_face["c"][face_idx]
+        eps = per_face["eps"][face_idx]
+        dmask = per_face["dirichlet_mask"][face_idx]
+        t0 = np.where(dmask, per_face["t0"][face_idx], mat["initial_temperature_K"])
+        alpha = np.where(dmask, 0.0, per_face["alpha"][face_idx])
+        irr = np.where(dmask, 0.0, irr)
+        bmask = ~dmask
+    else:
+        rho = np.full(k, mat["density_kg_m3"], dtype=np.float64)
+        c_vec = np.full(k, mat["specific_heat_J_kgK"], dtype=np.float64)
+        eps = np.full(k, mat["emissivity"], dtype=np.float64)
+        if mat["thermal_role"] == "DIRICHLET_SOURCE":
+            t_dir = mat["dirichlet_temperature_K"] or mat["initial_temperature_K"]
+            t0 = np.full(k, float(t_dir), dtype=np.float64)
+            alpha = np.zeros(k, dtype=np.float64)
+            irr = np.zeros(k, dtype=np.float64)
+            bmask = np.zeros(k, dtype=bool)
+        else:
+            t0 = np.full(k, mat["initial_temperature_K"], dtype=np.float64)
+            alpha = np.full(k, mat["thermal_diffusivity_mm2_s"], dtype=np.float64)
+            bmask = np.ones(k, dtype=bool)
+
+    verts_l.append(positions)
+    irr_l.append(irr)
+    t0_l.append(t0)
+    alpha_l.append(alpha)
+    rho_l.append(rho)
+    c_l.append(c_vec)
+    eps_l.append(eps)
+    bmask_l.append(bmask)
+    layout.append((obj.name, offset, k, "TEXEL"))
+    return offset + k
+
+
+def _combine(
+    sim_objects: list,
+    flux_by_obj: dict,
+    defaults: dict,
+    solver_cfg: dict,
+    assignment: Any | None = None,
+    atlas_plan: AtlasPlan | None = None,
+) -> SimpleNamespace | None:
+    """Stack per-object geometry + material vectors into one solver-ready system.
+
+    Surface vertices come first (layout records each object's slice); optional
+    interior POINTS-mode samples are appended afterwards by
+    the surface slices stay valid.
+
+    When *assignment* (a parsed thermal sidecar) is supplied and an object has
+    usable material slots, alpha/rho/c/eps/T0 and the Dirichlet mask are resolved
+    **per vertex** from the slot assignment
+    (:func:`materials.resolve_vertex_materials`) instead of being filled with one
+    object-level constant. ``resolve_material`` still supplies the per-object
+    fallback for unassigned slots, so addon-authored blends are unaffected. With
+    ``assignment=None`` this function behaves exactly as before.
+
+    When *atlas_plan* is supplied, any object with an entry in ``atlas_plan.texels``
+    contributes its **texel points** instead of its mesh vertices: position/normal come
+    straight from the rasterized tile, and materials are resolved **per face**
+    (:func:`materials.resolve_face_materials`, exact - no seam averaging) instead of
+    per vertex. Every other object (absent from ``atlas_plan.texels``, or
+    ``atlas_plan=None`` entirely) contributes exactly as today. ``layout`` entries gain
+    a trailing ``kind`` tag (``"VERTEX"`` or ``"TEXEL"``) so callers can tell the two
+    apart; with ``atlas_plan=None`` every entry is ``"VERTEX"`` and every other array is
+    byte-identical to before this parameter existed.
+    """
+    irradiance_scale = float(defaults.get("irradiance_scale", 1.0))
+
+    verts_l: list[np.ndarray] = []
+    faces_l: list[np.ndarray] = []
+    irr_l: list[np.ndarray] = []
+    t0_l: list[np.ndarray] = []
+    alpha_l: list[np.ndarray] = []
+    rho_l: list[np.ndarray] = []
+    c_l: list[np.ndarray] = []
+    eps_l: list[np.ndarray] = []
+    bmask_l: list[np.ndarray] = []
+    layout: list = []  # (name, offset, n, kind) over the surface points
+    geom_by_obj: dict = {}
+    offset = 0
+    atlas_texels = atlas_plan.texels if atlas_plan is not None else {}
+
+    for obj in sim_objects:
+        tex = atlas_texels.get(obj.name)
+        if tex is not None:
+            offset = _combine_texel_object(
+                obj, tex, flux_by_obj, defaults, assignment, irradiance_scale,
+                verts_l, irr_l, t0_l, alpha_l, rho_l, c_l, eps_l, bmask_l, layout, offset,
+            )
+            continue
+
+        geom = _extract_geometry(obj)
+        if geom is None:
+            continue
+        verts, faces, n = geom
+        geom_by_obj[obj] = geom
+        mat = resolve_material(obj, defaults)
+
+        per_vertex = None
+        if assignment is not None:
+            per_vertex = materials.resolve_vertex_materials(obj, assignment, mat)
+            # resolve_vertex_materials walks the object's *base* mesh, so its arrays
+            # are sized to len(obj.data.vertices). _combine operates on the *evaluated*
+            # geometry from _extract_geometry, whose vertex count differs when the
+            # object carries topology-changing modifiers (Subdivision, Array, ...).
+            # When they disagree we cannot map slots to evaluated vertices, so fall
+            # back to the object-level path for this object rather than crash - the
+            # same shape-mismatch degradation write_frame_attributes already applies.
+            if per_vertex is not None and int(per_vertex["alpha"].shape[0]) != n:
+                _log.warning(
+                    "[heatsim.adapter] '%s': base mesh has %d verts but evaluated geometry has %d "
+                    "(topology-changing modifier); per-slot thermal materials skipped, using object-level values.",
+                    obj.name, int(per_vertex["alpha"].shape[0]), n,
+                )
+                per_vertex = None
+
+        flux = flux_by_obj.get(obj)
+        if flux is not None and int(np.asarray(flux).reshape(-1).shape[0]) == n:
+            irr = (np.asarray(flux, dtype=np.float64).reshape(-1) / _WM2_TO_WMM2) * irradiance_scale
+        else:
+            irr = np.zeros(n, dtype=np.float64)
+
+        if per_vertex is not None:
+            # Per-slot resolution: every field is already (N,). Dirichlet vertices
+            # are pinned individually - alpha=0, no incident flux, excluded from the
+            # radiation/convection boundary - exactly what the object-level branch
+            # below does, just per vertex. T0 is the simulation's *initial condition*,
+            # not a constitutive property: a FEM-participant vertex starts at ambient
+            # even where it seams against a Dirichlet slot (materials.resolve_vertex_materials
+            # area-weights T0 like any other continuous field, which would otherwise
+            # pre-seed seam vertices with a slice of the reservoir's temperature before
+            # the solver ever runs a step -- mirrors the object-level branch below,
+            # which always starts a non-Dirichlet object at initial_temperature_K).
+            rho = per_vertex["rho"]
+            c_vec = per_vertex["c"]
+            eps = per_vertex["eps"]
+            dmask = per_vertex["dirichlet_mask"]
+            t0 = np.where(dmask, per_vertex["t0"], mat["initial_temperature_K"])
+            alpha = np.where(dmask, 0.0, per_vertex["alpha"])
+            irr = np.where(dmask, 0.0, irr)
+            bmask = ~dmask
+        else:
+            rho = np.full(n, mat["density_kg_m3"], dtype=np.float64)
+            c_vec = np.full(n, mat["specific_heat_J_kgK"], dtype=np.float64)
+            eps = np.full(n, mat["emissivity"], dtype=np.float64)
+            if mat["thermal_role"] == "DIRICHLET_SOURCE":
+                # Pinned reservoir: no diffusion, no incident flux, excluded from the
+                # radiation/convection boundary (mirrors fem_adapter Dirichlet setup).
+                t_dir = mat["dirichlet_temperature_K"] or mat["initial_temperature_K"]
+                t0 = np.full(n, float(t_dir), dtype=np.float64)
+                alpha = np.zeros(n, dtype=np.float64)
+                irr = np.zeros(n, dtype=np.float64)
+                bmask = np.zeros(n, dtype=bool)
+            else:
+                t0 = np.full(n, mat["initial_temperature_K"], dtype=np.float64)
+                alpha = np.full(n, mat["thermal_diffusivity_mm2_s"], dtype=np.float64)
+                bmask = np.ones(n, dtype=bool)
+
+        verts_l.append(verts)
+        faces_l.append(faces + offset)
+        irr_l.append(irr)
+        t0_l.append(t0)
+        alpha_l.append(alpha)
+        rho_l.append(rho)
+        c_l.append(c_vec)
+        eps_l.append(eps)
+        bmask_l.append(bmask)
+        layout.append((obj.name, offset, n, "VERTEX"))
+        offset += n
+
+    if not verts_l:
+        return None
+
+    faces_arr = np.vstack(faces_l).astype(np.int32) if faces_l else np.zeros((0, 3), dtype=np.int32)
+    combined = SimpleNamespace(
+        verts=np.vstack(verts_l),
+        faces=faces_arr,
+        irradiance=np.concatenate(irr_l),
+        t0=np.concatenate(t0_l),
+        alpha=np.concatenate(alpha_l),
+        density=np.concatenate(rho_l) / _KGM3_TO_KGMM3,  # kg/m^3 -> kg/mm^3
+        c=np.concatenate(c_l),
+        eps=np.concatenate(eps_l),
+        boundary_mask=np.concatenate(bmask_l),
+        surface_count=offset,
+        layout=layout,
+    )
+
+    return combined
+
+
+def _run_solver(combined: SimpleNamespace, solver_cfg: dict, defaults: dict) -> np.ndarray:
+    """Drive ``HeatSimFEM`` exactly like ``tests/test_heatsim_solver.py``.
+
+    ``NUM_FRAME_DELTA = timestep_s * 60`` so ``dt = NUM_FRAME_DELTA / 60 == timestep_s``;
+    ``record_time == sim_time`` records every step => history shape ``(sim_steps+1, N)``.
+    """
+    from visionsim.simulate.heatsim.solver import HeatSimFEM
+
+    sim_time_s = float(solver_cfg.get("sim_time_s", 1.0))
+    timestep_s = float(solver_cfg.get("timestep_s", 0.05))
+    domain = str(solver_cfg.get("domain", "POINTS")).upper()
+    backend = str(solver_cfg.get("laplacian_backend", "ROBUST")).upper()
+    device = str(solver_cfg.get("device", "cpu"))
+
+    gen_params = SimpleNamespace(
+        device=device,
+        RHO=float(defaults["density_kg_m3"]) / _KGM3_TO_KGMM3,  # kg/mm^3 fallback scalar
+        C=float(defaults["specific_heat_J_kgK"]),
+        K=float(defaults["thermal_diffusivity_mm2_s"]),
+        NUM_FRAME_DELTA=timestep_s * 60.0,
+    )
+    sim_params = SimpleNamespace(
+        sim_radiation=True,
+        sim_convection=False,  # CONVECTION_COEFF is 0 anyway
+        add_tikhonov_reg=False,
+        sim_time=sim_time_s,
+        record_time=sim_time_s,  # record_attimestep == 0 => record all steps
+    )
+
+    fem = HeatSimFEM(
+        gen_params,
+        sim_params,
+        laplacian_domain=domain,
+        laplacian_backend=backend,
+    )
+
+    is_points = domain == "POINTS"
+    history = fem.perform_gt_heat_simulation(
+        verts_np=combined.verts.copy(),
+        faces_np=None if is_points else combined.faces.copy(),
+        boundary_faces_np=None if is_points else combined.faces.copy(),
+        # NOTE: boundary_verts_mask_override is honoured by the solver in POINTS
+        # mode only.  In MESH mode the boundary is derived from face topology and
+        # the per-vertex override is silently ignored — Dirichlet sources are not
+        # correctly excluded in MESH mode (known follow-up).
+        boundary_verts_mask_override=combined.boundary_mask,
+        u0=combined.t0,
+        irradiance_map=combined.irradiance,
+        thermal_diffusivity_map=combined.alpha,
+        density_map=combined.density,
+        specific_heat_map=combined.c,
+        emissivity_map=combined.eps,
+    )
+    return np.asarray(history, dtype=np.float64)
+
+
+def _split_history(history: np.ndarray, combined: SimpleNamespace) -> dict:
+    """Trim interior points and split ``(T, N_total)`` into per-object ``(T, N)``."""
+    u = history
+    # Guard: in MESH mode the solver compresses the vertex array to only
+    # face-referenced vertices, so the column count can be LESS than
+    # surface_count.  Slicing per-object offsets into a shorter array would
+    # silently return wrong temperatures.  Raise loudly instead.
+    if u.ndim == 2 and u.shape[1] < combined.surface_count:
+        raise RuntimeError(
+            f"_split_history: solver returned {u.shape[1]} columns but combined "
+            f"geometry has {combined.surface_count} surface vertices.  This happens "
+            f"in MESH mode when the mesh contains orphan/unreferenced vertices that "
+            f"the solver drops.  Use POINTS domain (the supported M1 path) or ensure "
+            f"every vertex is referenced by at least one face."
+        )
+    out: dict = {}
+    for name, off, n, _kind in combined.layout:
+        out[name] = np.ascontiguousarray(u[:, off : off + n])
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Public entry points
+# ---------------------------------------------------------------------------
+
+
+def solve_scene(
+    scene: Any,
+    *,
+    defaults: dict,
+    solver_cfg: dict,
+    cache_root: Path,
+    assignment: Any | None = None,
+    atlas_plan: AtlasPlan | None = None,
+) -> dict:
+    """Cache-aware FEM heat solve for ``scene``.
+
+    On a cache hit the stored per-object ``(timesteps, vertices)`` history is
+    returned untouched. On a miss: gather meshes -> Direct-Kernel irradiance
+    (W/m^2 -> W/mm^2) -> combine -> ``HeatSimFEM.perform_gt_heat_simulation`` ->
+    split the combined history back per object -> write the cache.
+
+    When *atlas_plan* (from :func:`build_atlas_plan`) is supplied, its
+    atlas-participating objects additionally get per-texel irradiance
+    (:func:`_compute_texel_irradiance`) merged into the same ``flux_by_obj`` the
+    per-vertex path already builds, and it is threaded through to :func:`_combine`'s
+    TEXEL branch. ``atlas_plan=None`` (the default) reproduces today's behaviour
+    exactly, including the cache key.
+
+    Returns ``{obj_name: (timesteps, vertices) ndarray}``.
+    """
+    cache_root = Path(cache_root)
+    sim_objects = gather_meshes(scene)
+
+    blend_path = Path(str(getattr(getattr(bpy, "data", None), "filepath", "") or ""))
+    key_cfg = {
+        "solver": dict(solver_cfg),
+        "defaults": dict(defaults),
+        "objects": sorted(o.name for o in sim_objects),
+        "assignments": None if assignment is None else assignment.digest,
+    }
+    # The "atlas" key is entirely ABSENT (not present-with-value-None) when no atlas is
+    # in play, so key_cfg's JSON -- and therefore the SHA1 cache key -- is byte-identical
+    # to before the atlas feature existed. Adding an "atlas": None entry here would still
+    # change the JSON (and thus every existing .heatsim cache's key) even though nothing
+    # about the solve changed; see solve_scene's docstring guarantee below.
+    if atlas_plan is not None:
+        key_cfg["atlas"] = {
+            "density": atlas_plan.density,
+            "tile_min": atlas_plan.tile_min,
+            "tile_max": atlas_plan.tile_max,
+            "soft_max": atlas_plan.soft_max,
+            "layout_digest": atlas_plan.digest,
+        }
+    key = cache.cache_key(blend_path, key_cfg)
+
+    cached = cache.read_temperatures(cache_root, key)
+    if cached is not None:
+        _log.debug("[heatsim.adapter] cache hit: %s", key)
+        return cached
+
+    if not sim_objects:
+        cache.write_temperatures(cache_root, key, {}, {"objects": []})
+        return {}
+
+    atlas_names = set(atlas_plan.texels) if atlas_plan is not None else set()
+    vertex_objects = [o for o in sim_objects if o.name not in atlas_names]
+    flux_by_obj = _compute_irradiance(scene, vertex_objects, solver_cfg, defaults)
+    if atlas_plan is not None and atlas_plan.texels:
+        flux_by_obj.update(_compute_texel_irradiance(scene, sim_objects, atlas_plan, solver_cfg, defaults))
+    combined = _combine(sim_objects, flux_by_obj, defaults, solver_cfg, assignment=assignment, atlas_plan=atlas_plan)
+    if combined is None:
+        cache.write_temperatures(cache_root, key, {}, {"objects": []})
+        return {}
+
+    history = _run_solver(combined, solver_cfg, defaults)
+    per_object = _split_history(history, combined)
+
+    meta = {
+        "solver_cfg": dict(solver_cfg),
+        "objects": [name for name, _, _, _ in combined.layout],
+        "timesteps": int(history.shape[0]) if history.ndim == 2 else 0,
+        "surface_count": int(combined.surface_count),
+    }
+    cache.write_temperatures(cache_root, key, per_object, meta)
+    _log.debug("[heatsim.adapter] solved %d object(s); history %s", len(per_object), history.shape)
+    return per_object
+
+
+def _scene_fps(scene: Any) -> float:
+    """``scene.render.fps / scene.render.fps_base``, guarded against a zero base."""
+    r = scene.render
+    fps = float(getattr(r, "fps", 24) or 24)
+    fps_base = float(getattr(r, "fps_base", 1.0) or 1.0)
+    if fps_base <= 0.0:
+        fps_base = 1.0
+    return fps / fps_base
+
+
+def _order_fem_first(sim_objects: list, defaults: dict) -> tuple[list, set]:
+    """Split ``sim_objects`` into FEM-participant-first, Dirichlet-source-last order.
+
+    A Dirichlet source's evaluated vertex count may change frame to frame (e.g. a
+    regenerated fluid mesh). Keeping it last in the combine order means its resize
+    never shifts the ``_combine`` offsets of any FEM-participant object, so the
+    FEM-participant surface prefix has a stable width across frames -- exactly the
+    property :func:`solve_scene_animated` relies on to carry ``u_prev`` forward by
+    index.
+    """
+    fem: list = []
+    dirichlet: list = []
+    dirichlet_names: set = set()
+    for obj in sim_objects:
+        role = resolve_material(obj, defaults)["thermal_role"]
+        if role == "DIRICHLET_SOURCE":
+            dirichlet.append(obj)
+            dirichlet_names.add(obj.name)
+        else:
+            fem.append(obj)
+    return fem + dirichlet, dirichlet_names
+
+
+def _slot_level_dirichlet_mismatches(sim_objects: list, assignment: Any, defaults: dict) -> list:
+    """Objects with a **slot-level** ``DIRICHLET_SOURCE`` assignment their own
+    ``heat_sim_material.thermal_role`` does not already declare.
+
+    :func:`_order_fem_first` (and the per-substep re-pin loop in
+    :func:`solve_scene_animated`) only ever look at the object-level role, so a
+    material slot the sidecar assigns ``DIRICHLET_SOURCE`` is never re-pinned
+    between substeps in animated mode even though :func:`_combine` correctly
+    zeroes its ``alpha``/``irradiance`` and clears its ``boundary_mask`` for the
+    static solve. This is a detector for that gap, used to warn the caller
+    rather than silently drifting -- see :func:`solve_scene_animated`.
+    """
+    names: list = []
+    for obj in sim_objects:
+        if resolve_material(obj, defaults)["thermal_role"] == "DIRICHLET_SOURCE":
+            continue  # already re-pinned wholesale as an object-level Dirichlet source
+        for slot in getattr(obj, "material_slots", []):
+            material = getattr(slot, "material", None)
+            if material is None:
+                continue
+            entry = assignment.entry_for(str(getattr(material, "name", "")))
+            if entry is not None and entry.role == "DIRICHLET_SOURCE":
+                names.append(obj.name)
+                break
+    return names
+
+
+def solve_scene_animated(
+    scene: Any,
+    *,
+    defaults: dict,
+    solver_cfg: dict,
+    cache_root: Path,
+    frame_start: int,
+    frame_end: int,
+    every_n: int,
+    substeps_per_frame: int,
+    assignment: Any | None = None,
+) -> tuple[dict, list]:
+    """Transient per-frame FEM solve over an animated scene (Phase 1 / M2).
+
+    ``FEM_PARTICIPANT`` objects (stable topology) evolve: ``u_prev`` carries the
+    previous frame's final state forward by vertex index. ``DIRICHLET_SOURCE``
+    objects (topology may change frame to frame, e.g. a regenerated fluid mesh)
+    are a constant-temperature reservoir -- re-extracted every frame purely for
+    *position* (so they couple heat into nearby FEM-participant vertices through
+    the POINTS kNN Laplacian; see ``solver._build_matrices``, which builds that
+    Laplacian over ALL combined points regardless of source object) and reset to
+    the reservoir temperature every frame. Their own field never evolves and is
+    not recorded.
+
+    On a vertex-count change of any Dirichlet source, the combined system is
+    rebuilt from scratch for that frame (via :func:`_combine`); the
+    FEM-participant prefix of ``u_prev`` is preserved unchanged and the Dirichlet
+    slice is refilled with its (possibly keyframed) reservoir temperature. A
+    vertex-count change on a FEM-participant object is NOT supported (matches
+    heat-sim-blender's ANIMATE Phase 1) and raises ``RuntimeError`` with a clear
+    message pointing at ``thermal_role``.
+
+    POINTS domain only. Per the M2 design (irradiance re-bake is a deferred
+    non-goal -- see the design spec), irradiance is not computed here: coupling
+    into the FEM participants comes from the Dirichlet reservoir's *position* via
+    the shared POINTS Laplacian, which is sufficient for a "hot pour" testbed.
+    Known v1 limitation: interior-point-volume samples (POINTS domain,
+    temperature every frame rather than carried forward (deformation-aware
+    interior continuity is an explicit M2 non-goal).
+
+    Known limitation -- **slot-level Dirichlet sources are not supported here**:
+    when *assignment* is given, a material slot the sidecar assigns
+    ``DIRICHLET_SOURCE`` is pinned correctly in the static :func:`solve_scene`
+    but is only re-pinned *once per frame* here, not after every substep (the
+    per-substep re-pin loop below only knows about object-level
+    ``thermal_role``). Across substeps the FEM/Dirichlet coupling then lets
+    those vertices drift away from their reservoir temperature. A scene
+    exhibiting this logs a warning naming the affected object(s); use the
+    static solve for such scenes until per-vertex Dirichlet is supported in
+    the animated substep loop.
+
+    Returns ``({obj_name: (n_frames, n_surface_verts) ndarray}, frames)`` for
+    FEM-participant objects only -- Dirichlet sources are not recorded, since
+    their temperature is always the constant we configured. Cache-aware: a hit
+    on ``cache.read_animated`` short-circuits the solve entirely.
+    """
+    cache_root = Path(cache_root)
+    sim_objects = gather_meshes(scene)
+
+    frame_start = int(frame_start)
+    frame_end = int(frame_end)
+    every_n = max(1, int(every_n))
+    substeps_per_frame = max(1, int(substeps_per_frame))
+    frames = list(range(frame_start, frame_end + 1, every_n))
+
+    blend_path = Path(str(getattr(getattr(bpy, "data", None), "filepath", "") or ""))
+    key_cfg = {
+        "solver": dict(solver_cfg),
+        "defaults": dict(defaults),
+        "objects": sorted(o.name for o in sim_objects),
+        "animated": True,
+        "frame_start": frame_start,
+        "frame_end": frame_end,
+        "every_n": every_n,
+        "substeps": substeps_per_frame,
+        "assignments": None if assignment is None else assignment.digest,
+    }
+    key = cache.cache_key(blend_path, key_cfg)
+    cache_dir = cache_root / key
+
+    cached = cache.read_animated(cache_dir)
+    if cached is not None:
+        _log.debug("[heatsim.adapter] animated cache hit: %s", key)
+        return cached
+
+    if not frames or not sim_objects:
+        cache.write_animated(cache_dir, {}, frames, {"objects": []})
+        return {}, frames
+
+    ordered_objects, dirichlet_names = _order_fem_first(sim_objects, defaults)
+    objects_by_name = {o.name: o for o in ordered_objects}
+
+    # M2 design: irradiance re-bake is a deferred non-goal for animated mode --
+    # ``_combine`` below is always called with an empty ``flux_by_obj``, so every
+    # object's incident flux is always zero. The only possible heat source for an
+    # animated solve is therefore a DIRICHLET_SOURCE reservoir; warn once so a
+    # scene with neither doesn't silently stay at ambient for the whole run.
+    if not dirichlet_names:
+        _log.warning(
+            "[heatsim.adapter] solve_scene_animated: no DIRICHLET_SOURCE object and "
+            "animated mode never re-bakes irradiance -- this scene has no heat "
+            "source, so the solved field will stay at ambient temperature for the "
+            "entire run."
+        )
+
+    if assignment is not None:
+        mismatched = _slot_level_dirichlet_mismatches(ordered_objects, assignment, defaults)
+        if mismatched:
+            _log.warning(
+                "[heatsim.adapter] solve_scene_animated: %s: material slot(s) assigned "
+                "DIRICHLET_SOURCE in the thermal sidecar, but the object-level "
+                "thermal_role does not declare it. Slot-level Dirichlet sources are NOT "
+                "re-pinned per substep in animated mode, so these vertices will drift "
+                "away from their reservoir temperature within a frame -- use the static "
+                "solve (solve_scene) for this scene until per-vertex Dirichlet is "
+                "supported in the animated substep loop.",
+                ", ".join(sorted(mismatched)),
+            )
+
+    from visionsim.simulate.heatsim.solver import HeatSimFEM
+
+    device = str(solver_cfg.get("device", "cpu"))
+    domain = str(solver_cfg.get("domain", "POINTS")).upper()
+    backend = str(solver_cfg.get("laplacian_backend", "ROBUST")).upper()
+
+    fps = _scene_fps(scene)
+    dt = (1.0 / fps) / float(substeps_per_frame)
+
+    gen_params = SimpleNamespace(
+        device=device,
+        RHO=float(defaults["density_kg_m3"]) / _KGM3_TO_KGMM3,
+        C=float(defaults["specific_heat_J_kgK"]),
+        K=float(defaults["thermal_diffusivity_mm2_s"]),
+        NUM_FRAME_DELTA=dt * 60.0,
+    )
+    sim_params = SimpleNamespace(
+        sim_radiation=True,
+        sim_convection=False,
+        add_tikhonov_reg=False,
+        sim_time=0.0,
+        record_time=0.0,
+    )
+    fem = HeatSimFEM(
+        gen_params,
+        sim_params,
+        laplacian_domain=domain,
+        laplacian_backend=backend,
+    )
+
+    orig_frame = int(scene.frame_current)
+    history_rows: dict = {}
+    u_prev: np.ndarray | None = None
+    n_fem_surface: int | None = None
+
+    try:
+        for f in frames:
+            scene.frame_set(int(f))
+            combined = _combine(ordered_objects, {}, defaults, solver_cfg, assignment=assignment)
+            if combined is None:
+                raise RuntimeError(
+                    f"[heatsim.adapter] solve_scene_animated: no geometry at frame {f} "
+                    "(all sim objects vanished mid-run)."
+                )
+
+            fem_entries = [
+                (name, off, n) for name, off, n, _kind in combined.layout if name not in dirichlet_names
+            ]
+            cur_n_fem_surface = sum(n for _, _, n in fem_entries)
+
+            if u_prev is None:
+                u_prev = combined.t0.copy()
+                n_fem_surface = cur_n_fem_surface
+            else:
+                if cur_n_fem_surface != n_fem_surface:
+                    raise RuntimeError(
+                        "[heatsim.adapter] solve_scene_animated: a FEM_PARTICIPANT "
+                        f"object's vertex count changed at frame {f} (expected "
+                        f"{n_fem_surface} surface vertices, got {cur_n_fem_surface}). "
+                        "Animated mode requires stable topology for FEM participants; "
+                        "set thermal_role=DIRICHLET_SOURCE for meshes with changing "
+                        "topology (e.g. fluids)."
+                    )
+                new_u_prev = combined.t0.copy()
+                new_u_prev[:n_fem_surface] = u_prev[:n_fem_surface]
+                u_prev = new_u_prev
+
+            # Dirichlet pin: resolve each reservoir vertex's target temperature
+            # fresh every frame (also covers a future keyframed
+            # dirichlet_temperature_K) and hand the indices/values to
+            # simulate_for_pose so it re-pins them internally AFTER EVERY
+            # substep's CG solve, not just once on the returned array -- the
+            # FEM/Dirichlet coupling weight in the solve would otherwise let
+            # pinned nodes drift within a frame across substeps (and drift
+            # further as substeps_per_frame grows).
+            dir_idx: list[int] = []
+            dir_val: list[float] = []
+            for name, off, n, _kind in combined.layout:
+                if name in dirichlet_names:
+                    mat = resolve_material(objects_by_name[name], defaults)
+                    t_target = mat["dirichlet_temperature_K"] or mat["initial_temperature_K"]
+                    dir_idx.extend(range(off, off + n))
+                    dir_val.extend([t_target] * n)
+
+            states = fem.simulate_for_pose(
+                combined.verts,
+                combined.faces,
+                combined.boundary_mask,
+                u_prev,
+                combined.irradiance,
+                combined.alpha,
+                combined.density,
+                combined.c,
+                combined.eps,
+                num_substeps=substeps_per_frame,
+                dt=dt,
+                dirichlet_indices=dir_idx or None,
+                dirichlet_values=dir_val or None,
+            )  # (substeps, N); Dirichlet rows already pinned every substep.
+
+            u_prev = states[-1].copy()
+            for name, off, n in fem_entries:
+                history_rows.setdefault(name, []).append(
+                    np.asarray(states[-1, off : off + n], dtype=np.float64)
+                )
+    finally:
+        scene.frame_set(orig_frame)
+
+    history = {name: np.stack(rows, axis=0) for name, rows in history_rows.items()}
+
+    meta = {
+        "objects": sorted(history),
+        "frame_start": frame_start,
+        "frame_end": frame_end,
+        "every_n": every_n,
+        "substeps": substeps_per_frame,
+    }
+    cache.write_animated(cache_dir, history, frames, meta)
+    _log.debug("[heatsim.adapter] animated solve: %d object(s), %d frame(s)", len(history), len(frames))
+    return history, frames
+
+
+def _write_point_float_attr(mesh: Any, name: str, values: np.ndarray) -> None:
+    """(Re)create a POINT/FLOAT mesh attribute from ``values``."""
+    if name in mesh.attributes:
+        try:
+            mesh.attributes.remove(mesh.attributes[name])
+        except Exception:
+            pass
+    attr = mesh.attributes.new(name=name, type="FLOAT", domain="POINT")
+    attr.data.foreach_set("value", np.asarray(values, dtype=np.float32))
+
+
+def _fallback_temperature_K(obj: Any, defaults: dict, default_T: float) -> float:
+    """Object-level fallback temperature for ``write_frame_attributes``.
+
+    A ``DIRICHLET_SOURCE`` (e.g. a topology-changing hot liquid whose
+    evaluated vertex count doesn't line up with its base mesh, so it can't be
+    given a per-vertex history) must still render at its reservoir
+    temperature rather than ambient. Everything else (FEM participants)
+    keeps the ambient ``initial_temperature_K`` default.
+    """
+    material = resolve_material(obj, defaults)
+    if material["thermal_role"] == "DIRICHLET_SOURCE":
+        return float(material["dirichlet_temperature_K"]) or float(material["initial_temperature_K"])
+    return default_T
+
+
+def _write_emissivity_attr(obj: Any, mesh: Any, defaults: dict, assignment: Any | None, n: int) -> None:
+    """Write the ``emissivity`` POINT attribute, per-vertex from ``assignment`` when
+    available (falling back to the object's single resolved material emissivity
+    otherwise). Shared by the normal per-vertex write-back path and the constant-fill
+    fallback (:func:`_write_constant_fill_attributes`) so both leave the SAME emissivity
+    signal for the gray-body shader -- only the temperature detail differs between them.
+    """
+    material = resolve_material(obj, defaults)
+    eps_vec = None
+    if assignment is not None:
+        per_vertex = materials.resolve_vertex_materials(obj, assignment, material)
+        if per_vertex is not None:
+            eps_vec = np.asarray(per_vertex["eps"], dtype=np.float32).reshape(-1)
+    if eps_vec is None or eps_vec.shape[0] != n:
+        eps_vec = np.full(n, float(material["emissivity"]), dtype=np.float32)
+    _write_point_float_attr(mesh, "emissivity", eps_vec)
+
+
+def _write_constant_fill_attributes(
+    obj: Any, mesh: Any, defaults: dict, assignment: Any | None, fill_T: float
+) -> None:
+    """Constant-fill ``sim_temperature`` (and ``emissivity``) for a vertex-path object
+    whose per-vertex write-back is impossible this frame (topology mismatch or missing
+    history) -- called instead of leaving both attributes absent.
+
+    An absent ``sim_temperature`` makes the ``temperature`` AOV emit 0 K (see
+    ``thermal_shader._build_temperature_source_chain``'s ``is_valid = sim_temperature >
+    1.0`` gate), which silently discards a real solved field down to nothing worse than
+    if the object had never been simulated. A constant fill is coarser than genuine
+    per-vertex detail but is never worse than 0 K or (for the shape-mismatch case)
+    ambient -- see ``write_frame_attributes`` for how ``fill_T`` is chosen.
+    """
+    n = len(mesh.vertices)
+    _write_point_float_attr(mesh, "sim_temperature", np.full(n, fill_T, dtype=np.float32))
+    _write_emissivity_attr(obj, mesh, defaults, assignment, n)
+
+
+def write_frame_attributes(
+    scene: Any,
+    history: dict,
+    timestep: int,
+    defaults: dict,
+    assignment: Any | None = None,
+    atlas_plan: AtlasPlan | None = None,
+) -> None:
+    """Write per-vertex temperatures for the chosen ``timestep`` (use ``-1`` for last).
+
+    For every simulated mesh (present in ``history``) this writes a
+    ``sim_temperature`` (FLOAT/POINT) attribute for that timestep plus a constant
+    ``emissivity`` (FLOAT/POINT) attribute. Vertex-path objects whose per-vertex
+    write-back is impossible this frame -- ``history`` has no entry for them, or its
+    per-vertex count doesn't match the base mesh (a topology-changing modifier) -- still
+    get a CONSTANT-fill ``sim_temperature``/``emissivity`` (never left absent: an absent
+    ``sim_temperature`` makes the ``temperature`` AOV emit 0 K, see
+    :func:`_write_constant_fill_attributes`), plus an OBJECT-level
+    ``heatsim_default_temperature`` custom property so downstream rendering still has a
+    sane fallback too: ``defaults['initial_temperature_K']`` (ambient) for FEM
+    participants, or the object's own ``dirichlet_temperature_K`` reservoir temperature
+    for a ``DIRICHLET_SOURCE`` (e.g. a topology-changing hot liquid whose vertex count
+    can't be tracked per-frame) so it still renders hot instead of at ambient. This does
+    NOT apply to atlas participants (see below) -- they deliberately get no per-vertex
+    attribute at all.
+
+    When *assignment* is supplied the ``emissivity`` attribute is resolved **per
+    vertex** from the object's material slots rather than stamped as one
+    object-level constant, so per-slot emissivity reaches the gray-body radiance
+    shader. In LWIR that difference (polished metal ~0.05 vs painted ~0.9)
+    dominates how the rendered frame looks.
+
+    When *atlas_plan* is supplied (TEXEL render domain), objects present in
+    ``atlas_plan.texels`` are atlas participants: their per-pixel signal comes from the
+    rendered atlas image (:func:`write_atlas`) sampled by the shader, not from a per-vertex
+    mesh attribute, so this function writes ONLY their ``heatsim_default_temperature``
+    fallback (used where the atlas mix factor is 0, e.g. margin the dilation never reached)
+    and skips the ``sim_temperature``/``emissivity`` point-attribute write entirely -- even
+    if ``history[obj.name]``'s texel count happens to equal the mesh's vertex count.  Every
+    mesh also gets an explicit ``ATLAS_COVERAGE_PROP`` OBJECT-domain float (1.0 for atlas
+    participants, 0.0 otherwise); the shader multiplies this into its atlas mix factor so a
+    non-participant object can never pick up stray atlas coverage through the default (0,0,0)
+    vector a missing ``HeatSim_Atlas_UV`` attribute produces. Non-atlas objects are written
+    exactly as when ``atlas_plan=None``.
+    """
+    default_T = float(defaults["initial_temperature_K"])
+    atlas_names = set(atlas_plan.texels) if atlas_plan is not None else set()
+    for obj in scene.objects:
+        if getattr(obj, "type", None) != "MESH":
+            continue
+        mesh = getattr(obj, "data", None)
+        if mesh is None:
+            continue
+
+        if atlas_plan is not None:
+            obj[ATLAS_COVERAGE_PROP] = 1.0 if obj.name in atlas_names else 0.0
+
+        if obj.name in atlas_names:
+            # TEXEL: this object's field lives in the atlas image, not on its mesh --
+            # only the fallback (used wherever the atlas mix factor is 0) is written.
+            # Remove any stale sim_temperature/emissivity POINT attributes left by a
+            # prior VERTEX-mode run on this same mesh (long-lived RPyC service can
+            # switch modes between prepare_thermal calls): the shader's vertex path
+            # reads sim_temperature whenever it's present and > 1.0, so a leftover
+            # attribute would bleed stale per-vertex temperatures through atlas holes
+            # (mix factor 0) instead of the fresh fallback written below.
+            for attr_name in ("sim_temperature", "emissivity"):
+                if attr_name in mesh.attributes:
+                    mesh.attributes.remove(mesh.attributes[attr_name])
+            obj["heatsim_default_temperature"] = _fallback_temperature_K(obj, defaults, default_T)
+            continue
+
+        if atlas_plan is None and ATLAS_COVERAGE_PROP in obj:
+            # VERTEX mode: clear a stale coverage gate left by a prior TEXEL-mode run
+            # on this same object (long-lived RPyC service can switch modes between
+            # prepare_thermal calls). Otherwise the shader's atlas mix factor stays
+            # gated open by a stale alpha * stale coverage=1.0, letting a stale packed
+            # atlas image win over the fresh per-vertex sim_temperature written below.
+            del obj[ATLAS_COVERAGE_PROP]
+
+        hist = history.get(obj.name)
+        if hist is None:
+            # No solve history at all for this object (e.g. a DIRICHLET_SOURCE whose
+            # topology changes every frame, so it was never given a per-vertex field).
+            # Still constant-fill sim_temperature/emissivity -- an absent sim_temperature
+            # makes the temperature AOV emit 0 K instead of this object's reservoir/ambient
+            # fallback (see _write_constant_fill_attributes).
+            fallback_T = _fallback_temperature_K(obj, defaults, default_T)
+            obj["heatsim_default_temperature"] = fallback_T
+            _log.warning(
+                "[heatsim.adapter] '%s': no solve history for this object; sim_temperature "
+                "constant-filled at %.2f K instead of left absent.", obj.name, fallback_T,
+            )
+            _write_constant_fill_attributes(obj, mesh, defaults, assignment, fallback_T)
+            continue
+
+        arr = np.asarray(hist)
+        n = len(mesh.vertices)
+        if arr.ndim != 2 or arr.shape[0] == 0 or arr.shape[1] != n:
+            # Topology mismatch: a modifier changed the vertex count between the
+            # evaluated mesh the FEM solve ran on (``hist``'s vertex axis) and this base
+            # mesh (``n`` verts) sim_temperature must live on -- or the history is
+            # otherwise empty/malformed. Per-vertex write-back is structurally impossible
+            # either way, but the field itself is real, so constant-fill sim_temperature
+            # at the mean of its final timestep (preserves the actual heating) instead of
+            # collapsing to ambient, and instead of leaving the attribute absent (which
+            # would render as 0 K -- worse than either).
+            obj["heatsim_default_temperature"] = _fallback_temperature_K(obj, defaults, default_T)
+            if arr.ndim == 2 and arr.shape[0] > 0 and arr.shape[1] > 0:
+                fill_T = float(np.mean(np.asarray(arr[timestep], dtype=np.float64)))
+            else:
+                fill_T = _fallback_temperature_K(obj, defaults, default_T)
+            _log.warning(
+                "[heatsim.adapter] '%s': solved history has %d vertex-axis entries but the "
+                "base mesh has %d vert(s) (a modifier changed the vertex count); per-vertex "
+                "sim_temperature detail was replaced by a constant fill (%.2f K).",
+                obj.name, arr.shape[1] if arr.ndim == 2 else -1, n, fill_T,
+            )
+            _write_constant_fill_attributes(obj, mesh, defaults, assignment, fill_T)
+            continue
+
+        row = np.asarray(arr[timestep], dtype=np.float32).reshape(-1)
+        _write_point_float_attr(mesh, "sim_temperature", row)
+        _write_emissivity_attr(obj, mesh, defaults, assignment, n)
+        mesh.update()

--- a/visionsim/simulate/heatsim/atlas.py
+++ b/visionsim/simulate/heatsim/atlas.py
@@ -1,0 +1,381 @@
+"""Thermal atlas: selection, tile allocation, shelf packing, and UV-space texel rasterization.
+
+Pure geometry/allocation math on numpy arrays - **no bpy import, guarded or otherwise**. This
+module has to import and be testable without Blender; :mod:`visionsim.simulate.heatsim.adapter`
+(Task 2) is the only place that touches ``bpy`` objects and translates them into the arrays this
+module consumes.
+
+Why texels at all (see the design spec for the full argument): the thermal solver and shader both
+operate on mesh vertices today, and artist meshes are pathologically uneven - a 16-vertex floor
+spanning 80 m2 next to a 21k-vertex orchid. This module decouples both by giving area-dense
+objects a scene-wide **temperature atlas** tile sized by surface area (not vertex count), whose
+texel centers become simulation sample points and render lookup addresses simultaneously. Objects
+that are already sampled densely by their own vertices are excluded and keep the vertex path.
+
+Pipeline, in call order:
+
+1. :func:`surface_area_m2` + :func:`select_for_atlas` - per object, decide vertex-path vs. atlas.
+2. :func:`allocate` - size + shelf-pack tiles for every atlas-selected object into one atlas image.
+3. :func:`rasterize_tile` - per object, turn its tile-local UV triangles into texel samples
+   (position, normal, source face) for every covered texel.
+4. :func:`dilate` - after the solve, push valid texel values outward across the tile's invalid
+   margin so bilinear sampling at render time never reads an uninitialized texel.
+"""
+
+from __future__ import annotations
+
+import math
+import warnings
+from dataclasses import dataclass
+
+import numpy as np
+
+# `n_verts / max(area_m2, eps)` guards the selection ratio against division by (near-)zero area;
+# eps is deliberately far below any real mesh's area so it only ever engages for area==0.
+_AREA_EPS = 1.0e-9
+
+# Zero-area (UV-degenerate) triangles are skipped outright; this is well below the UV-space area
+# of any single covered texel for tile sizes in [tile_min, tile_max], so it never rejects a
+# legitimately thin-but-visible triangle.
+_DEGENERATE_UV_AREA_EPS = 1.0e-12
+
+# Tolerance for the half-open edge test's "on the edge" comparison (w == 0). Texel-space
+# coordinates here are bounded by `tile_max` (a few hundred) squared, well within float64's exact
+# integer range for the synthetic/test geometry this module is exercised with.
+_EDGE_EPS = 1.0e-9
+
+
+@dataclass(frozen=True)
+class TileSpec:
+    """One object's placement in the shared atlas image."""
+
+    obj_name: str
+    size: tuple[int, int]
+    """(w, h) texels; both are multiples of 4 and in [tile_min, tile_max] (tiles are square)."""
+    offset: tuple[int, int]
+    """(x, y) top-left corner of this tile in atlas pixels."""
+
+
+@dataclass(frozen=True)
+class AtlasLayout:
+    """The full result of :func:`allocate`: every tile's placement plus the density actually used."""
+
+    atlas_size: tuple[int, int]
+    tiles: dict[str, TileSpec]
+    effective_density: float
+    """Equal to the requested density unless the soft-max safety valve rescaled it down."""
+    rescaled: bool
+    """True iff the soft-max safety valve engaged (see :func:`allocate`)."""
+
+
+def surface_area_m2(verts_mm: np.ndarray, faces: np.ndarray) -> float:
+    """Total triangle surface area, converted from mm^2 (input units) to m^2."""
+    if faces.size == 0:
+        return 0.0
+    v0 = verts_mm[faces[:, 0]]
+    v1 = verts_mm[faces[:, 1]]
+    v2 = verts_mm[faces[:, 2]]
+    cross = np.cross(v1 - v0, v2 - v0)
+    area_mm2 = 0.5 * np.linalg.norm(cross, axis=1)
+    return float(np.sum(area_mm2)) / 1.0e6
+
+
+def select_for_atlas(
+    n_verts: int, area_m2: float, density: float, *, writeback_possible: bool = True
+) -> bool:
+    """True iff this object should join the atlas rather than keep the per-vertex path.
+
+    Normally that's a density call: native vertex density below the atlas target means
+    the object's own vertices are too sparse to sample it well, so it joins.
+
+    ``writeback_possible=False`` overrides the density rule unconditionally. It signals
+    that the caller cannot write a per-vertex result back onto this object's base mesh
+    at all (its base and evaluated vertex counts differ, e.g. a Bevel/Subdivision/
+    Geometry-Nodes modifier) - the vertex path is not merely low-resolution here, it is
+    structurally incapable of holding the solved field, so density is moot and the atlas
+    (UV-addressed, not vertex-addressed) is the only path that can represent this object.
+    """
+    if not writeback_possible:
+        return True
+    return (n_verts / max(area_m2, _AREA_EPS)) < density
+
+
+def _round_up_to_multiple(value: int, multiple: int) -> int:
+    return math.ceil(value / float(multiple)) * multiple
+
+
+def _tile_side(area_m2: float, density: float, tile_min: int, tile_max: int) -> int:
+    texel_count = max(area_m2, 0.0) * density
+    side = math.ceil(math.sqrt(max(texel_count, 0.0)))
+    side = _round_up_to_multiple(side, 4)
+    return min(max(side, tile_min), tile_max)
+
+
+def _sides_for_density(
+    areas: dict[str, float], density: float, tile_min: int, tile_max: int
+) -> dict[str, int]:
+    return {name: _tile_side(area, density, tile_min, tile_max) for name, area in areas.items()}
+
+
+def _shelf_pack(sides: dict[str, int], padding: int) -> tuple[dict[str, tuple[int, int]], tuple[int, int]]:
+    """Pack squares (descending height, name tiebreak) into shelves with >=`padding` gaps.
+
+    Bin width is chosen once, up front, from the padded total area (so it scales with the tile
+    set rather than being fixed); the atlas then grows downward, shelf by shelf, to fit.
+    """
+    if not sides:
+        return {}, (0, 0)
+
+    items = sorted(sides.items(), key=lambda kv: (-kv[1], kv[0]))
+    max_side = max(side for _, side in items)
+    padded_area = sum((side + padding) * (side + padding) for _, side in items)
+    width = max(max_side, math.ceil(math.sqrt(float(padded_area))))
+    width = _round_up_to_multiple(width, 4)
+
+    positions: dict[str, tuple[int, int]] = {}
+    x, y, shelf_h, used_w = 0, 0, 0, 0
+    for name, side in items:
+        if x != 0 and x + side > width:
+            y += shelf_h + padding
+            x, shelf_h = 0, 0
+        positions[name] = (x, y)
+        used_w = max(used_w, x + side)
+        x += side + padding
+        shelf_h = max(shelf_h, side)
+    used_h = y + shelf_h
+
+    atlas_size = (_round_up_to_multiple(max(used_w, max_side), 4), _round_up_to_multiple(max(used_h, max_side), 4))
+    return positions, atlas_size
+
+
+def allocate(
+    areas: dict[str, float],
+    density: float,
+    *,
+    tile_min: int = 16,
+    tile_max: int = 512,
+    soft_max: int = 500_000,
+    retained_vertex_count: int = 0,
+    padding: int = 2,
+) -> AtlasLayout:
+    """Size and shelf-pack one atlas tile per object in `areas`.
+
+    Tile side is purely area-driven (`ceil(sqrt(area_m2 * density))`, rounded up to a multiple of
+    4, clamped to [tile_min, tile_max]) - never squeezed by a budget. `soft_max` is a warn-only
+    safety valve: if `sum(side^2) + retained_vertex_count` exceeds it, density is rescaled
+    uniformly (down) by `(soft_max - retained_vertex_count) / tiles_total` and tiles are resized
+    at the new density; this is a single corrective pass, not an iterative solve, so clamping can
+    still leave the total above `soft_max` - the valve's job is to warn loudly and shrink, not to
+    silently degrade below the warning, and not to guarantee an exact bound.
+    """
+    if not areas:
+        return AtlasLayout(atlas_size=(0, 0), tiles={}, effective_density=density, rescaled=False)
+
+    sides = _sides_for_density(areas, density, tile_min, tile_max)
+    tiles_total = sum(side * side for side in sides.values())
+    effective_density = density
+    rescaled = False
+
+    if tiles_total + retained_vertex_count > soft_max and tiles_total > 0:
+        budget = soft_max - retained_vertex_count
+        ratio = budget / tiles_total if budget > 0 else _AREA_EPS
+        effective_density = density * ratio
+        rescaled = True
+        sides = _sides_for_density(areas, effective_density, tile_min, tile_max)
+        warnings.warn(
+            f"HeatSim atlas: requested density {density:g} texels/m^2 would need {tiles_total} texels "
+            f"(+{retained_vertex_count} retained vertices), exceeding soft_max={soft_max}; rescaling to "
+            f"effective density {effective_density:g} texels/m^2."
+        )
+
+    positions, atlas_size = _shelf_pack(sides, padding)
+    tiles = {
+        name: TileSpec(obj_name=name, size=(side, side), offset=positions[name])
+        for name, side in sides.items()
+    }
+    return AtlasLayout(atlas_size=atlas_size, tiles=tiles, effective_density=effective_density, rescaled=rescaled)
+
+
+def _cross2(ux: np.ndarray, uy: np.ndarray, vx: np.ndarray, vy: np.ndarray) -> np.ndarray:
+    return ux * vy - uy * vx
+
+
+def _is_top_left_edge(v1: np.ndarray, v2: np.ndarray) -> bool:
+    """Standard top-left fill rule: exactly one of an edge's two directed traversals owns it.
+
+    For any shared boundary between two independently CCW-normalized triangles, the edge is
+    traversed in opposite directions by each triangle, so this predicate is true for exactly one
+    of the two - guaranteeing on-edge texels are claimed by exactly one triangle.
+    """
+    if v1[1] == v2[1]:
+        return bool(v2[0] < v1[0])
+    return bool(v2[1] < v1[1])
+
+
+def _face_normal(v0: np.ndarray, v1: np.ndarray, v2: np.ndarray) -> np.ndarray:
+    n = np.cross(v1 - v0, v2 - v0)
+    norm = np.linalg.norm(n)
+    if norm < _DEGENERATE_UV_AREA_EPS:
+        return np.zeros(3, dtype=np.float64)
+    return n / norm
+
+
+def rasterize_tile(
+    verts_mm: np.ndarray, faces: np.ndarray, loop_uv: np.ndarray, tile_size: tuple[int, int]
+) -> dict[str, np.ndarray]:
+    """Rasterize triangles (given per-triangle-corner UVs already in tile-local [0,1] space).
+
+    Texel centers are tested at ``((x+0.5)/W, (y+0.5)/H)``; a half-open (top-left) edge rule means
+    abutting triangles never double-claim a boundary texel. Triangles are processed in `faces`
+    order and earlier ones win: once a texel is covered it is never revisited. Zero-UV-area
+    (degenerate) triangles are skipped and contribute no texels (and no NaNs).
+
+    Returns arrays for covered texels only: ``xy`` (K,2) int tile-local texel indices,
+    ``position_mm`` (K,3) barycentric-interpolated 3D positions, ``normal`` (K,3) unit face
+    normals, ``face`` (K,) int source-triangle index into `faces`.
+    """
+    width, height = tile_size
+    covered: np.ndarray = np.zeros((height, width), dtype=bool)
+
+    xy_parts: list[np.ndarray] = []
+    pos_parts: list[np.ndarray] = []
+    normal_parts: list[np.ndarray] = []
+    face_parts: list[np.ndarray] = []
+
+    n_faces = faces.shape[0]
+    for fi in range(n_faces):
+        i0, i1, i2 = int(faces[fi, 0]), int(faces[fi, 1]), int(faces[fi, 2])
+        uv0 = loop_uv[fi, 0].astype(np.float64) * (width, height)
+        uv1 = loop_uv[fi, 1].astype(np.float64) * (width, height)
+        uv2 = loop_uv[fi, 2].astype(np.float64) * (width, height)
+
+        area2 = float(_cross2(uv1[0] - uv0[0], uv1[1] - uv0[1], uv2[0] - uv0[0], uv2[1] - uv0[1]))
+        if abs(area2) < _DEGENERATE_UV_AREA_EPS:
+            continue
+
+        idx = (i0, i1, i2)
+        pts = (uv0, uv1, uv2)
+        if area2 < 0:
+            idx = (i0, i2, i1)
+            pts = (uv0, uv2, uv1)
+            area2 = -area2
+        a, b, c = pts
+        ia, ib, ic = idx
+
+        x_min = max(math.floor(min(a[0], b[0], c[0])), 0)
+        x_max = min(math.ceil(max(a[0], b[0], c[0])), width)
+        y_min = max(math.floor(min(a[1], b[1], c[1])), 0)
+        y_max = min(math.ceil(max(a[1], b[1], c[1])), height)
+        if x_min >= x_max or y_min >= y_max:
+            continue
+
+        xs = np.arange(x_min, x_max, dtype=np.float64) + 0.5
+        ys = np.arange(y_min, y_max, dtype=np.float64) + 0.5
+        px = xs[np.newaxis, :]
+        py = ys[:, np.newaxis]
+
+        w_c = _cross2(b[0] - a[0], b[1] - a[1], px - a[0], py - a[1])
+        w_a = _cross2(c[0] - b[0], c[1] - b[1], px - b[0], py - b[1])
+        w_b = _cross2(a[0] - c[0], a[1] - c[1], px - c[0], py - c[1])
+
+        # Half-open edge rule: a top-left edge admits w==0 (boundary belongs to this triangle);
+        # any other edge requires w>0 (boundary belongs to whichever neighbor treats it as
+        # top-left). `_EDGE_EPS` only absorbs floating-point noise around the w==0 comparison.
+        mask_c = w_c >= -_EDGE_EPS if _is_top_left_edge(a, b) else w_c >= _EDGE_EPS
+        mask_a = w_a >= -_EDGE_EPS if _is_top_left_edge(b, c) else w_a >= _EDGE_EPS
+        mask_b = w_b >= -_EDGE_EPS if _is_top_left_edge(c, a) else w_b >= _EDGE_EPS
+        mask = mask_c & mask_a & mask_b
+        if not mask.any():
+            continue
+
+        gy, gx = np.nonzero(mask)
+        gxs: np.ndarray = gx + x_min
+        gys: np.ndarray = gy + y_min
+        keep = ~covered[gys, gxs]
+        if not keep.any():
+            continue
+        gxs, gys, gy, gx = gxs[keep], gys[keep], gy[keep], gx[keep]
+        covered[gys, gxs] = True
+
+        wa = w_a[gy, gx] / area2
+        wb = w_b[gy, gx] / area2
+        wc = w_c[gy, gx] / area2
+        positions = (
+            verts_mm[ia] * wa[:, np.newaxis] + verts_mm[ib] * wb[:, np.newaxis] + verts_mm[ic] * wc[:, np.newaxis]
+        )
+        normal = _face_normal(verts_mm[i0], verts_mm[i1], verts_mm[i2])
+
+        xy_parts.append(np.stack([gxs, gys], axis=1).astype(np.int64))
+        pos_parts.append(positions)
+        normal_parts.append(np.tile(normal, (len(gxs), 1)))
+        face_parts.append(np.full(len(gxs), fi, dtype=np.int64))
+
+    if not xy_parts:
+        return {
+            "xy": np.zeros((0, 2), dtype=np.int64),
+            "position_mm": np.zeros((0, 3), dtype=np.float64),
+            "normal": np.zeros((0, 3), dtype=np.float64),
+            "face": np.zeros((0,), dtype=np.int64),
+        }
+    return {
+        "xy": np.concatenate(xy_parts, axis=0),
+        "position_mm": np.concatenate(pos_parts, axis=0),
+        "normal": np.concatenate(normal_parts, axis=0),
+        "face": np.concatenate(face_parts, axis=0),
+    }
+
+
+def _shift2d(arr: np.ndarray, dy: int, dx: int) -> np.ndarray:
+    """arr shifted so that `out[y, x] == arr[y + dy, x + dx]`; out-of-bounds reads become 0."""
+    shifted = np.roll(arr, shift=(-dy, -dx), axis=(0, 1))
+    if dy > 0:
+        shifted[-dy:, ...] = 0
+    elif dy < 0:
+        shifted[:-dy, ...] = 0
+    if dx > 0:
+        shifted[:, -dx:, ...] = 0
+    elif dx < 0:
+        shifted[:, :-dx, ...] = 0
+    return shifted
+
+
+_NEIGHBOR_OFFSETS = [(dy, dx) for dy in (-1, 0, 1) for dx in (-1, 0, 1) if (dy, dx) != (0, 0)]
+
+
+def dilate(image: np.ndarray, valid: np.ndarray, iterations: int = 4) -> np.ndarray:
+    """Push-out margin dilation: each invalid texel takes the mean of its valid 8-neighbors.
+
+    Repeated for `iterations` passes; a texel filled on one pass becomes a valid source for the
+    next (so the filled region grows outward by up to one texel per pass), but once a texel is
+    valid - originally or newly filled - its value is never touched again.
+
+    `valid` must be 2D (``(H, W)``) regardless of whether `image` is single- or multi-channel
+    (``(H, W)`` or ``(H, W, C)``) - one validity bit per texel, not per channel.
+    """
+    valid_arr = np.asarray(valid)
+    if valid_arr.ndim != 2:
+        raise ValueError(f"dilate: `valid` must be 2D (H, W), got shape {valid_arr.shape}")
+
+    out = np.array(image, dtype=np.float64, copy=True)
+    valid_mask = np.array(valid_arr, dtype=bool, copy=True)
+
+    for _ in range(iterations):
+        if valid_mask.all():
+            break
+        valid_f = valid_mask.astype(np.float64)
+        count = np.zeros(valid_mask.shape, dtype=np.float64)
+        total = np.zeros_like(out)
+        for dy, dx in _NEIGHBOR_OFFSETS:
+            nb_valid = _shift2d(valid_f, dy, dx)
+            nb_val = _shift2d(out, dy, dx)
+            count += nb_valid
+            total += nb_val * (nb_valid if out.ndim == 2 else nb_valid[..., np.newaxis])
+
+        fillable = (~valid_mask) & (count > 0)
+        if out.ndim == 2:
+            out[fillable] = total[fillable] / count[fillable]
+        else:
+            out[fillable] = total[fillable] / count[fillable][..., np.newaxis]
+        valid_mask |= fillable
+
+    return out

--- a/visionsim/simulate/heatsim/bvh_backend.py
+++ b/visionsim/simulate/heatsim/bvh_backend.py
@@ -1,0 +1,223 @@
+# Vendored from heat-sim-blender:addon/lib/bvh_backend.py @ e5b4afe
+"""BVH backend abstraction for the Direct Kernel irradiance source.
+
+Two implementations:
+
+  - **Embree** (preferred): via `embreex` 4.x. ~10–50× faster shadow-ray
+    throughput than the pure-Python fallback. Requires the user to have
+    pip-installed `embreex` into Blender's bundled Python — see
+    ``docs/animated-geometry-howto.md`` for the install command.
+  - **mathutils.bvhtree** (fallback): always available, ships with
+    Blender. Pure-Python loop over `BVHTree.ray_cast`; functional but
+    slower for large vertex counts.
+
+Public API:
+
+    backend = best_available()
+    handle = backend.build_for_meshes(meshes_world)
+    occluded = backend.shadow_rays(origins, directions, max_dists)
+    backend.name  # "embree" or "mathutils"
+
+`meshes_world` is a list of ``(world_verts (N,3) float64, faces (M,3)
+int32)`` tuples — already transformed into world space. The backend
+combines them into one BVH; per-vertex callers don't need to know
+which mesh originally owned a triangle.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import List, Optional, Tuple
+
+import numpy as np
+
+_log = logging.getLogger("rich")
+
+try:
+    from embreex import rtcore_scene as _embree_scene  # type: ignore
+    from embreex import mesh_construction as _embree_mesh  # type: ignore
+
+    _HAS_EMBREE = True
+    _EMBREE_IMPORT_ERROR: Optional[str] = None
+except Exception as _e:  # noqa: BLE001
+    _HAS_EMBREE = False
+    _EMBREE_IMPORT_ERROR = str(_e)
+
+
+def _shadow_ray_self_offset(eps_world: float, normals: np.ndarray) -> np.ndarray:
+    """Push ray origins along the surface normal by ``eps_world`` so we
+    don't self-intersect the receiver triangle. Returns origins + eps·n."""
+    return eps_world * normals
+
+
+# ---------------------------------------------------------------------------
+# Embree backend
+# ---------------------------------------------------------------------------
+
+
+class _EmbreeBackend:
+    name = "embree"
+
+    def __init__(self) -> None:
+        self._scene = None
+        self._mesh = None  # keep a ref so it isn't GC'd before the scene is queried
+
+    def build_for_meshes(
+        self,
+        meshes_world: List[Tuple[np.ndarray, np.ndarray]],
+    ) -> None:
+        """Combine all (verts, faces) into a single Embree scene."""
+        if not meshes_world:
+            self._scene = None
+            self._mesh = None
+            return
+        # Concatenate verts + faces with proper offsets.
+        all_verts: list[np.ndarray] = []
+        all_tris: list[np.ndarray] = []
+        offset = 0
+        for verts, faces in meshes_world:
+            v = np.asarray(verts, dtype=np.float32).reshape(-1, 3)
+            t = np.asarray(faces, dtype=np.uint32).reshape(-1, 3) + offset
+            all_verts.append(v)
+            all_tris.append(t)
+            offset += int(v.shape[0])
+        verts_cat = np.ascontiguousarray(np.vstack(all_verts), dtype=np.float32)
+        tris_cat = np.ascontiguousarray(np.vstack(all_tris), dtype=np.uint32)
+
+        scene = _embree_scene.EmbreeScene()
+        mesh = _embree_mesh.TriangleMesh(scene, verts_cat, tris_cat)
+        self._scene = scene
+        self._mesh = mesh
+
+    def shadow_rays(
+        self,
+        origins: np.ndarray,
+        directions: np.ndarray,
+        max_dists: np.ndarray,
+    ) -> np.ndarray:
+        """Returns a bool (N,) array — True iff the ray hit something
+        before ``max_dist``."""
+        if self._scene is None:
+            return np.zeros((int(origins.shape[0]),), dtype=bool)
+        o = np.ascontiguousarray(origins, dtype=np.float32)
+        d = np.ascontiguousarray(directions, dtype=np.float32)
+        # embreex 4.x scene.run with query='OCCLUDED' returns 1/0 per ray
+        # (1 = some hit, 0 = miss). It doesn't take per-ray max_dist; we
+        # apply max_dist as a post-filter using INTERSECT to get the t
+        # hit-distance and compare. That's slightly more expensive but
+        # gives us proper per-ray max-distance gating (essential for
+        # point/spot lights where we don't want hits past the light).
+        try:
+            tfar = float(np.max(max_dists)) if max_dists.size else 1e10
+            # Run INTERSECT to get hit distances for filtering.
+            res = self._scene.run(o, d, query="DISTANCE")
+            t_hit = np.asarray(res, dtype=np.float32).reshape(-1)
+            # res is the t value of the first hit; np.inf or large for misses.
+            occluded = (t_hit > 0.0) & (t_hit < np.asarray(max_dists, dtype=np.float32))
+            return occluded
+        except Exception:
+            # Fallback: query='OCCLUDED' is a Boolean (no max-dist).
+            res = self._scene.run(o, d, query="OCCLUDED")
+            return np.asarray(res, dtype=np.int32).reshape(-1) > 0
+
+
+# ---------------------------------------------------------------------------
+# Mathutils fallback backend
+# ---------------------------------------------------------------------------
+
+
+class _MathutilsBackend:
+    name = "mathutils"
+
+    def __init__(self) -> None:
+        self._bvh = None
+
+    def build_for_meshes(
+        self,
+        meshes_world: List[Tuple[np.ndarray, np.ndarray]],
+    ) -> None:
+        from mathutils import Vector
+        from mathutils.bvhtree import BVHTree
+
+        if not meshes_world:
+            self._bvh = None
+            return
+
+        verts_v: list = []
+        tris_t: list = []
+        offset = 0
+        for verts, faces in meshes_world:
+            for v in verts:
+                verts_v.append(Vector((float(v[0]), float(v[1]), float(v[2]))))
+            for f in faces:
+                tris_t.append(
+                    (int(f[0]) + offset, int(f[1]) + offset, int(f[2]) + offset)
+                )
+            offset += int(verts.shape[0])
+        try:
+            self._bvh = BVHTree.FromPolygons(verts_v, tris_t, all_triangles=True)
+        except Exception as e:  # noqa: BLE001
+            _log.debug("[HeatSim] BVHTree.FromPolygons failed: %s", e)
+            self._bvh = None
+
+    def shadow_rays(
+        self,
+        origins: np.ndarray,
+        directions: np.ndarray,
+        max_dists: np.ndarray,
+    ) -> np.ndarray:
+        from mathutils import Vector
+
+        if self._bvh is None:
+            return np.zeros((int(origins.shape[0]),), dtype=bool)
+        n = int(origins.shape[0])
+        out = np.zeros((n,), dtype=bool)
+        for i in range(n):
+            origin = Vector((float(origins[i, 0]), float(origins[i, 1]), float(origins[i, 2])))
+            direction = Vector((float(directions[i, 0]), float(directions[i, 1]), float(directions[i, 2])))
+            md = float(max_dists[i]) if max_dists.size else 1e10
+            try:
+                loc, _normal, _index, dist = self._bvh.ray_cast(origin, direction, md)
+            except Exception:
+                loc = None
+                dist = None
+            if loc is not None and dist is not None and dist < md:
+                out[i] = True
+        return out
+
+
+# ---------------------------------------------------------------------------
+# Selector
+# ---------------------------------------------------------------------------
+
+
+_BACKEND_CACHE: Optional[object] = None
+
+
+def best_available():
+    """Returns a backend instance. Embree is preferred; the mathutils
+    fallback is used when ``embreex`` isn't importable.
+
+    The instance is created fresh on each call (BVH state isn't shared),
+    but the backend choice is cached the first time so we don't re-import
+    embreex on every Run.
+    """
+    if _HAS_EMBREE:
+        return _EmbreeBackend()
+    return _MathutilsBackend()
+
+
+def backend_status_string() -> str:
+    """Human-readable status for the panel."""
+    if _HAS_EMBREE:
+        try:
+            import embreex
+            ver = getattr(embreex, "__version__", "unknown")
+        except Exception:
+            ver = "unknown"
+        return f"Embree (embreex {ver})"
+    return f"mathutils.bvhtree (built-in; embreex not installed: {_EMBREE_IMPORT_ERROR or 'no module'})"
+
+
+def has_embree() -> bool:
+    return bool(_HAS_EMBREE)

--- a/visionsim/simulate/heatsim/cache.py
+++ b/visionsim/simulate/heatsim/cache.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+def cache_key(blend_path: Path, solver_cfg: dict) -> str:
+    """Stable cache key from the blend identity and solver-relevant config.
+
+    Args:
+        blend_path: Path to the source blend file.
+        solver_cfg: Solver-relevant config values that affect the result.
+
+    Returns:
+        A short hex digest used as the cache subdirectory name.
+    """
+    blend_path = Path(blend_path)
+    try:
+        mtime = blend_path.stat().st_mtime_ns
+    except OSError:
+        mtime = 0
+    payload = json.dumps({"p": str(blend_path), "m": mtime, "c": solver_cfg}, sort_keys=True)
+    return hashlib.sha1(payload.encode()).hexdigest()[:16]
+
+
+def write_temperatures(cache_root: Path, key: str, per_object: dict[str, np.ndarray], meta: dict) -> Path:
+    """Write per-object temperature histories to ``<cache_root>/<key>/temperatures.npz``.
+
+    Args:
+        cache_root: Root directory for thermal caches.
+        key: Cache key from :func:`cache_key`.
+        per_object: Mapping of object name to a ``(timesteps, vertices)`` array.
+        meta: JSON-serializable metadata stored alongside the arrays.
+
+    Returns:
+        The path to the written ``.npz`` archive.
+    """
+    out_dir = Path(cache_root) / key
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out = out_dir / "temperatures.npz"
+    save_data: dict[str, Any] = {"__meta__": np.frombuffer(json.dumps(meta).encode(), dtype=np.uint8)}
+    save_data.update(per_object)
+    np.savez_compressed(out, **save_data)
+    return out
+
+
+def read_temperatures(cache_root: Path, key: str) -> dict[str, np.ndarray] | None:
+    """Read per-object temperature histories, or return ``None`` on a cache miss.
+
+    Args:
+        cache_root: Root directory for thermal caches.
+        key: Cache key from :func:`cache_key`.
+
+    Returns:
+        Mapping of object name to its history array, or ``None`` if absent.
+    """
+    path = Path(cache_root) / key / "temperatures.npz"
+    if not path.exists():
+        return None
+    with np.load(path) as data:
+        return {k: data[k] for k in data.files if k != "__meta__"}
+
+
+def write_animated(cache_dir: Path, history: dict[str, np.ndarray], frames: list[int], meta: dict) -> Path:
+    """Write per-frame animated temperature histories to ``<cache_dir>/frames.npz``.
+
+    Args:
+        cache_dir: Directory for this specific cache key (already resolved via :func:`cache_key`).
+        history: Mapping of object name to a ``(n_frames, n_vertices)`` array.
+        frames: Solved Blender frame numbers, aligned with each array's leading axis.
+        meta: JSON-serializable metadata stored alongside the arrays.
+
+    Returns:
+        The path to the written ``.npz`` archive.
+    """
+    out_dir = Path(cache_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out = out_dir / "frames.npz"
+    save_data: dict[str, Any] = {
+        "__meta__": np.frombuffer(json.dumps(meta).encode(), dtype=np.uint8),
+        "__frames__": np.asarray(frames, dtype=np.int64),
+    }
+    save_data.update(history)
+    np.savez_compressed(out, **save_data)
+    return out
+
+
+def read_animated(cache_dir: Path) -> tuple[dict[str, np.ndarray], list[int]] | None:
+    """Read per-frame animated temperature histories, or return ``None`` on a cache miss.
+
+    Args:
+        cache_dir: Directory for this specific cache key (already resolved via :func:`cache_key`).
+
+    Returns:
+        A tuple of (mapping of object name to its ``(n_frames, n_vertices)`` history array,
+        list of solved frame numbers), or ``None`` if absent.
+    """
+    path = Path(cache_dir) / "frames.npz"
+    if not path.exists():
+        return None
+    with np.load(path) as data:
+        frames = data["__frames__"].tolist()
+        history = {k: data[k] for k in data.files if k not in ("__meta__", "__frames__")}
+    return history, frames

--- a/visionsim/simulate/heatsim/constants.py
+++ b/visionsim/simulate/heatsim/constants.py
@@ -1,0 +1,123 @@
+# Vendored from heat-sim-blender:addon/lib/constants.py @ e5b4afe
+import math
+
+THERMAL_VIEW_LAYER_NAME = "HeatSim Thermal"
+THERMAL_MATERIAL_NAME = "HeatSim_Thermal_Override"
+IRRADIANCE_LAYER_NAME = "HeatSim_Irradiance"
+ALBEDO_LAYER_NAME = "HeatSim_Albedo"
+BAKE_UV_LAYER_NAME = "HeatSim_Bake_UV"
+ATLAS_UV_LAYER_NAME = "HeatSim_Atlas_UV"
+# The render-time atlas image (adapter.write_atlas writes the EXR; blender.py loads +
+# packs it under this datablock name; thermal_shader.py's temperature-source chain
+# samples it by this name).
+ATLAS_IMAGE_NAME = "HeatSim_Temperature_Atlas"
+# OBJECT-domain custom property (float 0.0/1.0): explicitly gates the shader's atlas
+# mix factor to 0 for any object that is not an atlas participant, independent of
+# whatever the atlas image happens to contain at the (0,0,0) UV a missing
+# HeatSim_Atlas_UV attribute defaults to. Stamped on every mesh by
+# adapter.write_frame_attributes whenever an atlas_plan is supplied.
+ATLAS_COVERAGE_PROP = "heatsim_atlas_coverage"
+
+
+CAMERA = 'Boson'
+HFOV = 24.3
+VFOV = 19.5
+
+SIGMA = 5.6704e-8/(1000**2) # W/(mm^2*K^4)
+AMBIENT_TEMP = 295.372
+
+# Cycles' DIFFUSE/DIRECT+INDIRECT bake stores outgoing radiance L_out
+# for an implicit ρ=1 Lambertian receiver, in W/m²/sr. The thermal heat
+# equation wants irradiance E in W/m². The Lambert hemisphere integral
+# gives E = π · L_out, so we multiply baked irradiance pixels by π at
+# ingest to recover physical irradiance. The Direct Kernel produces
+# E directly (no factor needed). NOT applied to the COLOR/albedo bake —
+# that pass stores ρ ∈ [0, 1] which is dimensionless.
+CYCLES_LOUT_TO_IRRADIANCE = math.pi
+
+# Just took this value from google for a room at 25c. The typical value ranges from 10 to 100
+CONVECTION_COEFF = 0/(1000**2) # W/(mm^2*K)
+
+
+# Density of the material in kg/mm^3 at 98 celcius
+Density = {
+    "aluminium": 2700/(1000**3),
+    "pvc": 1330/(1000**3),
+    "glass": 2500/(1000**3),
+    "copper": 8960/(1000**3),
+    "polystyrene": 1050/(1000**3),
+    "wood": 897/(1000**3),
+    "steel": 7930/(1000**3),
+    'brick': 2200/(1000**3),
+    "concrete": 2300/(1000**3),
+    "plaster": 1200/(1000**3),
+    "asphalt": 2100/(1000**3),
+    "iron": 7200/(1000**3),
+    "li_ion": 2500/(1000**3),
+}
+# Specific heat of the material in J/(kg*K) at 98 celcius
+SpecificHeat = {
+    "aluminium": 978,
+    "pvc": 880,
+    "glass": 840,
+    "copper": 385,
+    "polystyrene": 1300,
+    "wood": 2380,
+    "steel": 280,
+    "brick": 800,
+    "concrete": 880,
+    "plaster": 1090,
+    "asphalt": 920,
+    "iron": 450,
+    "li_ion": 1100,
+}
+Absorptivity = {
+    "aluminium": 1.0,
+    "pvc": 1.0,
+    "glass": 0.9,
+    "copper": 0.9,
+    "polystyrene": 0.9,
+    "wood": 0.9,
+    "steel": 0.9,
+    "brick": 0.9,
+    "concrete": 0.94,
+    "plaster": 0.93,
+    "asphalt": 0.95,
+    "iron": 0.30,
+    "li_ion": 0.88,
+}
+
+# Thermal diffusivity in mm^2/s (alpha = k / (rho * c))
+TDiff = {
+    "aluminium": 97.0, #97, #1.0, #97,
+    "aluminium-6061": 64,
+    "glass" : 0.34,
+    "pvc": 0.17, # conductivity - 0.2 W/mK,
+    "polystyrene": 0.5, #0.5,
+    "copper": 111,
+    "wood": 0.082,
+    "steel": 4.2,
+    "brick": 0.52,
+    "concrete": 0.5,
+    "plaster": 0.4,
+    "asphalt": 0.3,
+    "iron": 18.0,
+    "li_ion": 0.2,
+}
+
+
+TConductivity = {
+    "aluminium": TDiff["aluminium"]*(Density["aluminium"]*SpecificHeat["aluminium"]),
+    "pvc": TDiff["pvc"]*(Density["pvc"]*SpecificHeat["pvc"]),
+    "glass": TDiff["glass"]*(Density["glass"]*SpecificHeat["glass"]),
+    "copper": TDiff["copper"]*(Density["copper"]*SpecificHeat["copper"]),
+    "polystyrene": TDiff["polystyrene"]*(Density["polystyrene"]*SpecificHeat["polystyrene"]),
+    "wood": TDiff["wood"]*(Density["wood"]*SpecificHeat["wood"]),
+    "steel": TDiff["steel"]*(Density["steel"]*SpecificHeat["steel"]),
+    "brick": TDiff["brick"]*(Density["brick"]*SpecificHeat["brick"]),
+    "concrete": TDiff["concrete"]*(Density["concrete"]*SpecificHeat["concrete"]),
+    "plaster": TDiff["plaster"]*(Density["plaster"]*SpecificHeat["plaster"]),
+    "asphalt": TDiff["asphalt"]*(Density["asphalt"]*SpecificHeat["asphalt"]),
+    "iron": TDiff["iron"]*(Density["iron"]*SpecificHeat["iron"]),
+    "li_ion": TDiff["li_ion"]*(Density["li_ion"]*SpecificHeat["li_ion"]),
+}

--- a/visionsim/simulate/heatsim/irradiance.py
+++ b/visionsim/simulate/heatsim/irradiance.py
@@ -1,0 +1,892 @@
+"""Cycles COLOR albedo bake, ported from the heat-sim-blender addon.
+
+Vendored so VisionSim's Direct-Kernel albedo path (``irradiance_kernel.
+_bake_vertex_albedo_via_cycles`` → this module's ``bake_albedo_map``) can
+resolve per-vertex reflectivity without depending on the installed addon.
+
+Only the albedo (DIFFUSE/COLOR) bake is ported; the Cycles *irradiance* bake
+is intentionally not vendored (VisionSim uses the analytic Direct-Kernel for
+irradiance). ``bake_albedo_map`` returns a ``BakedFluxMap`` whose ``.pixels``
+is an ``(H, W, 3)`` float64 array — the contract consumed by
+``irradiance_kernel._bake_vertex_albedo_via_cycles``.
+"""
+
+from __future__ import annotations
+
+import warnings
+from dataclasses import dataclass
+
+import bpy
+import numpy as np
+
+from .constants import ALBEDO_LAYER_NAME, BAKE_UV_LAYER_NAME, CYCLES_LOUT_TO_IRRADIANCE, IRRADIANCE_LAYER_NAME
+from .uv_utils import restore_uv_states, snapshot_uv_states
+
+
+@dataclass
+class BakedFluxMap:
+    """Container for baked flux data coming from an image texture."""
+
+    pixels: np.ndarray  # shape (H, W, 3) in linear space
+    vertex_flux: np.ndarray  # per-vertex luminance * scale
+    width: int
+    height: int
+
+
+def _ensure_uv_layer(obj):
+    """Return an active UV layer or warn if missing."""
+    mesh = obj.data
+    if not mesh.uv_layers:
+        scene = bpy.context.scene
+        view_layer = bpy.context.view_layer
+        prev_active = view_layer.objects.active
+        prev_selection = [o for o in scene.objects if o.select_get()]
+        try:
+            bpy.ops.object.select_all(action="DESELECT")
+            obj.select_set(True)
+            view_layer.objects.active = obj
+            if obj.mode != "OBJECT":
+                bpy.ops.object.mode_set(mode="OBJECT")
+            bpy.ops.object.mode_set(mode="EDIT")
+            bpy.ops.mesh.select_all(action="SELECT")
+            # Using 1.6% island margin to prevent texture bleeding artifacts
+            bpy.ops.uv.smart_project(island_margin=0.016)
+            bpy.ops.object.mode_set(mode="OBJECT")
+        except Exception as exc:  # keep running but warn
+            warnings.warn(f"HeatSim: Failed to auto-unwrap UVs for {obj.name}: {exc}")
+        finally:
+            # Restore selection and active object/mode. Force OBJECT mode FIRST and
+            # guard the operators: if smart_project raised above it left the context
+            # in EDIT mode, and an unguarded object.select_all here would poll()-fail
+            # and abort the whole scene's bake instead of just skipping this object.
+            if getattr(bpy.context, "mode", "OBJECT") != "OBJECT":
+                try:
+                    bpy.ops.object.mode_set(mode="OBJECT")
+                except Exception:
+                    pass
+            try:
+                bpy.ops.object.select_all(action="DESELECT")
+            except Exception:
+                pass
+            for o in prev_selection:
+                try:
+                    o.select_set(True)
+                except Exception:
+                    pass
+            if prev_active:
+                view_layer.objects.active = prev_active
+
+    if not mesh.uv_layers:
+        warnings.warn(f"HeatSim: {obj.name} has no UV map; cannot bake irradiance texture.")
+        return None
+    return mesh.uv_layers.active or mesh.uv_layers[0]
+
+
+def prepare_object_bake_uv(obj: bpy.types.Object) -> None:
+    """
+    Ensure `BAKE_UV_LAYER_NAME` exists on the object and is unwrapped for baking.
+
+    This mirrors the shared baking pipeline, but operates on a single object:
+    - Create/activate `BAKE_UV_LAYER_NAME`
+    - Smart Project unwrap into that layer to get a non-overlapping 0..1 bake UVs
+    """
+    if obj is None or obj.type != "MESH":
+        return
+    mesh = obj.data
+    # NOTE: test `is None`, not truthiness. `mesh.uv_layers` on a mesh carrying zero UV
+    # layers is an EMPTY collection, which is falsy -- so a truthiness check bailed out on
+    # exactly the meshes that need a bake UV created, while the very next block
+    # (`uv_layers.new(...)` + Smart Project) exists to create one from scratch.
+    #
+    # The cost was severe and entirely silent. An object with no authored UVs never got
+    # HeatSim_Bake_UV, so `_write_atlas_uv_layer` had no source layer, HeatSim_Atlas_UV was
+    # never written, and `adapter.build_atlas_plan` demoted the object from the atlas to the
+    # per-vertex path. There, if a modifier changed the vertex count (Subsurf, Solidify,
+    # ...), per-vertex write-back is structurally impossible, so `write_frame_attributes`
+    # constant-filled the whole object at the MEAN of its solved field.
+    #
+    # Measured on visionsim50/diningroom (289 objects, 85% with no authored UVs):
+    # 259 selected for the atlas, 231 demoted for a missing UV layer, 229 then
+    # constant-filled -- each rendering as ONE flat value. That is why every chair showed a
+    # different uniform temperature, and why officebuilding's floor (Cube.006, base 68 verts
+    # vs 408 evaluated) rendered as a flat 330.74 K plateau while its solved field actually
+    # spanned 295.8-445.8 K with a 33 K standard deviation.
+    if mesh is None or getattr(mesh, "uv_layers", None) is None:
+        return
+    # Skip degenerate (zero-geometry) meshes: an empty object has no albedo to
+    # bake, and bpy.ops.uv.smart_project.poll() fails on it in --background mode
+    # (nothing to unwrap), which would otherwise abort the whole scene's bake.
+    # Mirrors the empty-mesh guard in irradiance_kernel.py.
+    if len(mesh.polygons) == 0 or len(mesh.vertices) == 0:
+        return
+
+    # Ensure bake UV layer exists
+    if BAKE_UV_LAYER_NAME not in mesh.uv_layers:
+        try:
+            mesh.uv_layers.new(name=BAKE_UV_LAYER_NAME)
+        except Exception:
+            return
+
+    # Set bake UV active for unwrap + baking
+    try:
+        mesh.uv_layers[BAKE_UV_LAYER_NAME].active = True
+        mesh.uv_layers[BAKE_UV_LAYER_NAME].active_render = True
+    except Exception:
+        pass
+
+    ctx = bpy.context
+    view_layer = ctx.view_layer
+    prev_selection = list(getattr(ctx, "selected_objects", []) or [])
+    prev_active = getattr(ctx, "active_object", None)
+
+    try:
+        # Establish a clean OBJECT-mode context before any selection operator.
+        # object.select_all / mode_set poll() fail in --background when the context
+        # is in EDIT mode with no valid active object (which happens on dense scenes
+        # once any earlier object's unwrap misbehaves). Point 'active' at the object
+        # we are about to bake first, so mode_set has a valid target to switch.
+        if view_layer.objects.active is None:
+            view_layer.objects.active = obj
+        if getattr(bpy.context, "mode", "OBJECT") != "OBJECT":
+            try:
+                bpy.ops.object.mode_set(mode="OBJECT")
+            except Exception:
+                pass
+
+        bpy.ops.object.select_all(action="DESELECT")
+        obj.select_set(True)
+        view_layer.objects.active = obj
+
+        bpy.ops.object.mode_set(mode="EDIT")
+        bpy.ops.mesh.select_all(action="SELECT")
+        # Using 1.6% island margin to prevent texture bleeding artifacts.
+        bpy.ops.uv.smart_project(island_margin=0.016)
+        bpy.ops.object.mode_set(mode="OBJECT")
+    except Exception as exc:
+        # A per-object unwrap failure (smart_project.poll() and friends can fail in
+        # --background on some meshes) must never abort the whole scene's bake. Warn
+        # and keep whatever UVs the object already has; the albedo kernel treats a
+        # missing/degenerate bake as full absorption, a documented fallback.
+        warnings.warn(f"HeatSim: bake-UV prep failed for {obj.name}; using existing UVs. {exc}")
+    finally:
+        # Restore selection / active / mode best-effort.
+        # Crucially, always return to OBJECT mode: this function enters EDIT mode
+        # above, and if smart_project raised, control skipped the mode_set back to
+        # OBJECT. Leaving the shared context in EDIT makes the *next* object's
+        # object.select_all.poll() fail and abort the bake (the backwards
+        # ``prev_mode != "OBJECT"`` guard used to skip this reset when the object
+        # started, as they all do, in OBJECT mode).
+        if getattr(bpy.context, "mode", "OBJECT") != "OBJECT":
+            try:
+                bpy.ops.object.mode_set(mode="OBJECT")
+            except Exception:
+                pass
+        try:
+            bpy.ops.object.select_all(action="DESELECT")
+        except Exception:
+            pass
+        for o in prev_selection:
+            try:
+                o.select_set(True)
+            except Exception:
+                pass
+        if prev_active and prev_active in getattr(ctx, "visible_objects", []):
+            try:
+                view_layer.objects.active = prev_active
+            except Exception:
+                pass
+
+
+def _ensure_bake_image(base_name: str, name_suffix: str, size: int):
+    """Create or reuse a float image that receives baked data."""
+    size = max(16, int(size))
+    img_name = f"{base_name}_{name_suffix}"
+    image = bpy.data.images.get(img_name)
+    if image is None:
+        image = bpy.data.images.new(img_name, width=size, height=size, alpha=False, float_buffer=True)
+    else:
+        if image.size[0] != size or image.size[1] != size:
+            image.scale(size, size)
+    # Prefer linear/non-color spaces; we treat all bake outputs numerically.
+    preferred = ("Linear", "Linear Rec.709", "Non-Color")
+    for name in preferred:
+        if name in image.colorspace_settings.bl_rna.properties["name"].enum_items:
+            image.colorspace_settings.name = name
+            break
+    # Clear previous contents
+    if image.pixels:
+        image.pixels.foreach_set([0.0] * (len(image.pixels)))
+    return image
+
+
+def _ensure_albedo_image(name_suffix: str, size: int):
+    return _ensure_bake_image(ALBEDO_LAYER_NAME, name_suffix, size)
+
+
+def _ensure_irradiance_image(name_suffix: str, size: int):
+    return _ensure_bake_image(IRRADIANCE_LAYER_NAME, name_suffix, size)
+
+
+def _prepare_image_nodes_for_bake(obj, image, node_name: str, node_label: str):
+    """Ensure each material has an image texture node set active for baking."""
+    if not obj.material_slots:
+        mat = bpy.data.materials.new(name="HeatSim_Irradiance_Bake")
+        mat.use_nodes = True
+        obj.data.materials.append(mat)
+
+    for slot in obj.material_slots:
+        mat = slot.material
+        if mat is None:
+            continue
+        # For shared bake, we might reuse materials if they are shared, but we need to ensure
+        # the node exists in all of them.
+        if not mat.use_nodes:
+            mat.use_nodes = True
+        nodes = mat.node_tree.nodes
+        img_node = nodes.get(node_name)
+        if img_node is None:
+            img_node = nodes.new("ShaderNodeTexImage")
+            img_node.name = node_name
+            img_node.label = node_label
+        img_node.image = image
+        nodes.active = img_node
+        for n in nodes:
+            n.select = False
+        img_node.select = True
+
+
+@dataclass
+class _BakeMaterialUVOverride:
+    """
+    Temporary material edits to ensure textures are sampled using the *original* UV map,
+    even while the bake target UV is switched to `BAKE_UV_LAYER_NAME`.
+    """
+
+    # (obj, slot_index, original_material) entries for slots we temporarily replaced with a copy
+    replaced_slots: list[tuple[bpy.types.Object, int, bpy.types.Material | None]]
+    # (material, uv_node_name) for UVMap nodes we created
+    created_uv_nodes: list[tuple[bpy.types.Material, str]]
+    # (material, tex_node_name) for TexImage nodes we connected
+    patched_tex_nodes: list[tuple[bpy.types.Material, str]]
+
+
+def _pick_source_uv_for_object(obj: bpy.types.Object, uv_snapshot_map: dict[int, tuple[str | None, str | None]]) -> str | None:
+    """
+    Choose the UV map name that represents the object's 'real' texturing UVs.
+    Prefer the snapshot's active_render, then active, then any non-bake UV layer.
+    """
+    state = uv_snapshot_map.get(obj.as_pointer(), (None, None))
+    active_name, render_name = state
+    if render_name:
+        return str(render_name)
+    if active_name:
+        return str(active_name)
+    try:
+        mesh = obj.data
+        if mesh and getattr(mesh, "uv_layers", None):
+            for uv in mesh.uv_layers:
+                if uv.name != BAKE_UV_LAYER_NAME:
+                    return uv.name
+            if len(mesh.uv_layers) > 0:
+                return mesh.uv_layers[0].name
+    except Exception:
+        pass
+    return None
+
+
+def _apply_uv_override_to_material(mat: bpy.types.Material, uv_name: str) -> tuple[str | None, list[str]]:
+    """
+    Ensure every unlinked Image Texture node samples using a specific UV map.
+    Returns (created_uv_node_name, patched_tex_node_names).
+    """
+    if mat is None or not mat.use_nodes or mat.node_tree is None:
+        return None, []
+    nt = mat.node_tree
+    nodes = nt.nodes
+    links = nt.links
+
+    # Create a deterministic UVMap node for this bake override
+    uv_node_name = f"HeatSim_OrigUV__{uv_name}"
+    uv_node = nodes.get(uv_node_name)
+    created = False
+    if uv_node is None:
+        uv_node = nodes.new("ShaderNodeUVMap")
+        uv_node.name = uv_node_name
+        uv_node.label = "HeatSim Orig UV (Bake Override)"
+        created = True
+    try:
+        uv_node.uv_map = uv_name
+    except Exception:
+        # Older Blender versions may differ; keep best-effort.
+        pass
+
+    patched = []
+    for node in nodes:
+        if node.type != "TEX_IMAGE":
+            continue
+        vec_in = node.inputs.get("Vector")
+        if vec_in is None or vec_in.is_linked:
+            continue
+        # Wire UVMap -> Vector
+        try:
+            links.new(uv_node.outputs.get("UV"), vec_in)
+            patched.append(node.name)
+        except Exception:
+            # Don't hard-fail on odd node trees
+            pass
+
+    if created:
+        return uv_node_name, patched
+    # Even if node existed, we still might have patched tex nodes
+    return uv_node_name, patched
+
+
+def _install_bake_uv_material_overrides(objects: list[bpy.types.Object], uv_snapshot) -> _BakeMaterialUVOverride:
+    """
+    Install per-material UVMap overrides so real materials keep sampling their textures
+    with the original UV map during shared UV baking.
+
+    Handles the tricky case where multiple objects share a material but have different
+    source UV map names by temporarily copying materials per-object.
+    """
+    uv_snapshot_map: dict[int, tuple[str | None, str | None]] = {
+        obj.as_pointer(): state for obj, state in (uv_snapshot or [])
+    }
+
+    # Build material usage: mat_ptr -> {uv_names}, plus occurrences to resolve per-object copies.
+    mat_uvs: dict[int, set[str]] = {}
+    occurrences: list[tuple[bpy.types.Object, int, bpy.types.Material | None, str | None]] = []
+    for obj in objects:
+        if obj is None or obj.type != "MESH":
+            continue
+        uv_name = _pick_source_uv_for_object(obj, uv_snapshot_map)
+        for slot_idx, slot in enumerate(getattr(obj, "material_slots", []) or []):
+            mat = getattr(slot, "material", None)
+            if mat is None or not getattr(mat, "use_nodes", False) or mat.node_tree is None:
+                continue
+            occurrences.append((obj, slot_idx, mat, uv_name))
+            if uv_name:
+                mat_uvs.setdefault(mat.as_pointer(), set()).add(str(uv_name))
+
+    replaced_slots: list[tuple[bpy.types.Object, int, bpy.types.Material | None]] = []
+    created_uv_nodes: list[tuple[bpy.types.Material, str]] = []
+    patched_tex_nodes: list[tuple[bpy.types.Material, str]] = []
+
+    # Apply overrides
+    for obj, slot_idx, mat, uv_name in occurrences:
+        if not uv_name:
+            continue
+        uv_set = mat_uvs.get(mat.as_pointer(), {str(uv_name)})
+        target_mat = mat
+
+        # If the same material is used with multiple different UV map names, copy per-object.
+        if len(uv_set) > 1:
+            try:
+                mat_copy = mat.copy()
+                mat_copy.name = f"{mat.name}__HeatSimBake"
+                obj.material_slots[slot_idx].material = mat_copy
+                replaced_slots.append((obj, slot_idx, mat))
+                target_mat = mat_copy
+            except Exception:
+                # If copying fails, fall back to editing the shared material (may be imperfect).
+                target_mat = mat
+
+        uv_node_name, patched = _apply_uv_override_to_material(target_mat, str(uv_name))
+        if uv_node_name:
+            created_uv_nodes.append((target_mat, uv_node_name))
+        for tex_node_name in patched:
+            patched_tex_nodes.append((target_mat, tex_node_name))
+
+    return _BakeMaterialUVOverride(
+        replaced_slots=replaced_slots,
+        created_uv_nodes=created_uv_nodes,
+        patched_tex_nodes=patched_tex_nodes,
+    )
+
+
+def _restore_bake_uv_material_overrides(state: _BakeMaterialUVOverride | None) -> None:
+    if state is None:
+        return
+
+    # Remove UVMap -> TexImage links we created and delete UVMap nodes.
+    # Do this before restoring original materials so we can clean up copied ones too.
+    for mat, uv_node_name in state.created_uv_nodes:
+        try:
+            if mat is None or not mat.use_nodes or mat.node_tree is None:
+                continue
+            nt = mat.node_tree
+            nodes = nt.nodes
+            links = nt.links
+            uv_node = nodes.get(uv_node_name)
+            if uv_node is None:
+                continue
+
+            # Remove links from this uv node into any TEX_IMAGE Vector inputs
+            for link in list(links):
+                if (
+                    link.from_node == uv_node
+                    and link.to_node
+                    and link.to_node.type == "TEX_IMAGE"
+                    and getattr(link.to_socket, "name", "") == "Vector"
+                ):
+                    try:
+                        links.remove(link)
+                    except Exception:
+                        pass
+
+            # Remove the uv node itself (if still present)
+            try:
+                nodes.remove(uv_node)
+            except Exception:
+                pass
+        except Exception:
+            pass
+
+    # Restore original materials in slots, and remove temporary copies if possible.
+    for obj, slot_idx, original_mat in state.replaced_slots:
+        try:
+            slot = obj.material_slots[slot_idx]
+            tmp = getattr(slot, "material", None)
+            slot.material = original_mat
+            # Best-effort cleanup of the temp material if it's not used elsewhere
+            try:
+                if tmp is not None and tmp.users == 0:
+                    bpy.data.materials.remove(tmp)
+            except Exception:
+                pass
+        except Exception:
+            pass
+
+
+def _image_pixels_to_rgb(image) -> np.ndarray | None:
+    """Convert a Blender image to (H, W, 3) numpy array."""
+    w, h = image.size
+    raw = np.array(image.pixels[:], dtype=np.float64)
+    expected = w * h * 4
+    if raw.size != expected:
+        warnings.warn(f"HeatSim: Unexpected pixel count for baked image {image.name} ({raw.size} vs {expected}).")
+        return None
+    rgb = raw.reshape((h * w, 4))[:, :3]
+    return rgb.reshape((h, w, 3))
+
+
+def _bilinear_sample(rgb_pixels: np.ndarray, width: int, height: int, uv: np.ndarray) -> float:
+    """Sample luminance from an RGB image at UV coordinates using bilinear filtering."""
+    u = float(np.clip(uv[0], 0.0, 1.0))
+    v = float(np.clip(uv[1], 0.0, 1.0))
+    x = u * (width - 1)
+    y = v * (height - 1)
+
+    x0 = int(np.floor(x))
+    y0 = int(np.floor(y))
+    x1 = min(x0 + 1, width - 1)
+    y1 = min(y0 + 1, height - 1)
+
+    tx = x - x0
+    ty = y - y0
+
+    c00 = rgb_pixels[y0, x0]
+    c10 = rgb_pixels[y0, x1]
+    c01 = rgb_pixels[y1, x0]
+    c11 = rgb_pixels[y1, x1]
+
+    c0 = c00 * (1 - tx) + c10 * tx
+    c1 = c01 * (1 - tx) + c11 * tx
+    rgb = c0 * (1 - ty) + c1 * ty
+    return float(rgb @ np.array((0.2126, 0.7152, 0.0722), dtype=np.float64))
+
+
+def _image_to_vertex_irradiance(
+    loop_vertex_indices: np.ndarray,
+    uv_data: np.ndarray,
+    rgb_pixels: np.ndarray,
+    width: int,
+    height: int,
+    scale: float,
+    vert_count: int,
+) -> np.ndarray:
+    """Accumulate image luminance to vertices via UVs."""
+    accum = np.zeros(vert_count, dtype=np.float64)
+    counts = np.zeros(vert_count, dtype=np.int32)
+    for loop_idx, vert_idx in enumerate(loop_vertex_indices):
+        uv = uv_data[loop_idx]
+        flux = _bilinear_sample(rgb_pixels, width, height, uv) * float(scale)
+        accum[vert_idx] += flux
+        counts[vert_idx] += 1
+
+    counts[counts == 0] = 1
+    return accum / counts
+
+
+def _mesh_to_sample(obj):
+    """The mesh a bake's per-vertex reduction must be indexed against.
+
+    Both bakes MUST use this. The solver builds its nodes from
+    ``adapter._extract_geometry``, which reads ``obj.evaluated_get(depsgraph).data`` --
+    modifiers applied. A bake that reduces against ``obj.data`` instead produces an array
+    sized to the pre-modifier vertex count, and ``_combine`` drops a flux array whose
+    length does not match the node count: the object then receives NO absorbed flux and
+    sits at its initial temperature, warmed only by conduction from its neighbours.
+
+    Measured on one 289-object interior before this was fixed: 229 objects (79%)
+    mismatched, and every one landed at +0.332-0.334 K regardless of the flux computed
+    for it, while the 60 aligned objects rose a median 13.3 K per unit flux. Two
+    instances of the same asset made it unmistakable -- 584 verts/584 nodes rose 33.8 K;
+    584 verts/9305 nodes rose 0.333 K on identical material and flux.
+
+    This lives in one function because the fix was originally applied to only one of the
+    two near-identical bake bodies, which silently reintroduced the same class of bug on
+    the albedo side: a mismatched albedo is discarded in favour of albedo=0, i.e. full
+    absorption, overestimating absorbed flux by up to ~4x on a light surface.
+
+    Falls back to ``obj.data`` when the evaluated mesh is unusable (no vertices, or no UV
+    layers to sample through).
+    """
+    try:
+        depsgraph = bpy.context.evaluated_depsgraph_get()
+        candidate = obj.evaluated_get(depsgraph).data
+        if candidate is not None and len(candidate.vertices) > 0 and len(candidate.uv_layers) > 0:
+            return candidate
+    except Exception:  # pragma: no cover - defensive, mirrors this module's style
+        pass
+    return obj.data
+
+
+def bake_albedo_map(scene, obj, texture_size: int) -> BakedFluxMap | None:
+    """
+    Bake visible diffuse albedo (COLOR pass) for a single object.
+    """
+    if obj.type != "MESH":
+        return None
+
+    # Ensure object has source UVs for its real materials to sample from.
+    if _ensure_uv_layer(obj) is None:
+        return None
+
+    # Snapshot UV state so we don't permanently change the user's UV selections.
+    uv_snapshot = snapshot_uv_states([obj])
+
+    # Ensure the bake UV exists and is unwrapped.
+    prepare_object_bake_uv(obj)
+
+    # Record which UV map this bake used (bake UV, matching shared pipeline).
+    try:
+        obj["heat_sim_albedo_uv"] = BAKE_UV_LAYER_NAME
+    except Exception:
+        pass
+
+    image = _ensure_albedo_image(obj.name, texture_size)
+    _prepare_image_nodes_for_bake(obj, image, "HeatSim_Albedo", "HeatSim Albedo")
+
+    render = scene.render
+    bake_settings = render.bake
+    prev_engine = render.engine
+    prev_settings = (
+        getattr(bake_settings, "use_pass_direct", None),
+        getattr(bake_settings, "use_pass_indirect", None),
+        getattr(bake_settings, "use_pass_color", None),
+        getattr(bake_settings, "target", None),
+    )
+
+    view_layer = scene.view_layers.active if hasattr(scene.view_layers, "active") else scene.view_layers[0]
+    prev_active = view_layer.objects.active
+    prev_selection = [o for o in scene.objects if o.select_get()]
+    uv_override_state: _BakeMaterialUVOverride | None = None
+
+    try:
+        render.engine = "CYCLES"
+        if hasattr(bake_settings, "use_pass_direct"):
+            bake_settings.use_pass_direct = False
+        if hasattr(bake_settings, "use_pass_indirect"):
+            bake_settings.use_pass_indirect = False
+        if hasattr(bake_settings, "use_pass_color"):
+            bake_settings.use_pass_color = True
+        if hasattr(bake_settings, "target"):
+            bake_settings.target = "IMAGE_TEXTURES"
+
+        # Keep textures sampling from the original UVs while baking into BAKE_UV_LAYER_NAME.
+        uv_override_state = _install_bake_uv_material_overrides([obj], uv_snapshot)
+
+        # object.select_all.poll() fails in --background when the context is in
+        # EDIT mode; make sure we are in OBJECT mode (with a valid active object)
+        # before selecting the bake target.
+        if view_layer.objects.active is None:
+            view_layer.objects.active = obj
+        if getattr(bpy.context, "mode", "OBJECT") != "OBJECT":
+            try:
+                bpy.ops.object.mode_set(mode="OBJECT")
+            except Exception:
+                pass
+        bpy.ops.object.select_all(action="DESELECT")
+        obj.select_set(True)
+        view_layer.objects.active = obj
+
+        with bpy.context.temp_override(scene=scene, view_layer=view_layer, active_object=obj, selected_objects=[obj]):
+            bpy.ops.object.bake(type="DIFFUSE", pass_filter={"COLOR"}, target="IMAGE_TEXTURES", margin=8, margin_type='EXTEND')
+
+    except Exception as exc:
+        warnings.warn(f"HeatSim albedo bake failed for {obj.name}: {exc}")
+        return None
+    finally:
+        render.engine = prev_engine
+        if hasattr(bake_settings, "use_pass_direct") and prev_settings[0] is not None:
+            bake_settings.use_pass_direct = prev_settings[0]
+        if hasattr(bake_settings, "use_pass_indirect") and prev_settings[1] is not None:
+            bake_settings.use_pass_indirect = prev_settings[1]
+        if hasattr(bake_settings, "use_pass_color") and prev_settings[2] is not None:
+            bake_settings.use_pass_color = prev_settings[2]
+        if hasattr(bake_settings, "target") and prev_settings[3] is not None:
+            bake_settings.target = prev_settings[3]
+
+        _restore_bake_uv_material_overrides(uv_override_state)
+
+        # Guarded: this runs in a finally, so an unhandled poll() failure here
+        # (context left in EDIT mode) would mask the real error and abort the
+        # whole scene's bake.
+        try:
+            bpy.ops.object.select_all(action="DESELECT")
+        except Exception:
+            pass
+        for item in prev_selection:
+            try:
+                item.select_set(True)
+            except Exception:
+                pass
+        view_layer.objects.active = prev_active
+        # Restore original UV selections
+        restore_uv_states(uv_snapshot)
+
+    rgb_pixels = _image_pixels_to_rgb(image)
+    if rgb_pixels is None:
+        return None
+
+    mesh = _mesh_to_sample(obj)
+    mesh.calc_loop_triangles()
+    if len(mesh.loop_triangles) == 0:
+        return None
+
+    # Use the bake UV layer for mapping baked pixels to vertices.
+    uv_layer = mesh.uv_layers.get(BAKE_UV_LAYER_NAME) or (mesh.uv_layers.active or mesh.uv_layers[0])
+
+    loop_indices = np.zeros((len(mesh.loop_triangles), 3), dtype=np.int32)
+    mesh.loop_triangles.foreach_get("loops", loop_indices.ravel())
+
+    uv_data = np.zeros((len(mesh.loops), 2), dtype=np.float64)
+    uv_layer.data.foreach_get("uv", uv_data.ravel())
+
+    loop_vertex_indices = np.zeros(len(mesh.loops), dtype=np.int32)
+    mesh.loops.foreach_get("vertex_index", loop_vertex_indices)
+
+    width, height = image.size
+    vertex_luma = _image_to_vertex_irradiance(
+        loop_vertex_indices,
+        uv_data,
+        rgb_pixels,
+        width,
+        height,
+        1.0,
+        len(mesh.vertices),
+    )
+
+    obj["heat_sim_albedo_image"] = image.name
+    return BakedFluxMap(
+        pixels=rgb_pixels,
+        vertex_flux=vertex_luma,
+        width=width,
+        height=height,
+    )
+
+
+def bake_irradiance_map(scene, obj, texture_size: int, samples: int | None = None) -> BakedFluxMap | None:
+    """Bake incident irradiance (DIFFUSE DIRECT+INDIRECT) for a single object.
+
+    The mirror image of :func:`bake_albedo_map`: that bakes COLOR with the light
+    passes off (a texture lookup, no light transport); this bakes the light passes
+    with COLOR off, so the result is incoming light *independent of surface colour* -
+    irradiance, not radiosity.
+
+    Why this exists: the analytic Direct Kernel counts only objects of type ``LIGHT``
+    plus a world sky term. A scene lit by *emissive geometry* - the standard way an
+    interior is daylit, e.g. visionsim50/classroom's ``dayLight_portal`` material at
+    emission strength 20 across 6.17 m2 of windows - therefore receives no thermal flux
+    from its actual light source, and the kernel models no indirect bounce either.
+    Cycles resolves emissive meshes, bounce, portals and HDRI transport for free.
+
+    Cost is close to the albedo bake already run per object: both are dominated by UV
+    setup, texture allocation and BVH build rather than ray tracing. Measured on
+    classroom at 512px/128spp: 0.95 s/object COLOR vs 0.97 s/object DIRECT+INDIRECT.
+
+    ``vertex_flux`` is per-vertex irradiance in W/m2; Cycles bakes outgoing radiance so
+    it is scaled by ``CYCLES_LOUT_TO_IRRADIANCE`` (= pi).
+
+    NOTE: this is *incident* flux. The solver wants *absorbed* flux, so the caller
+    applies (1 - albedo) - see ``adapter._compute_irradiance_cycles``. The Direct
+    Kernel returns absorbed flux directly; that is the one contract difference.
+    """
+    if obj.type != "MESH":
+        return None
+
+    # Ensure object has source UVs for its real materials to sample from.
+    if _ensure_uv_layer(obj) is None:
+        return None
+
+    # Snapshot UV state so we don't permanently change the user's UV selections.
+    uv_snapshot = snapshot_uv_states([obj])
+
+    # Ensure the bake UV exists and is unwrapped.
+    prepare_object_bake_uv(obj)
+
+    # Record which UV map this bake used (bake UV, matching shared pipeline).
+    try:
+        obj["heat_sim_flux_uv"] = BAKE_UV_LAYER_NAME
+    except Exception:
+        pass
+
+    image = _ensure_irradiance_image(obj.name, texture_size)
+    _prepare_image_nodes_for_bake(obj, image, "HeatSim_Irradiance", "HeatSim Irradiance")
+
+    render = scene.render
+    bake_settings = render.bake
+    prev_engine = render.engine
+    prev_settings = (
+        getattr(bake_settings, "use_pass_direct", None),
+        getattr(bake_settings, "use_pass_indirect", None),
+        getattr(bake_settings, "use_pass_color", None),
+        getattr(bake_settings, "target", None),
+    )
+
+    view_layer = scene.view_layers.active if hasattr(scene.view_layers, "active") else scene.view_layers[0]
+    prev_active = view_layer.objects.active
+    prev_selection = [o for o in scene.objects if o.select_get()]
+    uv_override_state: _BakeMaterialUVOverride | None = None
+
+    # Bake sampling is deliberately overridden rather than inherited. The dataset's
+    # blends ship `samples=256` with adaptive sampling at threshold 0.05 - five times
+    # looser than Blender's 0.01 default - so adaptive terminates texels far below the
+    # nominal cap. Measured on visionsim50/diningroom that leaves 9.6-19.2% relative
+    # noise per texel; a steady-state surface sits at T ~ (E/(eps*sigma))^(1/4), so that
+    # is ~2.4-4.8% in T, i.e. several-Kelvin blotches across the temperature field.
+    # Adaptive is switched OFF, not merely tightened: at a matched cap it measured
+    # WORSE than fixed sampling (4.17% vs 3.06%) because it still cuts texels short.
+    # Denoising is deliberately NOT touched - it provably does nothing for a bake
+    # (output identical to four decimals with it on and off), unlike a rendered pass.
+    cycles = getattr(scene, "cycles", None)
+    prev_sampling = None
+    if cycles is not None and samples is not None:
+        prev_sampling = (
+            getattr(cycles, "samples", None),
+            getattr(cycles, "use_adaptive_sampling", None),
+        )
+
+    try:
+        render.engine = "CYCLES"
+        if prev_sampling is not None:
+            if hasattr(cycles, "use_adaptive_sampling"):
+                cycles.use_adaptive_sampling = False
+            if hasattr(cycles, "samples"):
+                cycles.samples = int(samples)
+        if hasattr(bake_settings, "use_pass_direct"):
+            bake_settings.use_pass_direct = True
+        if hasattr(bake_settings, "use_pass_indirect"):
+            bake_settings.use_pass_indirect = True
+        if hasattr(bake_settings, "use_pass_color"):
+            bake_settings.use_pass_color = False
+        if hasattr(bake_settings, "target"):
+            bake_settings.target = "IMAGE_TEXTURES"
+
+        # Keep textures sampling from the original UVs while baking into BAKE_UV_LAYER_NAME.
+        uv_override_state = _install_bake_uv_material_overrides([obj], uv_snapshot)
+
+        # object.select_all.poll() fails in --background when the context is in
+        # EDIT mode; make sure we are in OBJECT mode (with a valid active object)
+        # before selecting the bake target.
+        if view_layer.objects.active is None:
+            view_layer.objects.active = obj
+        if getattr(bpy.context, "mode", "OBJECT") != "OBJECT":
+            try:
+                bpy.ops.object.mode_set(mode="OBJECT")
+            except Exception:
+                pass
+        bpy.ops.object.select_all(action="DESELECT")
+        obj.select_set(True)
+        view_layer.objects.active = obj
+
+        with bpy.context.temp_override(scene=scene, view_layer=view_layer, active_object=obj, selected_objects=[obj]):
+            bpy.ops.object.bake(type="DIFFUSE", pass_filter={"DIRECT", "INDIRECT"}, target="IMAGE_TEXTURES", margin=8, margin_type='EXTEND')
+
+    except Exception as exc:
+        warnings.warn(f"HeatSim irradiance bake failed for {obj.name}: {exc}")
+        return None
+    finally:
+        render.engine = prev_engine
+        if prev_sampling is not None:
+            if prev_sampling[0] is not None and hasattr(cycles, "samples"):
+                cycles.samples = prev_sampling[0]
+            if prev_sampling[1] is not None and hasattr(cycles, "use_adaptive_sampling"):
+                cycles.use_adaptive_sampling = prev_sampling[1]
+        if hasattr(bake_settings, "use_pass_direct") and prev_settings[0] is not None:
+            bake_settings.use_pass_direct = prev_settings[0]
+        if hasattr(bake_settings, "use_pass_indirect") and prev_settings[1] is not None:
+            bake_settings.use_pass_indirect = prev_settings[1]
+        if hasattr(bake_settings, "use_pass_color") and prev_settings[2] is not None:
+            bake_settings.use_pass_color = prev_settings[2]
+        if hasattr(bake_settings, "target") and prev_settings[3] is not None:
+            bake_settings.target = prev_settings[3]
+
+        _restore_bake_uv_material_overrides(uv_override_state)
+
+        # Guarded: this runs in a finally, so an unhandled poll() failure here
+        # (context left in EDIT mode) would mask the real error and abort the
+        # whole scene's bake.
+        try:
+            bpy.ops.object.select_all(action="DESELECT")
+        except Exception:
+            pass
+        for item in prev_selection:
+            try:
+                item.select_set(True)
+            except Exception:
+                pass
+        view_layer.objects.active = prev_active
+        # Restore original UV selections
+        restore_uv_states(uv_snapshot)
+
+    rgb_pixels = _image_pixels_to_rgb(image)
+    if rgb_pixels is None:
+        return None
+
+    mesh = _mesh_to_sample(obj)
+    mesh.calc_loop_triangles()
+    if len(mesh.loop_triangles) == 0:
+        return None
+
+    # Use the bake UV layer for mapping baked pixels to vertices.
+    uv_layer = mesh.uv_layers.get(BAKE_UV_LAYER_NAME) or (mesh.uv_layers.active or mesh.uv_layers[0])
+
+    loop_indices = np.zeros((len(mesh.loop_triangles), 3), dtype=np.int32)
+    mesh.loop_triangles.foreach_get("loops", loop_indices.ravel())
+
+    uv_data = np.zeros((len(mesh.loops), 2), dtype=np.float64)
+    uv_layer.data.foreach_get("uv", uv_data.ravel())
+
+    loop_vertex_indices = np.zeros(len(mesh.loops), dtype=np.int32)
+    mesh.loops.foreach_get("vertex_index", loop_vertex_indices)
+
+    width, height = image.size
+    vertex_luma = _image_to_vertex_irradiance(
+        loop_vertex_indices,
+        uv_data,
+        rgb_pixels,
+        width,
+        height,
+        CYCLES_LOUT_TO_IRRADIANCE,
+        len(mesh.vertices),
+    )
+
+    obj["heat_sim_irradiance_image"] = image.name
+    return BakedFluxMap(
+        pixels=rgb_pixels,
+        vertex_flux=vertex_luma,
+        width=width,
+        height=height,
+    )

--- a/visionsim/simulate/heatsim/irradiance_kernel.py
+++ b/visionsim/simulate/heatsim/irradiance_kernel.py
@@ -1,0 +1,642 @@
+# Vendored from heat-sim-blender:addon/lib/irradiance_kernel.py @ e5b4afe
+"""Direct-Kernel orchestrator: per-vertex irradiance without Cycles bakes.
+
+This is the alternative to `irradiance.bake_irradiance_for_active_frame()`
+(Cycles texture bake → sample at vertices). It replaces the Cycles direct
++ indirect light pass with:
+
+  1. **Per-light analytic** form-factors from ``light_models`` (sun, point,
+     spot, area).
+  2. **Per-vertex visibility** via Embree (or mathutils.bvhtree fallback)
+     in ``bvh_backend`` — one ray per (light × vertex) sample point. Area
+     lights take K rays per vertex (stratified shadow MC).
+  3. **Sky / HDRI** via 9-coefficient SH irradiance using
+     ``sh9_sky.prefilter_world`` + ``eval_per_vertex``. No rays — the
+     SH9 reconstruction implicitly assumes the sky is unoccluded above
+     the upper hemisphere of each vertex.
+  4. **Per-vertex albedo** baked once via Cycles (``bake_albedo_map``)
+     and cached on disk as a sidecar npz. Sampled at vertices via the
+     existing UV-mapped sampler; stored as a mesh attribute named
+     ``albedo`` for re-use.
+
+Output: ``{obj: {"vertex_flux": (N,) float64 W/m²}}`` — absorbed flux per
+vertex (post-(1−albedo)). The FEM solver consumes this directly through
+the existing ``combined_irradiance`` slot, bypassing texture sampling.
+
+Relative to the Cycles bake this is faster (no GPU pass, no UV unwrap,
+no texture allocation) but sacrifices fidelity: no indirect bounce, no
+specular contribution, sky is unshadowed by definition. For thermal use
+on time-varying scenes this is generally a win — see
+``proposals/phase-3-direct-light-vertex-kernel.md``.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+import bpy
+import numpy as np
+
+from visionsim.simulate.heatsim import bvh_backend, light_models, occluders, sh9_sky, sky_visibility
+
+_log = logging.getLogger("rich")
+
+
+# ---------------------------------------------------------------------------
+# Geometry extraction
+# ---------------------------------------------------------------------------
+
+
+def _extract_world_geometry(obj: bpy.types.Object) -> tuple[np.ndarray, np.ndarray, np.ndarray] | None:
+    """Returns ``(world_verts (N,3) m, world_normals (N,3) unit, faces (M,3) int32)``
+    for ``obj``'s evaluated mesh, or None if extraction fails. Verts are in
+    meters (Blender's native unit) so the BVH backend gets consistent units."""
+    if obj.type != "MESH":
+        return None
+    depsgraph = bpy.context.evaluated_depsgraph_get()
+    obj_eval = obj.evaluated_get(depsgraph)
+    mesh = obj_eval.data
+    if len(mesh.vertices) == 0 or len(mesh.polygons) == 0:
+        return None
+
+    n_v = len(mesh.vertices)
+    co = np.zeros(n_v * 3, dtype=np.float64)
+    mesh.vertices.foreach_get("co", co)
+    co = co.reshape(n_v, 3)
+
+    nrm = np.zeros(n_v * 3, dtype=np.float64)
+    mesh.vertices.foreach_get("normal", nrm)
+    nrm = nrm.reshape(n_v, 3)
+
+    mw = np.array(obj.matrix_world, dtype=np.float64)
+    R = mw[:3, :3]
+    t = mw[:3, 3]
+    world_verts = (co @ R.T) + t  # (N, 3) meters
+    # Normal transform: inv-transpose of R.
+    try:
+        N_mat = np.linalg.inv(R).T
+    except np.linalg.LinAlgError:
+        N_mat = R
+    world_normals = nrm @ N_mat.T
+    n_norm = np.linalg.norm(world_normals, axis=1, keepdims=True)
+    n_norm = np.where(n_norm > 1e-12, n_norm, 1.0)
+    world_normals = world_normals / n_norm
+
+    # Triangulate via loop_triangles (matches the FEM extractor).
+    mesh.calc_loop_triangles()
+    n_tri = len(mesh.loop_triangles)
+    if n_tri == 0:
+        return None
+    tri_verts = np.zeros(n_tri * 3, dtype=np.int32)
+    mesh.loop_triangles.foreach_get("vertices", tri_verts)
+    faces = tri_verts.reshape(n_tri, 3)
+
+    return (
+        world_verts.astype(np.float64),
+        world_normals.astype(np.float64),
+        faces.astype(np.int32),
+    )
+
+
+def _collect_scene_meshes_world(scene: bpy.types.Scene) -> list[tuple[np.ndarray, np.ndarray]]:
+    """Build the occluder BVH input set: every renderable, shadow-casting mesh
+    in the scene, in world meters (so non-sim props still cast shadows)."""
+    out: list[tuple[np.ndarray, np.ndarray]] = []
+    for obj in scene.objects:
+        if obj.type != "MESH":
+            continue
+        if obj.hide_render or not obj.visible_get():
+            continue
+        if not occluders.casts_shadow(obj):
+            continue
+        geom = _extract_world_geometry(obj)
+        if geom is None:
+            continue
+        verts, _normals, faces = geom
+        out.append((verts, faces))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Albedo: per-vertex via the existing Cycles albedo bake (cached on disk +
+# stored as a mesh attribute so subsequent solves don't re-bake).
+# ---------------------------------------------------------------------------
+
+
+def _read_vertex_albedo_attr(obj: bpy.types.Object, attr_name: str) -> np.ndarray | None:
+    """Try to read a (N,) float per-vertex albedo from the named POINT/FLOAT
+    attribute. Returns None if missing or wrong shape."""
+    mesh = getattr(obj, "data", None)
+    if mesh is None:
+        return None
+    try:
+        attr = mesh.attributes.get(attr_name)
+    except Exception:
+        attr = None
+    if attr is None:
+        return None
+    if getattr(attr, "domain", None) != "POINT" or getattr(attr, "data_type", None) != "FLOAT":
+        return None
+    n = len(mesh.vertices)
+    if n != len(attr.data):
+        return None
+    out = np.zeros((n,), dtype=np.float32)
+    try:
+        attr.data.foreach_get("value", out)
+    except Exception:
+        return None
+    return out.astype(np.float64)
+
+
+def store_vertex_flux_attr(obj: bpy.types.Object, vals: np.ndarray, attr_name: str = "sim_irradiance") -> None:
+    """Persist (N,) per-vertex absorbed flux (W/m²) as a POINT/FLOAT
+    mesh attribute. Used by View Flux to render per-vertex irradiance
+    through the turbo colormap in DIRECT_KERNEL mode."""
+    mesh = getattr(obj, "data", None)
+    if mesh is None:
+        return
+    if len(mesh.vertices) != int(vals.shape[0]):
+        return
+    if attr_name in mesh.attributes:
+        try:
+            mesh.attributes.remove(mesh.attributes[attr_name])
+        except Exception:
+            pass
+    try:
+        attr = mesh.attributes.new(name=attr_name, type="FLOAT", domain="POINT")
+        attr.data.foreach_set("value", np.asarray(vals, dtype=np.float32))
+        mesh.update()
+    except Exception:
+        pass
+
+
+def _store_vertex_albedo_attr(obj: bpy.types.Object, attr_name: str, vals: np.ndarray) -> None:
+    """Store (N,) per-vertex albedo as a POINT/FLOAT mesh attribute on the
+    original (non-evaluated) mesh. Skipped silently on vertex-count mismatch
+    (object has modifiers that change topology — kernel albedo not supported
+    for those today)."""
+    mesh = getattr(obj, "data", None)
+    if mesh is None:
+        return
+    if len(mesh.vertices) != int(vals.shape[0]):
+        return
+    if attr_name in mesh.attributes:
+        try:
+            mesh.attributes.remove(mesh.attributes[attr_name])
+        except Exception:
+            pass
+    try:
+        attr = mesh.attributes.new(name=attr_name, type="FLOAT", domain="POINT")
+        attr.data.foreach_set("value", np.asarray(vals, dtype=np.float32))
+        mesh.update()
+    except Exception:
+        pass
+
+
+def _bake_vertex_albedo_via_cycles(
+    scene: bpy.types.Scene,
+    obj: bpy.types.Object,
+    texture_size: int,
+) -> np.ndarray | None:
+    """Run the existing Cycles albedo bake and reduce to (N,) per-vertex
+    grayscale (luminance). Returns None on bake failure."""
+    from visionsim.simulate.heatsim import irradiance
+
+    baked = irradiance.bake_albedo_map(scene, obj, texture_size)
+    if baked is None or baked.pixels is None:
+        return None
+
+    # Must match what the solver indexes against -- see irradiance._mesh_to_sample. This
+    # is the third place the same base-vs-evaluated mesh choice is made; getting it wrong
+    # here sizes the albedo to the pre-modifier vertex count, and the caller then discards
+    # it in favour of albedo=0 (full absorption), overestimating absorbed flux.
+    mesh = irradiance._mesh_to_sample(obj)
+    mesh.calc_loop_triangles()
+    if len(mesh.loop_triangles) == 0:
+        return None
+
+    from visionsim.simulate.heatsim.constants import BAKE_UV_LAYER_NAME
+
+    uv_layer = (
+        mesh.uv_layers.get(BAKE_UV_LAYER_NAME)
+        or mesh.uv_layers.active
+        or (mesh.uv_layers[0] if mesh.uv_layers else None)
+    )
+    if uv_layer is None:
+        return None
+
+    n_loops = len(mesh.loops)
+    uv_flat = np.zeros(n_loops * 2, dtype=np.float64)
+    uv_layer.data.foreach_get("uv", uv_flat)
+    uv = uv_flat.reshape(-1, 2)
+
+    loop_vert_indices = np.zeros(n_loops, dtype=np.int32)
+    mesh.loops.foreach_get("vertex_index", loop_vert_indices)
+
+    pixels = baked.pixels
+    h, w = int(pixels.shape[0]), int(pixels.shape[1])
+    u = uv[:, 0] - np.floor(uv[:, 0])
+    v = uv[:, 1] - np.floor(uv[:, 1])
+    px = np.clip((u * (w - 1)).astype(np.int32), 0, w - 1)
+    py = np.clip((v * (h - 1)).astype(np.int32), 0, h - 1)
+    sampled = pixels[py, px]  # (n_loops, 3)
+    luma = (
+        sampled[..., 0] * 0.2126 + sampled[..., 1] * 0.7152 + sampled[..., 2] * 0.0722
+    ).astype(np.float64)
+    luma = np.clip(luma, 0.0, 1.0)
+
+    n_verts = len(mesh.vertices)
+    accum = np.zeros(n_verts, dtype=np.float64)
+    counts = np.zeros(n_verts, dtype=np.int32)
+    np.add.at(accum, loop_vert_indices, luma)
+    np.add.at(counts, loop_vert_indices, 1)
+    counts = np.where(counts > 0, counts, 1)
+    return accum / counts
+
+
+def get_or_bake_vertex_albedo(
+    scene: bpy.types.Scene,
+    objects: list[bpy.types.Object],
+    *,
+    texture_size: int,
+    attr_name: str = "albedo",
+    disk_cache: dict[str, np.ndarray] | None = None,
+) -> dict[str, np.ndarray]:
+    """For each object, return its per-vertex albedo (N,) in [0, 1].
+
+    Resolution order:
+      1. The mesh attribute ``attr_name`` if present and shape matches.
+      2. The disk_cache dict (loaded by the caller from the kernel albedo
+         sidecar).
+      3. Cycles bake → store as both attribute and (caller's responsibility
+         to) disk cache.
+
+    Returns ``{obj.name: (N,) float64}``. Objects whose albedo can't be
+    obtained (no UVs, bake failure) are absent from the return — the caller
+    should treat those as albedo=0 (full absorption) for safety.
+    """
+    out: dict[str, np.ndarray] = {}
+    if disk_cache is None:
+        disk_cache = {}
+
+    for obj in objects:
+        # 1. Existing mesh attribute.
+        vals = _read_vertex_albedo_attr(obj, attr_name)
+        # An all-zero albedo is the degenerate "fully absorbing" fallback (and the
+        # sentinel a stale/cross-tool cache leaves behind), never a real bake — so
+        # ignore it and fall through to a fresh bake.
+        if vals is not None and vals.size > 0 and float(np.max(vals)) > 0.0:
+            out[obj.name] = np.clip(vals, 0.0, 1.0)
+            continue
+
+        # 2. Disk cache.
+        cached = disk_cache.get(obj.name)
+        if (cached is not None
+                and int(cached.shape[0]) == len(obj.data.vertices)
+                and np.asarray(cached).size > 0
+                and float(np.max(np.asarray(cached))) > 0.0):
+            vals = np.clip(np.asarray(cached, dtype=np.float64), 0.0, 1.0)
+            _store_vertex_albedo_attr(obj, attr_name, vals)
+            out[obj.name] = vals
+            continue
+
+        # 3. Cycles bake (one-shot).
+        _log.debug("[HeatSim:Kernel] Baking per-vertex albedo for '%s' (one-time, then cached).", obj.name)
+        vals = _bake_vertex_albedo_via_cycles(scene, obj, texture_size)
+        if vals is None:
+            _log.debug("[HeatSim:Kernel] Albedo bake failed for '%s'; treating as black (full absorption).", obj.name)
+            continue
+        vals = np.clip(vals, 0.0, 1.0)
+        _store_vertex_albedo_attr(obj, attr_name, vals)
+        out[obj.name] = vals
+
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Visibility-aware light contribution
+# ---------------------------------------------------------------------------
+
+
+def _accumulate_light_contributions(
+    light_objs: list[bpy.types.Object],
+    vert_positions: np.ndarray,
+    vert_normals: np.ndarray,
+    backend,
+    n_samples_for_area: int,
+    rng: np.random.Generator,
+) -> np.ndarray:
+    """Returns (N,) W/m² unshadowed → shadowed direct irradiance from all
+    lights. ``backend`` is a built BVH (ready for shadow_rays())."""
+    Nv = int(vert_positions.shape[0])
+    total = np.zeros((Nv,), dtype=np.float64)
+
+    for light in light_objs:
+        irr_per_sample, origins, dirs, max_dists = light_models.evaluate_light(
+            light, vert_positions, vert_normals,
+            n_samples_for_area=n_samples_for_area, rng=rng,
+        )
+        if not bool(np.any(irr_per_sample > 0)):
+            continue
+        S, N = irr_per_sample.shape
+        # Only fire rays for samples with nonzero unshadowed contribution.
+        mask = irr_per_sample > 0
+        if not bool(np.any(mask)):
+            continue
+
+        # Flatten the (S, N) stack into a single ray batch.
+        flat_o = origins.reshape(S * N, 3)
+        flat_d = dirs.reshape(S * N, 3)
+        flat_md = max_dists.reshape(S * N)
+        flat_mask = mask.reshape(S * N)
+
+        # Shadow-ray only for masked samples.
+        contributions = np.zeros((S * N,), dtype=np.float64)
+        if int(flat_mask.sum()) > 0:
+            occluded = backend.shadow_rays(
+                flat_o[flat_mask], flat_d[flat_mask], flat_md[flat_mask],
+            )
+            visible = ~occluded
+            irr_flat = irr_per_sample.reshape(S * N)
+            contributions[flat_mask] = irr_flat[flat_mask] * visible.astype(np.float64)
+        contributions = contributions.reshape(S, N)
+        total += contributions.sum(axis=0)
+
+    return total
+
+
+# ---------------------------------------------------------------------------
+# Sky cache (in-memory; one entry per session)
+# ---------------------------------------------------------------------------
+
+
+_SKY_CACHE: dict[str, np.ndarray] = {}
+
+
+def _get_sky_coefficients(world) -> np.ndarray:
+    """Cached SH9 prefilter. Hashes the world; recomputes when the hash
+    changes (or on the first call of a session)."""
+    key = sh9_sky.world_hash(world)
+    cached = _SKY_CACHE.get(key)
+    if cached is not None:
+        return cached
+    coeffs = sh9_sky.prefilter_world(world)
+    _SKY_CACHE[key] = coeffs
+    return coeffs
+
+
+def invalidate_sky_cache() -> None:
+    """Drop the in-memory SH9 cache. Called by Reset / source-switch."""
+    _SKY_CACHE.clear()
+
+
+# ---------------------------------------------------------------------------
+# Shared points->irradiance core (used by both the per-vertex and texel paths)
+# ---------------------------------------------------------------------------
+
+
+def _sky_irradiance_plain(normals: np.ndarray, sky_coeffs: np.ndarray, sky_has_energy: bool) -> np.ndarray:
+    """Unoccluded SH9 sky irradiance at ``normals`` - (N,) W/m².
+
+    No per-point bent-normal/AO occlusion: this is what the per-vertex path already
+    falls back to when sky occlusion is disabled or unavailable for a vertex, and it is
+    the ONLY sky term the texel path uses (texels have no baked per-point AO)."""
+    if not sky_has_energy:
+        return np.zeros((int(normals.shape[0]),), dtype=np.float64)
+    return sh9_sky.eval_per_vertex(normals, sky_coeffs)
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+
+def compute_per_vertex_irradiance(
+    scene: bpy.types.Scene,
+    sim_objects: list[bpy.types.Object],
+    settings,
+    *,
+    objects_to_compute: list[bpy.types.Object] | None = None,
+    force_sky_revisibility: bool = False,
+) -> dict[bpy.types.Object, dict]:
+    """Direct-Kernel replacement for ``bake_irradiance_for_active_frame``.
+
+    Returns ``{obj: {"vertex_flux": (N,) float64 W/m² absorbed}}``.
+
+    The flux is post-albedo (i.e. ``Q_abs = E_total · (1 − albedo_gray)``)
+    so the FEM solver can install it directly without further conversion.
+
+    ``objects_to_compute`` is the per-frame subset to update (mirrors
+    ``bake_irradiance_for_active_frame``'s `objects_to_bake`). Defaults to
+    every sim object.
+    """
+    if objects_to_compute is None:
+        objects_to_compute = list(sim_objects)
+    # Dirichlet sources don't need a per-vertex flux contribution — their
+    # temperature is pinned regardless of what light hits them. Skip them
+    # entirely (no albedo bake, no sky-visibility bake, no flux output).
+    objects_to_compute = [
+        o for o in objects_to_compute
+        if str(getattr(getattr(o, "heat_sim_material", None), "thermal_role", "FEM_PARTICIPANT")).upper()
+        != "DIRICHLET_SOURCE"
+    ]
+    if not objects_to_compute:
+        return {}
+
+    t0 = time.perf_counter()
+
+    # 1. Gather lights, scene-wide mesh occluders, and the BVH backend.
+    light_objs = [
+        o for o in scene.objects
+        if getattr(o, "type", None) == "LIGHT" and not o.hide_render and o.visible_get()
+    ]
+    scene_meshes = _collect_scene_meshes_world(scene)
+    backend = bvh_backend.best_available()
+    backend.build_for_meshes(scene_meshes)
+
+    # 2. Sky SH9 (cached).
+    sky_coeffs = _get_sky_coefficients(getattr(scene, "world", None))
+    sky_has_energy = sh9_sky.coeffs_have_energy(sky_coeffs)
+
+    # 3. Per-vertex albedo (cached on disk + as mesh attribute).
+    from visionsim.simulate.heatsim import temperature_io
+    albedo_disk = temperature_io.read_kernel_albedo_cache(scene) or {}
+    texture_size_for_albedo = int(getattr(settings, "irradiance_texture_size", 512))
+    vertex_albedo_map = get_or_bake_vertex_albedo(
+        scene, objects_to_compute,
+        texture_size=texture_size_for_albedo,
+        disk_cache=albedo_disk,
+    )
+    # Persist any newly-baked albedos to disk.
+    if vertex_albedo_map:
+        merged = dict(albedo_disk)
+        merged.update(vertex_albedo_map)
+        temperature_io.write_kernel_albedo_cache(scene, merged)
+
+    # 3b. Per-vertex sky visibility (bent normal + AO), cached on disk +
+    # as mesh attributes. Skipped when sky is unenergetic or feature is off.
+    enable_sky_occ = bool(getattr(settings, "enable_sky_occlusion", True))
+    sky_vis_map: dict[str, dict[str, np.ndarray]] = {}
+    if enable_sky_occ and sky_has_energy:
+        sky_vis_map = sky_visibility.get_or_bake_for_objects(
+            scene, objects_to_compute, backend, settings,
+            force_rebake=bool(force_sky_revisibility),
+        )
+    ao_floor = float(getattr(settings, "sky_ao_min_for_bent", 0.02))
+
+    # 4. Per-receiver computation.
+    n_samples_for_area = max(1, int(getattr(settings, "direct_kernel_soft_shadow_rays", 8)))
+    rng = np.random.default_rng(0)
+    out: dict[bpy.types.Object, dict] = {}
+
+    for obj in objects_to_compute:
+        geom = _extract_world_geometry(obj)
+        if geom is None:
+            continue
+        world_verts, world_normals, _faces = geom
+        Nv = int(world_verts.shape[0])
+
+        # Direct light contribution (visibility-aware).
+        direct = _accumulate_light_contributions(
+            light_objs, world_verts, world_normals,
+            backend, n_samples_for_area, rng,
+        )
+
+        # Sky contribution. SH9 is the prefiltered ambient form; when
+        # sky-occlusion is enabled we evaluate it at the per-vertex bent
+        # normal and attenuate by AO. When AO falls below the floor the
+        # bent normal is unreliable (very few visible rays) — fall back
+        # to the surface normal.
+        sv = sky_vis_map.get(obj.name) if sky_has_energy else None
+        if sky_has_energy and enable_sky_occ and sv is not None:
+            bn = np.asarray(sv["bent_normal"], dtype=np.float64)
+            ao = np.asarray(sv["ao"], dtype=np.float64)
+            if int(bn.shape[0]) == Nv and int(ao.shape[0]) == Nv:
+                use_bent = (ao >= ao_floor)[:, None]
+                eval_normals = np.where(use_bent, bn, world_normals)
+                sky_irr = sh9_sky.eval_per_vertex(eval_normals, sky_coeffs) * ao
+            else:
+                sky_irr = _sky_irradiance_plain(world_normals, sky_coeffs, sky_has_energy)
+        else:
+            sky_irr = _sky_irradiance_plain(world_normals, sky_coeffs, sky_has_energy)
+
+        e_total = direct + sky_irr  # (N,) W/m²
+
+        # Albedo absorption.
+        alb = vertex_albedo_map.get(obj.name)
+        if alb is not None and int(alb.shape[0]) == Nv:
+            absorbed = e_total * (1.0 - alb)
+        else:
+            # Missing albedo → assume fully absorbing (safer than fully reflecting).
+            absorbed = e_total
+
+        out[obj] = {"vertex_flux": absorbed.astype(np.float64)}
+        store_vertex_flux_attr(obj, absorbed)
+
+        try:
+            mean_e = float(np.mean(e_total))
+            max_e = float(np.max(e_total))
+            mean_a = float(np.mean(absorbed))
+            _log.debug(
+                "  %s (Nv=%d): E_mean=%.2f W/m², E_max=%.2f, absorbed_mean=%.2f (post-albedo)",
+                obj.name, Nv, mean_e, max_e, mean_a,
+            )
+        except Exception:
+            pass
+
+    dt = time.perf_counter() - t0
+    _log.debug(
+        "[HeatSim:Kernel] Direct-kernel irradiance computed for %d/%d object(s) in %.2f s "
+        "(BVH backend: %s).",
+        len(out), len(objects_to_compute), dt, backend.name,
+    )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Texel-sim entry point (Task 2 / thermal atlas)
+# ---------------------------------------------------------------------------
+
+
+def compute_irradiance_at_points(
+    scene: bpy.types.Scene,
+    positions_mm: np.ndarray,
+    normals: np.ndarray,
+    albedo: np.ndarray,
+    *,
+    backend=None,
+    n_samples_for_area: int = 8,
+) -> np.ndarray:
+    """Direct-Kernel irradiance at arbitrary world-space points - the texel-sim entry point.
+
+    Factored from :func:`compute_per_vertex_irradiance`'s per-object core
+    (:func:`_accumulate_light_contributions` + :func:`_sky_irradiance_plain`) so the two
+    paths cannot silently diverge; this function does not change what
+    :func:`compute_per_vertex_irradiance` computes for a mesh's own vertices - it is a new,
+    additional entry point for point clouds that aren't a mesh's vertex set (e.g. a
+    thermal-atlas tile's texel centers from ``atlas.rasterize_tile``).
+
+    Returns ``(K,) W/m²`` ABSORBED flux (post-``(1 - albedo)``), matching
+    :func:`compute_per_vertex_irradiance`'s ``vertex_flux`` contract.
+
+    Unlike the per-vertex path this has no baked per-point sky-occlusion (bent normal /
+    AO) - every point uses its own surface normal for the (unoccluded) SH9 sky term, the
+    same fallback the per-vertex path takes when sky occlusion is disabled or unavailable
+    for a given vertex.
+
+    Args:
+        scene: The Blender scene (for lights, occluders and the world/sky).
+        positions_mm: ``(K, 3)`` world-space positions in **millimetres** (the adapter's
+            native unit, e.g. ``atlas.rasterize_tile``'s ``position_mm``); converted to
+            metres internally to match the light/BVH pipeline's units
+            (``_extract_world_geometry`` works in metres).
+        normals: ``(K, 3)`` world-space unit normals.
+        albedo: ``(K,)`` per-point albedo in ``[0, 1]``. A shape mismatch against
+            ``positions_mm`` is treated as "no albedo" (full absorption), matching
+            :func:`compute_per_vertex_irradiance`'s missing-albedo fallback.
+        backend: An optional, already-built BVH backend (``bvh_backend.best_available()``
+            with ``.build_for_meshes(...)`` already called). When given, the scene-mesh
+            collection and BVH build are skipped entirely and this backend is used as-is
+            -- lets a caller that queries many point sets against the same static scene
+            (e.g. one call per atlas-participating object in a single solve) build the
+            BVH once and reuse it, instead of paying a full scene BVH rebuild per call.
+            Defaults to ``None``, which preserves today's behaviour: build a fresh backend
+            from ``scene`` on every call.
+        n_samples_for_area: Shadow-ray sample count for area lights, the same knob
+            :func:`compute_per_vertex_irradiance` reads from
+            ``settings.direct_kernel_soft_shadow_rays``. Defaults to ``8`` (that setting's
+            own default), so omitting it reproduces today's behaviour exactly.
+    """
+    positions_mm = np.asarray(positions_mm, dtype=np.float64).reshape(-1, 3)
+    normals = np.asarray(normals, dtype=np.float64).reshape(-1, 3)
+    albedo = np.asarray(albedo, dtype=np.float64).reshape(-1)
+    k = int(positions_mm.shape[0])
+    if k == 0:
+        return np.zeros((0,), dtype=np.float64)
+
+    positions_m = positions_mm / 1000.0
+
+    light_objs = [
+        o for o in scene.objects
+        if getattr(o, "type", None) == "LIGHT" and not o.hide_render and o.visible_get()
+    ]
+    if backend is None:
+        scene_meshes = _collect_scene_meshes_world(scene)
+        backend = bvh_backend.best_available()
+        backend.build_for_meshes(scene_meshes)
+
+    sky_coeffs = _get_sky_coefficients(getattr(scene, "world", None))
+    sky_has_energy = sh9_sky.coeffs_have_energy(sky_coeffs)
+
+    n_samples_for_area = max(1, int(n_samples_for_area))
+    rng = np.random.default_rng(0)
+
+    direct = _accumulate_light_contributions(light_objs, positions_m, normals, backend, n_samples_for_area, rng)
+    sky_irr = _sky_irradiance_plain(normals, sky_coeffs, sky_has_energy)
+    e_total = direct + sky_irr
+
+    if albedo.shape[0] != k:
+        albedo = np.zeros(k, dtype=np.float64)
+    absorbed = e_total * (1.0 - np.clip(albedo, 0.0, 1.0))
+    return absorbed.astype(np.float64)

--- a/visionsim/simulate/heatsim/laplacian.py
+++ b/visionsim/simulate/heatsim/laplacian.py
@@ -1,0 +1,126 @@
+# Vendored from heat-sim-blender:addon/lib/robust_laplacian_backend.py @ e5b4afe
+"""
+Optional integration with `robust_laplacian` (Sharp & Crane SGP 2020).
+
+This module is safe to import even when the dependency is missing.
+Callers should check `HAS_ROBUST_LAPLACIAN` before using.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import scipy.sparse as sp
+
+try:
+    import robust_laplacian  # type: ignore
+
+    HAS_ROBUST_LAPLACIAN = True
+    ROBUST_IMPORT_ERROR: str | None = None
+except Exception as e:  # pragma: no cover
+    robust_laplacian = None
+    HAS_ROBUST_LAPLACIAN = False
+    ROBUST_IMPORT_ERROR = str(e)
+
+
+def mesh_laplacian_and_mass(
+    verts: np.ndarray,
+    faces: np.ndarray,
+    mollify_factor: float = 1e-5,
+):
+    """
+    Build robust mesh Laplacian + lumped mass matrix.
+
+    Returns:
+        (L, M) as SciPy sparse matrices.
+    """
+    if not HAS_ROBUST_LAPLACIAN:  # pragma: no cover
+        raise ImportError(
+            "robust_laplacian is not available. "
+            f"Import error: {ROBUST_IMPORT_ERROR or 'unknown'}"
+        )
+
+    verts = np.asarray(verts, dtype=np.float64)
+    faces = np.asarray(faces, dtype=np.int32)
+    L, M = robust_laplacian.mesh_laplacian(verts, faces, mollify_factor=mollify_factor)
+    return L, M
+
+
+def point_cloud_laplacian_and_mass(
+    points: np.ndarray,
+    mollify_factor: float = 1e-5,
+    n_neighbors: int = 30,
+):
+    """
+    Build robust point-cloud Laplacian + diagonal lumped mass matrix.
+
+    Returns:
+        (L, M) as SciPy sparse matrices.
+    """
+    if not HAS_ROBUST_LAPLACIAN:  # pragma: no cover
+        raise ImportError(
+            "robust_laplacian is not available. "
+            f"Import error: {ROBUST_IMPORT_ERROR or 'unknown'}"
+        )
+
+    points = np.asarray(points, dtype=np.float64)
+    # Clamp n_neighbors to len(points)-1 (defensive, matches the scipy fallback
+    # in solver.py: prevents robust_laplacian "k+1 is greater than number of
+    # points" crash on small point clouds; no-op on real dense meshes).
+    n_neighbors = max(1, min(int(n_neighbors), len(points) - 1))
+    L, M = robust_laplacian.point_cloud_laplacian(
+        points, mollify_factor=mollify_factor, n_neighbors=int(n_neighbors)
+    )
+
+    # Sanitize: robust_laplacian can emit non-finite entries for degenerate local
+    # neighbourhoods (coincident or near-coincident points, where the local tangent
+    # plane is undefined). They are rare and they are fatal, because the failure is
+    # global rather than local: an inf on L's diagonal makes diagA inf, so the Jacobi
+    # preconditioner entry becomes 0, A @ p goes non-finite, and PCG's
+    # ``alpha = rz_old / (p . Ap)`` -- a SCALAR -- becomes NaN. One bad node therefore
+    # poisons the entire field on the first timestep.
+    #
+    # Observed on visionsim50/bathroom1: exactly 2 of 120,183 nodes carried -inf on
+    # diag(L) while rho, c, eps, alpha, diag(M) and the RHS were all finite. The solve
+    # returned 99.80% NaN -- every object, every timestep past the initial condition --
+    # and the pipeline still exited 0 and rendered 600 frames from it.
+    #
+    # Zeroing a bad row isolates that node from conduction; it still exchanges with
+    # ambient through the boundary terms and still receives its absorbed flux, so it
+    # behaves like a thermally disconnected speck rather than destroying the solve.
+    # This is strictly better than the alternative of propagating NaN, and it is a
+    # no-op on well-conditioned clouds.
+    L = L.tocsr()
+    bad_data = ~np.isfinite(L.data)
+    if bad_data.any():
+        rows = np.repeat(np.arange(L.shape[0]), np.diff(L.indptr))[bad_data]
+        bad_rows = np.unique(np.concatenate([rows, L.indices[bad_data]]))
+        warnings.warn(
+            f"point_cloud_laplacian: {int(bad_data.sum())} non-finite Laplacian entries "
+            f"across {bad_rows.size} node(s); isolating them. Node indices: "
+            f"{bad_rows[:8].tolist()}{'...' if bad_rows.size > 8 else ''}",
+            RuntimeWarning,
+        )
+        L = L.tolil()
+        for r in bad_rows:
+            L[r, :] = 0.0
+            L[:, r] = 0.0
+        L = L.tocsr()
+        L.eliminate_zeros()
+
+    M = M.tocsr()
+    m_diag = M.diagonal()
+    bad_mass = ~np.isfinite(m_diag) | (m_diag <= 0.0)
+    if bad_mass.any():
+        good = m_diag[~bad_mass]
+        repl = float(np.median(good)) if good.size else 1.0
+        warnings.warn(
+            f"point_cloud_laplacian: {int(bad_mass.sum())} non-finite/non-positive mass "
+            f"entries; replacing with the median ({repl:.3e}).",
+            RuntimeWarning,
+        )
+        m_diag = np.where(bad_mass, repl, m_diag)
+        M = sp.diags(m_diag, format="csr")
+
+    return L, M

--- a/visionsim/simulate/heatsim/light_models.py
+++ b/visionsim/simulate/heatsim/light_models.py
@@ -1,0 +1,358 @@
+# Vendored from heat-sim-blender:addon/lib/light_models.py @ e5b4afe
+"""Per-light analytic diffuse-irradiance forms for the Direct Kernel.
+
+Each light type contributes one of:
+
+  - **Sun (directional)**: 1 shadow ray per vertex.
+    E = light.energy · max(0, n · L_to_sun)
+    where ``light.energy`` is W/m² (Blender's sun is a per-area unit
+    directly).
+
+  - **Point**: 1 shadow ray per vertex.
+    E = light.energy / (4π·d²) · max(0, n · L_to_light)
+    where ``light.energy`` is W (radiated power isotropically).
+
+  - **Spot**: same as point × spot attenuation (smoothstep between
+    ``cos(spot_size·(1−spot_blend)/2)`` and ``cos(spot_size/2)``).
+
+  - **Area**: K stratified shadow samples across the area surface.
+    Per-sample contribution is the form-factor + Lambert emission:
+    dE = L_e · cos_emit · cos_recv / d² · dA
+    Summed over K, with K rays per vertex queried against the BVH.
+
+The orchestrator (`irradiance_kernel.compute_per_vertex_irradiance`)
+calls ``evaluate_light(...)`` per light, which returns the per-sample
+unshadowed irradiance and the per-sample shadow-ray geometry. The
+orchestrator then batch-queries the BVH and masks contributions by
+visibility.
+
+Returns:
+    `(irradiance_per_sample, ray_origins, ray_dirs, ray_max_dists)`
+        - irradiance_per_sample: (S, N) float64 W/m² unshadowed
+        - ray_origins:           (S, N, 3) float32 world coordinates
+        - ray_dirs:              (S, N, 3) float32 unit vectors
+        - ray_max_dists:         (S, N) float32 (∞ for sun, distance for others)
+
+S = 1 for sun/point/spot; S = soft_shadow_rays for area.
+N = number of vertices in the receiver mesh.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+_RAY_EPS = 1e-4  # mm-ish; pushes the ray origin off the surface so we don't self-hit.
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _world_axis_z_neg(matrix_world) -> np.ndarray:
+    """Blender's lights point along their local -Z axis (Cycles convention).
+    Returns the world-space direction of the light's emission axis as a
+    unit vector."""
+    m = np.asarray(matrix_world, dtype=np.float64)
+    # Take the world rotation of the local (0, 0, -1) axis.
+    local_axis = np.array([0.0, 0.0, -1.0])
+    world = (m[:3, :3] @ local_axis)
+    n = float(np.linalg.norm(world))
+    return (world / n) if n > 1e-12 else local_axis
+
+
+def _light_world_pos(matrix_world) -> np.ndarray:
+    """World-space position of the light."""
+    m = np.asarray(matrix_world, dtype=np.float64)
+    return m[:3, 3].astype(np.float32)
+
+
+# ---------------------------------------------------------------------------
+# Sun
+# ---------------------------------------------------------------------------
+
+
+def evaluate_sun(
+    light_obj,
+    vert_positions: np.ndarray,  # (N, 3) world meters
+    vert_normals: np.ndarray,    # (N, 3) world unit
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    energy = float(getattr(light_obj.data, "energy", 0.0) or 0.0)
+    sun_emit_dir = _world_axis_z_neg(light_obj.matrix_world)  # direction sun emits toward
+    # Direction from a vertex TO the sun (opposite of emission direction).
+    L = (-sun_emit_dir).astype(np.float32)
+
+    n = vert_normals.astype(np.float64)
+    cos_theta = np.maximum(0.0, n @ L.astype(np.float64))  # (N,)
+    irr = (energy * cos_theta).astype(np.float64)  # (N,) W/m²
+
+    # Shadow rays: from vertex pushed off surface, toward the sun, very far.
+    Nv = int(vert_positions.shape[0])
+    origins = (vert_positions.astype(np.float32)
+               + (_RAY_EPS * vert_normals.astype(np.float32)))
+    origins = origins.reshape(1, Nv, 3)
+    dirs = np.broadcast_to(L.reshape(1, 1, 3), (1, Nv, 3)).astype(np.float32)
+    max_dists = np.full((1, Nv), 1e9, dtype=np.float32)
+
+    return irr.reshape(1, Nv), origins.copy(), dirs.copy(), max_dists
+
+
+# ---------------------------------------------------------------------------
+# Point
+# ---------------------------------------------------------------------------
+
+
+def evaluate_point(
+    light_obj,
+    vert_positions: np.ndarray,
+    vert_normals: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    energy = float(getattr(light_obj.data, "energy", 0.0) or 0.0)
+    light_pos = _light_world_pos(light_obj.matrix_world).astype(np.float64)
+
+    delta = light_pos.reshape(1, 3) - vert_positions.astype(np.float64)  # (N, 3)
+    d2 = np.einsum("ij,ij->i", delta, delta)  # (N,)
+    # Near-field floor: Blender models a POINT light as a sphere of radius
+    # `shadow_soft_size` (0 by default), not a literal zero-size point. Inside
+    # that radius the 1/(4*pi*d^2) point-source falloff has no physical meaning
+    # and diverges without bound as a receiver approaches the light's origin --
+    # a `max(d2, 1e-20)` numerical floor is nowhere near tight enough to catch
+    # this (see the identical, *reached* bug in evaluate_area below). Clamp d^2
+    # to at least the light's own radius (and a small absolute floor for a
+    # literal radius=0 light) so a close receiver saturates instead of exploding.
+    _radius = float(getattr(light_obj.data, "shadow_soft_size", 0.0) or 0.0)
+    d2 = np.maximum(d2, max(_radius * _radius, 1e-6))
+    d = np.sqrt(d2)  # (N,)
+    L = delta / d[:, None]  # (N, 3) unit vec from vertex to light
+
+    n = vert_normals.astype(np.float64)
+    cos_theta = np.maximum(0.0, np.einsum("ij,ij->i", n, L))
+    # Isotropic point: energy distributed over 4π steradians.
+    irr = (energy / (4.0 * math.pi * d2)) * cos_theta  # (N,) W/m²
+
+    Nv = int(vert_positions.shape[0])
+    origins = (vert_positions.astype(np.float32)
+               + (_RAY_EPS * vert_normals.astype(np.float32)))
+    return (
+        irr.reshape(1, Nv),
+        origins.reshape(1, Nv, 3).astype(np.float32),
+        L.astype(np.float32).reshape(1, Nv, 3),
+        d.astype(np.float32).reshape(1, Nv) - _RAY_EPS,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Spot
+# ---------------------------------------------------------------------------
+
+
+def evaluate_spot(
+    light_obj,
+    vert_positions: np.ndarray,
+    vert_normals: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    energy = float(getattr(light_obj.data, "energy", 0.0) or 0.0)
+    light_pos = _light_world_pos(light_obj.matrix_world).astype(np.float64)
+    spot_axis = _world_axis_z_neg(light_obj.matrix_world).astype(np.float64)
+    spot_size = float(getattr(light_obj.data, "spot_size", math.pi / 4.0) or 0.0)
+    spot_blend = float(np.clip(getattr(light_obj.data, "spot_blend", 0.15) or 0.0, 0.0, 1.0))
+
+    half_outer = spot_size * 0.5
+    half_inner = half_outer * (1.0 - spot_blend)
+    cos_outer = math.cos(half_outer)
+    cos_inner = math.cos(half_inner)
+
+    delta = light_pos.reshape(1, 3) - vert_positions.astype(np.float64)  # (N, 3)
+    d2 = np.einsum("ij,ij->i", delta, delta)
+    # Near-field floor: same reasoning as evaluate_point -- a SPOT light is
+    # modelled as a sphere of radius `shadow_soft_size` (0 by default), so the
+    # point-source falloff is only meaningful outside that radius.
+    _radius = float(getattr(light_obj.data, "shadow_soft_size", 0.0) or 0.0)
+    d2 = np.maximum(d2, max(_radius * _radius, 1e-6))
+    d = np.sqrt(d2)
+    L = delta / d[:, None]  # vertex → light
+
+    n = vert_normals.astype(np.float64)
+    cos_theta_recv = np.maximum(0.0, np.einsum("ij,ij->i", n, L))
+    base = energy / (4.0 * math.pi * d2) * cos_theta_recv
+
+    # Spot attenuation: cosine of angle between spot axis (light → scene)
+    # and the direction from light to the vertex.
+    light_to_vert = -L  # (N, 3) (light → vertex)
+    cos_axis = np.einsum("j,ij->i", spot_axis, light_to_vert)
+    if cos_inner > cos_outer:
+        atten = np.clip((cos_axis - cos_outer) / (cos_inner - cos_outer), 0.0, 1.0)
+    else:
+        atten = (cos_axis >= cos_outer).astype(np.float64)
+    irr = base * atten
+
+    Nv = int(vert_positions.shape[0])
+    origins = (vert_positions.astype(np.float32)
+               + (_RAY_EPS * vert_normals.astype(np.float32)))
+    return (
+        irr.reshape(1, Nv),
+        origins.reshape(1, Nv, 3).astype(np.float32),
+        L.astype(np.float32).reshape(1, Nv, 3),
+        d.astype(np.float32).reshape(1, Nv) - _RAY_EPS,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Area
+# ---------------------------------------------------------------------------
+
+
+def _area_surface_samples(light_obj, n_samples: int, rng: np.random.Generator) -> tuple[np.ndarray, np.ndarray, float]:
+    """Generate n_samples positions on the area light's surface (world
+    coordinates) plus the world-space surface normal (one normal — area
+    lights are flat). Returns (positions (S, 3), normal (3,), area_m²).
+
+    Stratified inside the bounding rectangle. For DISK / ELLIPSE we
+    reject samples outside the disk and resample (acceptable for small
+    rejection ratio ≤ 21 %)."""
+    data = light_obj.data
+    shape = str(getattr(data, "shape", "SQUARE")).upper()
+    sx = float(getattr(data, "size", 1.0) or 0.0)
+    sy = float(getattr(data, "size_y", sx) or sx) if shape in ("RECTANGLE", "ELLIPSE") else sx
+
+    if sx <= 1e-9 or sy <= 1e-9:
+        return np.zeros((1, 3), dtype=np.float64), np.zeros((3,), dtype=np.float64), 0.0
+
+    # Stratified sample in [-0.5, 0.5]² (local) then transform to world.
+    K = max(1, int(n_samples))
+    side = math.ceil(math.sqrt(K))
+    K_actual = side * side
+    grid_u, grid_v = np.meshgrid(np.arange(side), np.arange(side), indexing="ij")
+    jitter_u = rng.random((side, side))
+    jitter_v = rng.random((side, side))
+    u = (grid_u + jitter_u) / float(side) - 0.5  # in [-0.5, 0.5)
+    v = (grid_v + jitter_v) / float(side) - 0.5
+    u = u.reshape(-1)
+    v = v.reshape(-1)
+
+    if shape in ("DISK", "ELLIPSE"):
+        # Reject samples outside the unit ellipse. Up to 21% loss for disk.
+        # We're sampling [-0.5, 0.5]² → unit ellipse condition: (2u)² + (2v)² ≤ 1.
+        ok = ((2 * u) ** 2 + (2 * v) ** 2) <= 1.0
+        u = u[ok]
+        v = v[ok]
+        if u.size == 0:
+            u = np.zeros((1,))
+            v = np.zeros((1,))
+        K_actual = int(u.size)
+
+    local = np.column_stack([u * sx, v * sy, np.zeros(K_actual)])  # (K, 3)
+    m = np.asarray(light_obj.matrix_world, dtype=np.float64)
+    local_h = np.column_stack([local, np.ones((K_actual, 1))])
+    world = (m @ local_h.T).T[:, :3]
+
+    normal = _world_axis_z_neg(light_obj.matrix_world).astype(np.float64)
+    if shape in ("DISK", "ELLIPSE"):
+        area = math.pi * (sx * 0.5) * (sy * 0.5)
+    else:
+        area = sx * sy
+    return world.astype(np.float64), normal, float(area)
+
+
+def evaluate_area(
+    light_obj,
+    vert_positions: np.ndarray,
+    vert_normals: np.ndarray,
+    *,
+    n_samples: int = 8,
+    rng: np.random.Generator | None = None,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    energy = float(getattr(light_obj.data, "energy", 0.0) or 0.0)
+    if rng is None:
+        rng = np.random.default_rng(0)
+    samples, light_normal, area = _area_surface_samples(light_obj, n_samples, rng)
+    if area <= 1e-12 or samples.shape[0] == 0:
+        Nv = int(vert_positions.shape[0])
+        return (
+            np.zeros((1, Nv), dtype=np.float64),
+            np.zeros((1, Nv, 3), dtype=np.float32),
+            np.zeros((1, Nv, 3), dtype=np.float32),
+            np.full((1, Nv), 1e9, dtype=np.float32),
+        )
+
+    K = int(samples.shape[0])
+    Nv = int(vert_positions.shape[0])
+    n = vert_normals.astype(np.float64)
+    p = vert_positions.astype(np.float64)
+
+    # Per (sample, vertex): delta = sample - vertex
+    s = samples.reshape(K, 1, 3)
+    delta = s - p.reshape(1, Nv, 3)  # (K, Nv, 3)
+    d2 = np.einsum("kij,kij->ki", delta, delta)
+    # Near-field floor: THE root cause of a measured >6000 K localized FEM
+    # blow-up (visionsim50/kitchen1: a floor slab's texels sitting a few cm from
+    # the base of a large, floor-adjacent area light -- e.g. a floor-to-ceiling
+    # window/panel light -- picked up a stratified sample landing within
+    # millimetres of the receiver). Each of the K stratified samples stands in
+    # for a finite sub-patch of the light's own surface (area/K, not a literal
+    # point), so the point-sampled 1/d^2 estimator is only valid at ranges large
+    # compared to that sub-patch's own size; a `max(d2, 1e-20)` numerical floor
+    # is many orders of magnitude too small to catch a genuinely close receiver.
+    # Clamp d^2 to at least the sub-patch's half-linear-size squared so a close
+    # receiver saturates at a bounded near-field value instead of diverging.
+    _patch_radius = 0.5 * math.sqrt(area / float(K))
+    d2 = np.maximum(d2, max(_patch_radius * _patch_radius, 1e-6))
+    d = np.sqrt(d2)
+    L = delta / d[..., None]  # (K, Nv, 3) unit vector from vertex to sample
+
+    cos_recv = np.maximum(0.0, np.einsum("ij,kij->ki", n, L))
+    cos_emit = np.maximum(0.0, np.einsum("j,kij->ki", -light_normal, L))
+
+    # Per-sample contribution: energy * cos_emit * cos_recv / (π * K * d²)
+    irr = (energy * cos_emit * cos_recv) / (math.pi * float(K) * d2)
+
+    origins = np.broadcast_to(
+        (vert_positions.astype(np.float32) + _RAY_EPS * vert_normals.astype(np.float32)).reshape(1, Nv, 3),
+        (K, Nv, 3),
+    ).copy()
+    return (
+        irr.astype(np.float64),
+        origins,
+        L.astype(np.float32),
+        (d - _RAY_EPS).astype(np.float32),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+
+def evaluate_light(
+    light_obj,
+    vert_positions: np.ndarray,
+    vert_normals: np.ndarray,
+    *,
+    n_samples_for_area: int = 8,
+    rng: np.random.Generator | None = None,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Returns ``(irradiance (S, N), origins (S, N, 3), dirs (S, N, 3),
+    max_dists (S, N))`` for any light type. S = 1 for sun/point/spot,
+    K for area."""
+    light_type = str(getattr(light_obj.data, "type", "POINT")).upper()
+    if light_type == "SUN":
+        return evaluate_sun(light_obj, vert_positions, vert_normals)
+    if light_type == "POINT":
+        return evaluate_point(light_obj, vert_positions, vert_normals)
+    if light_type == "SPOT":
+        return evaluate_spot(light_obj, vert_positions, vert_normals)
+    if light_type == "AREA":
+        return evaluate_area(
+            light_obj, vert_positions, vert_normals,
+            n_samples=n_samples_for_area, rng=rng,
+        )
+    # Unknown / unsupported type: contribute zero.
+    Nv = int(vert_positions.shape[0])
+    return (
+        np.zeros((1, Nv), dtype=np.float64),
+        np.zeros((1, Nv, 3), dtype=np.float32),
+        np.zeros((1, Nv, 3), dtype=np.float32),
+        np.full((1, Nv), 1e9, dtype=np.float32),
+    )

--- a/visionsim/simulate/heatsim/materials.py
+++ b/visionsim/simulate/heatsim/materials.py
@@ -1,0 +1,439 @@
+"""Thermal material properties: preset library, per-scene assignment, per-vertex resolution.
+
+Three layers, one job: turn a Blender object's **material slots** into the
+per-vertex ``(N,)`` arrays the FEM solver already accepts.
+
+1. :data:`PRESETS` - a fixed library of named thermal materials.
+2. :func:`load_assignments` - parse a scene's committed sidecar, which maps
+   Blender material names onto those presets.
+3. :func:`resolve_vertex_materials` - walk ``mesh.polygons[].material_index``
+   and produce the per-vertex arrays.
+
+Units are SI-with-mm-diffusivity, matching :mod:`visionsim.simulate.heatsim.adapter`:
+``alpha_mm2_s`` mm^2/s, ``density_kg_m3`` kg/m^3, ``specific_heat_J_kgK`` J/(kg.K),
+``emissivity_ir`` dimensionless in [0, 1], temperatures in K.
+
+There is deliberately **no** solar-absorptivity column: absorbed flux is already
+computed post-``(1 - albedo)`` from a Cycles bake of the scene's real textures
+(``irradiance_kernel``), so a per-preset absorptivity would double-count.
+
+Nothing here calls out to a network or an LLM. Sidecars are authored offline by
+``scripts/thermal_assign.py`` and committed; this module only reads them.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import warnings
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+MIN_DIRICHLET_K = 280.0
+"""Below this a 'heat source' is really a cold sink; almost always an authoring slip."""
+
+MAX_DIRICHLET_K = 500.0
+"""Above this we are out of interior-scene territory (an oven element, not a room)."""
+
+_SCHEMA_VERSION = 1
+_ROLES = ("FEM_PARTICIPANT", "DIRICHLET_SOURCE")
+
+# Degenerate (zero-area) faces still have to vote, otherwise their vertices end up
+# with no incident area and fall back to the object defaults - which reads as
+# "unassigned" when the material is in fact known.
+_MIN_FACE_AREA = 1.0e-12
+
+
+# ---------------------------------------------------------------------------
+# 1. Preset library
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ThermalPreset:
+    """One named thermal material. Frozen so the shared library cannot be mutated."""
+
+    key: str
+    alpha_mm2_s: float
+    density_kg_m3: float
+    specific_heat_J_kgK: float
+    emissivity_ir: float
+    notes: str
+
+
+# key, alpha (mm^2/s), density (kg/m^3), specific heat (J/kg.K), IR emissivity, notes.
+#
+# The first 13 are seeded from the vendored ``constants.py`` dicts; their
+# alpha/rho/c must stay in lockstep with them (guarded by a test) so the two
+# cannot silently drift. Emissivities are literature LWIR values - constants.py
+# has no emissivity column (its ``Absorptivity`` dict is solar, and dead code).
+_PRESET_TABLE = (
+    ("aluminium", 97.0, 2700.0, 978.0, 0.20, "Mill-finish / lightly oxidised aluminium."),
+    ("pvc", 0.17, 1330.0, 880.0, 0.93, "Generic rigid plastic; also the global default."),
+    ("glass", 0.34, 2500.0, 840.0, 0.92, "Soda-lime glass. Opaque in LWIR despite visible transparency."),
+    ("copper", 111.0, 8960.0, 385.0, 0.15, "Oxidised copper."),
+    ("polystyrene", 0.5, 1050.0, 1300.0, 0.90, "Expanded / rigid polystyrene."),
+    ("wood", 0.082, 897.0, 2380.0, 0.90, "Generic hardwood."),
+    ("steel", 4.2, 7930.0, 280.0, 0.28, "Bare rolled steel."),
+    ("brick", 0.52, 2200.0, 800.0, 0.93, "Common fired brick."),
+    ("concrete", 0.5, 2300.0, 880.0, 0.92, "Structural concrete."),
+    ("plaster", 0.4, 1200.0, 1090.0, 0.91, "Plastered / rendered wall."),
+    ("asphalt", 0.3, 2100.0, 920.0, 0.95, "Asphalt / bitumen."),
+    ("iron", 18.0, 7200.0, 450.0, 0.31, "Cast iron."),
+    ("li_ion", 0.2, 2500.0, 1100.0, 0.88, "Li-ion cell pack; rare in interior scenes."),
+    ("aluminium_polished", 97.0, 2700.0, 978.0, 0.05, "Mirror-polished aluminium; the low emissivity is the point."),
+    ("stainless_steel", 4.0, 7900.0, 500.0, 0.16, "Brushed stainless: appliance bodies, sinks, cookware."),
+    ("metal_painted", 4.2, 7930.0, 280.0, 0.92, "Steel bulk, painted/powder-coated surface. Use for any coated metal."),
+    ("ceramic", 0.6, 2300.0, 850.0, 0.93, "Glazed ceramic tile, sanitaryware, pottery."),
+    ("porcelain", 0.7, 2400.0, 840.0, 0.92, "Vitrified porcelain: tableware, basins."),
+    ("marble", 1.2, 2700.0, 880.0, 0.94, "Marble / granite / engineered stone worktops."),
+    ("drywall", 0.31, 800.0, 1090.0, 0.90, "Gypsum plasterboard; the commonest interior wall/ceiling."),
+    ("fabric", 0.09, 300.0, 1300.0, 0.95, "Upholstery, curtains, bedding, clothing."),
+    ("carpet", 0.06, 200.0, 1300.0, 0.90, "Carpet and rugs. Lowest diffusivity in the library."),
+    ("leather", 0.11, 900.0, 1500.0, 0.95, "Leather and leatherette upholstery."),
+    ("rubber", 0.10, 1200.0, 1400.0, 0.94, "Rubber, silicone, gaskets, cable sheathing."),
+    ("paper", 0.13, 700.0, 1340.0, 0.93, "Paper, card, books, posters, lampshade paper."),
+    ("water", 0.143, 997.0, 4182.0, 0.96, "Liquid water. Surface FEM ignores convection, so approximate."),
+    ("foliage", 0.15, 700.0, 3000.0, 0.96, "Live and artificial plants, leaves, grass."),
+    ("food", 0.14, 1000.0, 3200.0, 0.95, "Food items; high water content dominates the bulk properties."),
+    ("skin", 0.11, 1050.0, 3470.0, 0.98, "Human skin. Pair with role=DIRICHLET_SOURCE at ~307 K."),
+)
+
+
+def _build_library() -> dict[str, ThermalPreset]:
+    library: dict[str, ThermalPreset] = {}
+    for key, alpha, rho, c, eps, notes in _PRESET_TABLE:
+        if alpha <= 0.0 or rho <= 0.0 or c <= 0.0:
+            raise ValueError(f"preset {key!r}: alpha, density and specific heat must all be > 0")
+        if not 0.0 <= eps <= 1.0:
+            raise ValueError(f"preset {key!r}: emissivity_ir must lie in [0, 1]")
+        if key in library:
+            raise ValueError(f"duplicate preset key {key!r}")
+        library[key] = ThermalPreset(key, alpha, rho, c, eps, notes)
+    return library
+
+
+PRESETS: dict[str, ThermalPreset] = _build_library()
+"""The thermal preset library, keyed by preset name."""
+
+
+def preset_keys() -> list[str]:
+    """Sorted preset keys. This is the closed enum the offline assignment tool chooses from."""
+    return sorted(PRESETS)
+
+
+# ---------------------------------------------------------------------------
+# 2. Per-scene assignment sidecar
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MaterialEntry:
+    """One material's assignment. ``preset is None`` means 'fall back to the globals'."""
+
+    preset: ThermalPreset | None
+    role: str
+    dirichlet_K: float | None
+    confidence: float
+    reason: str
+
+
+@dataclass(frozen=True)
+class SceneAssignment:
+    """A scene's sidecar, keyed by Blender material name."""
+
+    scene: str
+    digest: str
+    default_preset: ThermalPreset | None
+    materials: dict[str, MaterialEntry]
+
+    def entry_for(self, material_name: str) -> MaterialEntry | None:
+        """Return the entry for *material_name*, or ``None`` if the sidecar omits it."""
+        return self.materials.get(material_name)
+
+
+def _lookup_preset(key: Any, where: str) -> ThermalPreset | None:
+    if key is None:
+        return None
+    preset = PRESETS.get(str(key))
+    if preset is None:
+        warnings.warn(
+            f"thermal assignment {where}: unknown preset {str(key)!r}; falling back to the global defaults",
+            UserWarning,
+            stacklevel=3,
+        )
+    return preset
+
+
+def load_assignments(path: Path) -> SceneAssignment:
+    """Parse and validate the sidecar at *path*.
+
+    Every recoverable inconsistency degrades to the global defaults **with a
+    warning** rather than a silent guess: an unknown preset key, an unknown role,
+    or an out-of-band Dirichlet temperature. Structural problems raise.
+    """
+    path = Path(path)
+    raw_bytes = path.read_bytes()
+    digest = hashlib.sha256(raw_bytes).hexdigest()
+    raw = json.loads(raw_bytes.decode("utf-8"))
+
+    version = int(raw.get("schema_version", 0))
+    if version != _SCHEMA_VERSION:
+        raise ValueError(f"{path}: schema_version {version} != expected {_SCHEMA_VERSION}")
+
+    defaults_block = raw.get("defaults", {})
+    if not isinstance(defaults_block, dict):
+        raise ValueError(f"{path}: 'defaults' must be an object, got {type(defaults_block).__name__}")
+    default_preset = _lookup_preset(defaults_block.get("preset"), f"{path.name}:defaults")
+
+    materials_block = raw.get("materials", {})
+    if not isinstance(materials_block, dict):
+        raise ValueError(f"{path}: 'materials' must be an object, got {type(materials_block).__name__}")
+
+    entries: dict[str, MaterialEntry] = {}
+    for name, spec in materials_block.items():
+        where = f"{path.name}:{name}"
+        if not isinstance(spec, dict):
+            raise ValueError(f"{path}: material {name!r} spec must be an object, got {type(spec).__name__}")
+        preset = _lookup_preset(spec.get("preset"), where)
+
+        role = str(spec.get("role") or "FEM_PARTICIPANT").upper()
+        if role not in _ROLES:
+            warnings.warn(f"thermal assignment {where}: unknown role {spec.get('role')!r}; "
+                          "treating as FEM_PARTICIPANT", UserWarning, stacklevel=2)
+            role = "FEM_PARTICIPANT"
+
+        dirichlet_K: float | None = None
+        if spec.get("dirichlet_K") is not None:
+            try:
+                value = float(spec["dirichlet_K"])
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"{path}: material {name!r} has non-numeric dirichlet_K {spec['dirichlet_K']!r}"
+                ) from exc
+            if MIN_DIRICHLET_K <= value <= MAX_DIRICHLET_K:
+                dirichlet_K = value
+            elif role == "DIRICHLET_SOURCE":
+                # An out-of-band K on a DIRICHLET_SOURCE must not silently keep the role: with
+                # dirichlet_K dropped but role left as DIRICHLET_SOURCE, _slot_tables would still
+                # mark the slot dirichlet and pin it at the *ambient* fallback temperature (alpha=0,
+                # no incident flux, excluded from the radiation/convection boundary) -- an intended
+                # 5000 K source silently becomes an ambient-temperature heat SINK. Degrading the role
+                # to FEM_PARTICIPANT instead lets the slot behave as an ordinary participant, which is
+                # the closer-to-harmless failure mode for "the authored temperature was nonsense".
+                warnings.warn(
+                    f"thermal assignment {where}: dirichlet_K={value} outside "
+                    f"[{MIN_DIRICHLET_K}, {MAX_DIRICHLET_K}] K; dropping it and degrading role "
+                    "DIRICHLET_SOURCE -> FEM_PARTICIPANT (an out-of-band source pinned at ambient "
+                    "would otherwise silently act as a heat sink)", UserWarning, stacklevel=2,
+                )
+                role = "FEM_PARTICIPANT"
+            else:
+                warnings.warn(f"thermal assignment {where}: dirichlet_K={value} outside "
+                              f"[{MIN_DIRICHLET_K}, {MAX_DIRICHLET_K}] K; ignoring it", UserWarning, stacklevel=2)
+
+        entries[str(name)] = MaterialEntry(
+            preset=preset,
+            role=role,
+            dirichlet_K=dirichlet_K,
+            confidence=float(spec.get("confidence", 0.0)),
+            reason=str(spec.get("reason") or ""),
+        )
+
+    return SceneAssignment(
+        scene=str(raw.get("scene") or path.name),
+        digest=digest,
+        default_preset=default_preset,
+        materials=entries,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. Slot -> per-vertex resolution
+# ---------------------------------------------------------------------------
+
+
+def _slot_tables(obj: Any, assignment: SceneAssignment, fallback: dict[str, Any]) -> dict[str, np.ndarray]:
+    """Per-slot scalar tables. Unassigned slots inherit the object-level *fallback*."""
+    names = []
+    for slot in obj.material_slots:
+        material = getattr(slot, "material", None)
+        names.append(None if material is None else str(getattr(material, "name", "")))
+
+    n = len(names)
+    table: dict[str, np.ndarray] = {key: np.empty(n, dtype=np.float64) for key in ("t0", "alpha", "rho", "c", "eps")}
+    table["is_dirichlet"] = np.zeros(n, dtype=bool)
+    fallback_T = float(fallback["initial_temperature_K"])
+
+    for i, name in enumerate(names):
+        entry = assignment.entry_for(name) if name is not None else None
+        preset = entry.preset if entry is not None else None
+        if preset is None:
+            preset = assignment.default_preset  # sidecar-wide fallback, then the object-level one
+
+        if preset is None:
+            table["alpha"][i] = float(fallback["thermal_diffusivity_mm2_s"])
+            table["rho"][i] = float(fallback["density_kg_m3"])
+            table["c"][i] = float(fallback["specific_heat_J_kgK"])
+            table["eps"][i] = float(fallback["emissivity"])
+        else:
+            table["alpha"][i] = preset.alpha_mm2_s
+            table["rho"][i] = preset.density_kg_m3
+            table["c"][i] = preset.specific_heat_J_kgK
+            table["eps"][i] = preset.emissivity_ir
+
+        if entry is not None and entry.role == "DIRICHLET_SOURCE":
+            table["is_dirichlet"][i] = True
+            table["t0"][i] = float(entry.dirichlet_K) if entry.dirichlet_K is not None else fallback_T
+        else:
+            table["t0"][i] = fallback_T
+
+    return table
+
+
+def resolve_vertex_materials(
+    obj: Any,
+    assignment: SceneAssignment,
+    fallback: dict[str, Any],
+) -> dict[str, np.ndarray] | None:
+    """Return per-vertex thermal arrays for *obj*, or ``None`` if slots cannot drive it.
+
+    Blender stores materials on **faces**; the solver wants one value per
+    **vertex**. Almost every vertex is interior to a single material region, so
+    the conversion is a lookup. At a **seam** - a vertex touching faces of two
+    different materials - the rule differs by the kind of quantity:
+
+    * **Continuous** (alpha, rho, c, eps, T0) -> **area-weighted mean**. A
+      wood-to-metal joint really is a material gradient, so a blend is closer to
+      reality than an arbitrary hard jump.
+    * **Categorical** (pinned or not, and at what temperature) -> **dominant**
+      incident material by area. A vertex cannot be "60% pinned".
+
+    Both rules share one accumulation pass building face area per
+    ``(vertex, slot)``; only the final reduction differs (weighted mean vs
+    ``argmax``). The cheaper alternative - "pinned if *any* touching face is a
+    source" - is rejected because it leaks a lamp filament's temperature outward
+    into the surrounding glass shade.
+
+    Args:
+        obj: A Blender ``MESH`` object (or duck-typed stand-in) exposing
+            ``data.vertices``, ``data.polygons`` and ``material_slots``.
+        assignment: The scene's parsed sidecar.
+        fallback: The object-level resolution from ``adapter.resolve_material``,
+            used for unassigned slots and untouched vertices - so an explicitly
+            authored ``heat_sim_material`` still wins where the sidecar is silent.
+
+    Returns:
+        ``{"t0", "alpha", "rho", "c", "eps", "dirichlet_mask"}``, each ``(N,)``,
+        or ``None`` when the object has no slots or no vertices (the caller then
+        keeps its existing object-level path).
+
+        ``t0`` is only meaningful where ``dirichlet_mask`` is ``True`` -- there it
+        holds the vertex's exact reservoir temperature. Where ``dirichlet_mask`` is
+        ``False`` it instead holds the same area-weighted mean as every other
+        continuous field, which at a seam onto a Dirichlet slot blends in a slice of
+        that reservoir's temperature even though the vertex itself is not pinned.
+        Callers must supply the ambient initial temperature themselves for unpinned
+        vertices rather than using this array's value wholesale (see
+        ``adapter._combine``, which does exactly that).
+    """
+    mesh = getattr(obj, "data", None)
+    if mesh is None:
+        return None
+    n_verts = len(getattr(mesh, "vertices", []))
+    n_slots = len(getattr(obj, "material_slots", []))
+    if n_verts == 0 or n_slots == 0:
+        return None
+
+    area: np.ndarray = np.zeros((n_verts, n_slots), dtype=np.float64)
+    for poly in getattr(mesh, "polygons", []):
+        slot = min(max(int(getattr(poly, "material_index", 0)), 0), n_slots - 1)
+        face_area = max(float(getattr(poly, "area", 0.0)), _MIN_FACE_AREA)
+        for vert in poly.vertices:
+            index = int(vert)
+            if 0 <= index < n_verts:
+                area[index, slot] += face_area
+
+    table = _slot_tables(obj, assignment, fallback)
+    total = area.sum(axis=1)
+    touched = total > 0.0
+
+    fallback_scalar = {
+        "t0": float(fallback["initial_temperature_K"]),
+        "alpha": float(fallback["thermal_diffusivity_mm2_s"]),
+        "rho": float(fallback["density_kg_m3"]),
+        "c": float(fallback["specific_heat_J_kgK"]),
+        "eps": float(fallback["emissivity"]),
+    }
+    out: dict[str, np.ndarray] = {}
+    for key, default in fallback_scalar.items():
+        values: np.ndarray = np.full(n_verts, default, dtype=np.float64)
+        if np.any(touched):
+            values[touched] = (area[touched] @ table[key]) / total[touched]
+        out[key] = values
+
+    dominant = area.argmax(axis=1)
+    out["dirichlet_mask"] = table["is_dirichlet"][dominant] & touched
+
+    # A pinned vertex holds its reservoir temperature exactly - an area-weighted
+    # blend with a neighbouring participant would quietly cool the source.
+    if np.any(out["dirichlet_mask"]):
+        out["t0"][out["dirichlet_mask"]] = table["t0"][dominant][out["dirichlet_mask"]]
+
+    out["eps"] = np.clip(out["eps"], 0.0, 1.0)
+    return out
+
+
+def resolve_face_materials(
+    obj: Any,
+    assignment: SceneAssignment,
+    fallback: dict[str, Any],
+    face_slots: np.ndarray,
+) -> dict[str, np.ndarray] | None:
+    """Return per-FACE thermal arrays for *obj*, or ``None`` if slots cannot drive it.
+
+    The texel-sim analogue of :func:`resolve_vertex_materials`: a texel belongs to exactly
+    one face, and a face belongs to exactly one material slot, so there is no seam to blend
+    across - unlike the per-vertex path this is an exact lookup, never an area-weighted mean.
+
+    Args:
+        obj: A Blender ``MESH`` object (or duck-typed stand-in) exposing ``material_slots``.
+        assignment: The scene's parsed sidecar.
+        fallback: The object-level resolution from ``adapter.resolve_material``, used for
+            unassigned slots - so an explicitly authored ``heat_sim_material`` still wins
+            where the sidecar is silent.
+        face_slots: ``(M,)`` int array of ``material_index`` per face. The caller is
+            responsible for keeping face order consistent with whatever ``face`` indices it
+            later uses to index into the result (e.g. ``atlas.rasterize_tile``'s ``face``
+            output, which indexes into the same triangulated face array this was built
+            from). An out-of-range index is clamped to the last slot, mirroring
+            :func:`resolve_vertex_materials`'s ``material_index`` handling.
+
+    Returns:
+        ``{"t0", "alpha", "rho", "c", "eps", "dirichlet_mask"}``, each ``(M,)`` where
+        ``M = len(face_slots)``, or ``None`` when the object has no material slots.
+
+        ``t0`` here is always the face's exact assigned value (the reservoir temperature
+        where ``dirichlet_mask`` is True, else the slot/object ambient) since there is no
+        seam to blend across a whole face. A caller that wants the vertex path's "an
+        unpinned face starts at ambient regardless of a neighboring Dirichlet slot"
+        convention gets that for free here already - there is no neighbor contribution to
+        exclude. Callers combining this with an object-level Dirichlet override should
+        still apply that themselves (see ``adapter._combine``).
+    """
+    n_slots = len(getattr(obj, "material_slots", []))
+    if n_slots == 0:
+        return None
+
+    table = _slot_tables(obj, assignment, fallback)
+    slots = np.clip(np.asarray(face_slots, dtype=np.int64), 0, n_slots - 1)
+
+    out: dict[str, np.ndarray] = {}
+    for key in ("t0", "alpha", "rho", "c", "eps"):
+        out[key] = table[key][slots]
+    out["dirichlet_mask"] = table["is_dirichlet"][slots]
+    out["eps"] = np.clip(out["eps"], 0.0, 1.0)
+    return out

--- a/visionsim/simulate/heatsim/occluders.py
+++ b/visionsim/simulate/heatsim/occluders.py
@@ -1,0 +1,183 @@
+"""Which meshes block a shortwave (solar / lamp) shadow ray.
+
+The thermal irradiance kernel integrates the shortwave band, and it builds a BVH
+of occluders to decide what light reaches each surface. Deciding membership of
+that set is a Blender-material question rather than a physics one, so it lives
+here instead of in the vendored kernel:
+
+* Geometry the artist marked as non-shadow-casting in Cycles is honoured.
+* Clear geometry — glass panes, and the render-only "light portal" planes that
+  let an exterior lamp into an interior — passes the beam. Real glass is opaque
+  in the LWIR band but transmits most incident solar shortwave, which is the
+  band being integrated.
+
+Getting this wrong is asymmetric: wrongly skipping a mesh deletes a real shadow,
+while wrongly keeping one starves every surface behind it. Anything that cannot
+be resolved statically therefore reads as opaque.
+
+Known limitation: a node group's *external* inputs are followed regardless of
+whether the group routes them to its output internally, so an unused Shader-type
+group input wired to an opaque shader reads as opaque. Resolving that properly
+means mapping internal Group Input nodes back to external sockets; the failure
+direction is a spurious shadow rather than a deleted one, so it is left alone.
+"""
+
+from __future__ import annotations
+
+try:
+    import bpy  # type: ignore
+except ImportError:  # pragma: no cover - host interpreter without Blender
+    bpy = None  # type: ignore
+
+
+__all__ = ["casts_shadow", "material_is_clear", "principled_is_clear", "surface_shader_nodes"]
+
+
+# A mesh only stops casting shadows once it is essentially clear glass; a
+# partly-transmissive surface still blocks most of the beam.
+_TRANSMISSION_OCCLUDER_CUTOFF = 0.95
+
+_CLEAR_BSDF_NODES = frozenset({"BSDF_GLASS", "BSDF_TRANSPARENT", "BSDF_REFRACTION"})
+
+# Shaders that put opaque energy on the surface. Their presence anywhere in the
+# tree means the material is not clear glass, however it is mixed — this is what
+# keeps alpha-cutout foliage (an opaque leaf mixed with a Transparent BSDF)
+# casting shadows.
+_OPAQUE_BSDF_NODES = frozenset({
+    "BSDF_DIFFUSE", "BSDF_GLOSSY", "BSDF_ANISOTROPIC", "BSDF_VELVET", "BSDF_SHEEN",
+    "BSDF_TOON", "BSDF_TRANSLUCENT", "BSDF_HAIR", "BSDF_HAIR_PRINCIPLED",
+    "SUBSURFACE_SCATTERING", "EMISSION", "PRINCIPLED_VOLUME", "VOLUME_ABSORPTION",
+    "VOLUME_SCATTER", "BACKGROUND",
+})
+
+
+def principled_is_clear(node: bpy.types.Node) -> bool:
+    """Whether a Principled BSDF is driven fully transmissive by a constant.
+
+    A linked transmission input cannot be evaluated statically, so it reads as
+    opaque — the safe assumption, since guessing clear would delete a real
+    shadow.
+    """
+    for key in ("Transmission Weight", "Transmission"):
+        socket = node.inputs.get(key)
+        if socket is None or socket.is_linked:
+            continue
+        try:
+            if float(socket.default_value) >= _TRANSMISSION_OCCLUDER_CUTOFF:
+                return True
+        except (TypeError, ValueError):
+            continue
+    return False
+
+
+def _active_output(tree: bpy.types.NodeTree, node_type: str) -> bpy.types.Node | None:
+    """The output node Blender actually renders from, or None if there is none.
+
+    A tree may hold several output nodes; only the active one contributes. When
+    none is flagged active (Blender allows that) the first is the best guess.
+    """
+    outputs = [n for n in tree.nodes if n.type == node_type]
+    if not outputs:
+        return None
+    return next((n for n in outputs if getattr(n, "is_active_output", False)), outputs[0])
+
+
+def surface_shader_nodes(tree: bpy.types.NodeTree) -> list[bpy.types.Node] | None:
+    """Shader nodes actually reachable from the active Material Output's Surface.
+
+    Walking the graph rather than scanning ``tree.nodes`` matters in both
+    directions: Blender leaves an unconnected Principled node in every new
+    material (which would otherwise read as opaque), and an alpha-cutout leaf
+    genuinely routes an opaque shader into the output through a Mix Shader
+    (which must read as opaque). The walk descends into node groups, since
+    reusable glass/window shaders are commonly wrapped in one.
+
+    Returns ``None`` when the material has no surface at all — no Material
+    Output, or its Surface input left unlinked (a volume-only fog box, say).
+    Cycles draws no surface there, so nothing can block a ray. That is distinct
+    from an empty list, which means a surface exists but reached no shader.
+    """
+    active = _active_output(tree, "OUTPUT_MATERIAL")
+    if active is None:
+        return None
+    surface = active.inputs.get("Surface")
+    if surface is None or not surface.is_linked:
+        return None
+
+    seen: set = set()
+    stack = [link.from_node for link in surface.links]
+    reachable: list[bpy.types.Node] = []
+    while stack:
+        node = stack.pop()
+        # Node names are only unique within a tree, so key on the tree too.
+        key = (id(node.id_data), node.name)
+        if key in seen:
+            continue
+        seen.add(key)
+        reachable.append(node)
+
+        group_tree = getattr(node, "node_tree", None)
+        if node.type == "GROUP" and group_tree is not None:
+            # Only the active Group Output feeds the instance, exactly as with the
+            # Material Output above. Following an inactive leftover as well would let
+            # a stale opaque branch mark a clear pane as a shadow caster.
+            group_output = _active_output(group_tree, "GROUP_OUTPUT")
+            if group_output is not None:
+                for socket in group_output.inputs:
+                    for link in socket.links:
+                        stack.append(link.from_node)
+
+        for socket in node.inputs:
+            for link in socket.links:
+                stack.append(link.from_node)
+    return reachable
+
+
+def material_is_clear(mat: bpy.types.Material | None) -> bool:
+    """Whether ``mat`` passes essentially all shortwave light through.
+
+    True only when the shaders feeding the surface output include a transmissive
+    one and no opaque one.
+    """
+    if mat is None or not mat.use_nodes or mat.node_tree is None:
+        return False
+    nodes = surface_shader_nodes(mat.node_tree)
+    if nodes is None:
+        # No surface shader at all — Cycles renders nothing to block a ray.
+        return True
+    saw_clear = False
+    for node in nodes:
+        if node.type in _OPAQUE_BSDF_NODES:
+            return False
+        if node.type in _CLEAR_BSDF_NODES:
+            saw_clear = True
+        elif node.type == "BSDF_PRINCIPLED":
+            if not principled_is_clear(node):
+                return False
+            saw_clear = True
+    return saw_clear
+
+
+def casts_shadow(obj: bpy.types.Object) -> bool:
+    """Whether ``obj`` should block a shortwave (solar/lamp) shadow ray.
+
+    Two classes of geometry are transparent to the beam even though they are
+    renderable meshes, and treating them as solid starves every surface behind
+    them:
+
+    * Cycles ray-visibility has shadow casting switched off.
+    * Every material slot is clear (glass panes, and the render-only "light
+      portal" planes that let exterior lamps into an interior). Real glass is
+      opaque in the LWIR band but transmits ~85% of incident solar shortwave,
+      which is the band this kernel integrates.
+
+    An object with no material slots is opaque by default.
+    """
+    if not getattr(obj, "visible_shadow", True):
+        return False
+    slots = [slot.material for slot in obj.material_slots]
+    if not slots:
+        return True
+    # An empty slot renders with Blender's default opaque material, so faces
+    # assigned to it cast a real shadow; material_is_clear(None) is False.
+    return not all(material_is_clear(mat) for mat in slots)

--- a/visionsim/simulate/heatsim/properties.py
+++ b/visionsim/simulate/heatsim/properties.py
@@ -1,0 +1,130 @@
+"""Per-object thermal material PropertyGroup for visionsim heat simulation.
+
+Schema-compatible with heat-sim-blender so addon-authored blends load their
+values directly. Only the core per-object fields are included here; the full
+scene-level HeatSimSettings lives only in the Blender addon.
+"""
+
+from __future__ import annotations
+
+try:
+    import bpy  # type: ignore
+    from bpy.props import BoolProperty, EnumProperty, FloatProperty, PointerProperty  # type: ignore
+
+    _BPY_AVAILABLE = True
+except ImportError:
+    bpy = None  # type: ignore
+    _BPY_AVAILABLE = False
+
+# Only define the PropertyGroup when bpy is available (i.e. inside Blender).
+if _BPY_AVAILABLE:
+
+    class HeatSimObjectMaterialProperties(bpy.types.PropertyGroup):  # type: ignore[name-defined]
+        """Per-object material + initial condition configuration for heat simulation.
+
+        Values are stored in SI units:
+            thermal_diffusivity_mm2_s: mm²/s
+            density_kg_m3:             kg/m³
+            specific_heat_J_kgK:       J/(kg·K)
+            initial_temperature_K:     K
+        """
+
+        initial_temperature_K: FloatProperty(  # type: ignore[assignment]
+            name="Initial Temp (K)",
+            description="Initial temperature for this object (used if no per-vertex attribute override is provided)",
+            default=295.0,  # match ThermalConfig.initial_temperature_K (config.py)
+            min=0.0,
+        )
+
+        thermal_diffusivity_mm2_s: FloatProperty(  # type: ignore[assignment]
+            name="Thermal Diffusivity α (mm²/s)",
+            description=(
+                "Thermal diffusivity for this object in mm²/s (used if no per-vertex attribute override is provided). "
+                "Note: your solver uses mm-units internally, so mm²/s is the natural unit here."
+            ),
+            default=0.17,  # PVC-ish (matches constants.TDiff['pvc'])
+            min=0.0,
+        )
+
+        density_kg_m3: FloatProperty(  # type: ignore[assignment]
+            name="Density ρ (kg/m³)",
+            description="Material density in kg/m^3 (used if no per-vertex attribute override is provided)",
+            default=1330.0,  # PVC
+            min=0.0,
+        )
+
+        specific_heat_J_kgK: FloatProperty(  # type: ignore[assignment]
+            name="Specific Heat c (J/kgK)",
+            description="Specific heat capacity in J/(kg*K) (used if no per-vertex attribute override is provided)",
+            default=880.0,  # PVC
+            min=0.0,
+        )
+
+        emissivity: FloatProperty(  # type: ignore[assignment]
+            name="Emissivity ε",
+            description="Surface emissivity for thermal rendering and radiation calculations (0-1)",
+            default=0.9,
+            min=0.0,
+            max=1.0,
+        )
+
+        thermal_role: EnumProperty(  # type: ignore[assignment]
+            name="Thermal Role",
+            description=(
+                "How this object participates in the FEM heat sim. "
+                "FEM Participant (default): full transient FEM; topology must be stable. "
+                "Dirichlet Source: vertex temperatures are pinned to a constant value every step."
+            ),
+            items=[
+                ("FEM_PARTICIPANT", "FEM Participant", "Full transient simulation; stable topology required"),
+                ("DIRICHLET_SOURCE", "Dirichlet Source (constant T)", "Vertex temperatures pinned; topology may change per frame"),
+            ],
+            default="FEM_PARTICIPANT",
+        )
+
+        dirichlet_temperature_K: FloatProperty(  # type: ignore[assignment]
+            name="Dirichlet Temperature (K)",
+            description=(
+                "Constant temperature for this object's vertices when Thermal Role = "
+                "Dirichlet Source. When set to 0 (or below), falls back to this "
+                "object's Initial Temp."
+            ),
+            default=0.0,
+            min=0.0,
+            soft_min=0.0,
+            soft_max=2000.0,
+        )
+
+
+def register() -> None:
+    """Register the per-object thermal material PropertyGroup on ``bpy.types.Object``."""
+    if not _BPY_AVAILABLE or bpy is None:
+        return
+    bpy.utils.register_class(HeatSimObjectMaterialProperties)  # type: ignore[name-defined]
+    bpy.types.Object.heat_sim_material = PointerProperty(type=HeatSimObjectMaterialProperties)  # type: ignore[name-defined,assignment]
+    bpy.types.Object.heat_simulation_enabled = BoolProperty(  # type: ignore[name-defined,assignment]
+        name="Heat Simulation Enabled",
+        description=(
+            "If disabled, this object is excluded from FEM/Zombie solving, but it will still render using "
+            "its initial/default temperature."
+        ),
+        default=True,
+    )
+
+
+def unregister() -> None:
+    """Unregister the thermal material PropertyGroup."""
+    if not _BPY_AVAILABLE or bpy is None:
+        return
+    try:
+        del bpy.types.Object.heat_simulation_enabled  # type: ignore[name-defined]
+    except Exception:
+        pass
+    try:
+        del bpy.types.Object.heat_sim_material  # type: ignore[name-defined]
+    except Exception:
+        pass
+    try:
+        bpy.utils.unregister_class(HeatSimObjectMaterialProperties)  # type: ignore[name-defined]
+    except Exception:
+        pass

--- a/visionsim/simulate/heatsim/sh9_sky.py
+++ b/visionsim/simulate/heatsim/sh9_sky.py
@@ -1,0 +1,386 @@
+# Vendored from heat-sim-blender:addon/lib/sh9_sky.py @ e5b4afe
+"""SH9 sky-dome prefilter for the Direct Kernel irradiance source.
+
+Implements the Ramamoorthi & Hanrahan 2001 "An Efficient Representation
+for Irradiance Environment Maps" technique:
+
+  1. Prefilter the world's background environment into 9 spherical
+     harmonic (SH) coefficients per RGB channel — done once per world
+     (cached, invalidated on world hash change).
+  2. Evaluate per-vertex irradiance E(n) from the SH coefficients with
+     a closed-form quadratic in the vertex normal — no rays required.
+
+Two world-shader cases are supported:
+
+  - **Solid background color** (a `Background` node feeding the world
+    output, with an RGBA color and a strength multiplier). The whole
+    sphere is treated as constant radiance — only the SH00 band is
+    nonzero.
+  - **Environment texture** (an `Image Texture` or `Environment
+    Texture` feeding `Background`, equirectangular layout). We sum
+    over pixels weighted by sin(θ) and the SH basis.
+
+Anything more exotic (Sky shaders, mix nodes, color-ramps) falls back
+to using the `world.color` as a solid color.
+
+For thermal use, RGB irradiance is collapsed to a scalar via the mean
+of the channels — the FEM solver doesn't do spectral transport.
+
+Public API:
+
+    coeffs_rgb = prefilter_world(world)            # (9, 3) float64
+    irr = eval_per_vertex(normals, coeffs_rgb)     # (N,) W/m²
+
+The orchestrator (``irradiance_kernel``) caches the (9, 3) coefficients
+keyed by ``world_hash(world)`` so re-baking is free for an unchanged
+world.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import math
+from typing import Optional, Tuple
+
+import numpy as np
+
+_log = logging.getLogger("rich")
+
+# Ramamoorthi-Hanrahan diffuse reconstruction constants
+# (table 1 of "An Efficient Representation for Irradiance Environment Maps").
+_C1 = 0.429043
+_C2 = 0.511664
+_C3 = 0.743125
+_C4 = 0.886227
+_C5 = 0.247708
+
+# Real SH basis function coefficients for l ∈ {0, 1, 2}.
+# Order: [Y00, Y1-1, Y10, Y11, Y2-2, Y2-1, Y20, Y21, Y22]
+_Y_NORM = np.array([
+    0.282094791773878,   # Y00 = 1/(2√π)
+    0.488602511902920,   # Y1-1 = √(3/(4π)) y
+    0.488602511902920,   # Y10  = √(3/(4π)) z
+    0.488602511902920,   # Y11  = √(3/(4π)) x
+    1.092548430592079,   # Y2-2 = √(15/(4π)) xy
+    1.092548430592079,   # Y2-1 = √(15/(4π)) yz
+    0.315391565252520,   # Y20  = √(5/(16π))(3z²−1)
+    1.092548430592079,   # Y21  = √(15/(4π)) xz
+    0.546274215296039,   # Y22  = √(15/(16π))(x²−y²)
+], dtype=np.float64)
+
+
+# ---------------------------------------------------------------------------
+# World introspection / hashing
+# ---------------------------------------------------------------------------
+
+
+def world_hash(world) -> str:
+    """A short stable hash for the world. Used as cache key. Changes
+    when shader nodes, image filepath, or strength change. We hash
+    enough state to detect the common edits — a subtle node-graph
+    mutation that doesn't touch any of the inspected fields will not
+    invalidate the cache (acceptable: the user can press Reset)."""
+    if world is None:
+        return "no_world"
+    h = hashlib.md5()
+    h.update((world.name or "").encode("utf-8"))
+    color = tuple(float(c) for c in (getattr(world, "color", None) or (0.0, 0.0, 0.0)))
+    h.update(repr(color).encode("utf-8"))
+    if getattr(world, "use_nodes", False) and world.node_tree is not None:
+        for node in world.node_tree.nodes:
+            h.update(node.bl_idname.encode("utf-8"))
+            h.update((node.name or "").encode("utf-8"))
+            for inp in node.inputs:
+                if hasattr(inp, "default_value"):
+                    try:
+                        h.update(repr(tuple(inp.default_value)).encode("utf-8"))
+                    except TypeError:
+                        h.update(repr(float(inp.default_value)).encode("utf-8"))
+            img = getattr(node, "image", None)
+            if img is not None:
+                h.update((img.filepath or img.name or "").encode("utf-8"))
+                h.update(repr((int(img.size[0]), int(img.size[1]))).encode("utf-8"))
+    return h.hexdigest()[:16]
+
+
+def _find_background_node(world):
+    """Walk the world node tree for the Background node feeding the
+    World Output. Returns the Background node or None."""
+    if not getattr(world, "use_nodes", False) or world.node_tree is None:
+        return None
+    nt = world.node_tree
+    out = next((n for n in nt.nodes if n.bl_idname == "ShaderNodeOutputWorld" and n.is_active_output), None)
+    if out is None:
+        out = next((n for n in nt.nodes if n.bl_idname == "ShaderNodeOutputWorld"), None)
+    if out is None:
+        return None
+    surface_input = out.inputs.get("Surface")
+    if surface_input is None or not surface_input.is_linked:
+        return None
+    src = surface_input.links[0].from_node
+    if src.bl_idname == "ShaderNodeBackground":
+        return src
+    return None
+
+
+def _find_env_image_node(background_node):
+    """If the Background's Color input is fed by an Image/Environment
+    Texture, return that node; else None."""
+    if background_node is None:
+        return None
+    color_input = background_node.inputs.get("Color")
+    if color_input is None or not color_input.is_linked:
+        return None
+    src = color_input.links[0].from_node
+    if src.bl_idname in ("ShaderNodeTexEnvironment", "ShaderNodeTexImage"):
+        return src
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Solid color path (no env map)
+# ---------------------------------------------------------------------------
+
+
+def _solid_color_sh(color_rgb: np.ndarray, strength: float) -> np.ndarray:
+    """A constant-radiance sky has nonzero only in the SH00 band:
+    L00 = (color · strength) · ∫ Y00 dΩ = (color · strength) · √(4π) · Y00 = color · strength · 2√π · 1/(2√π) · 4π / (2√π · 4π)
+
+    Simpler: ∫ L Y00 dΩ over the sphere with constant L = c·s gives
+    L00 = c·s · √(4π) (since Y00 = 1/(2√π) and area = 4π)."""
+    c = np.asarray(color_rgb, dtype=np.float64).reshape(3) * float(strength)
+    coeffs = np.zeros((9, 3), dtype=np.float64)
+    coeffs[0] = c * math.sqrt(4.0 * math.pi)
+    return coeffs
+
+
+# ---------------------------------------------------------------------------
+# HDRI prefilter (equirectangular)
+# ---------------------------------------------------------------------------
+
+
+def _read_image_pixels(image) -> Optional[np.ndarray]:
+    """Return image pixels as (H, W, 4) float32 in linear space, or
+    None if the image has no pixel data loaded."""
+    if image is None:
+        return None
+    try:
+        w, h = int(image.size[0]), int(image.size[1])
+        if w <= 0 or h <= 0:
+            return None
+        n_channels = int(image.channels) if image.channels else 4
+        flat = np.asarray(image.pixels[:], dtype=np.float32)
+        if flat.size != w * h * n_channels:
+            return None
+        arr = flat.reshape(h, w, n_channels)
+        # Blender's pixel buffer is bottom-up; flip so row 0 = top.
+        return np.flipud(arr)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _prefilter_equirectangular(pixels_rgba: np.ndarray, strength: float) -> np.ndarray:
+    """Sum-quadrature SH9 prefilter for an equirectangular image.
+
+    pixels_rgba: (H, W, ≥3) float linear radiance (W/m²/sr scale unknown,
+    inherits image authoring convention). We treat values as relative
+    radiance and let ``strength`` apply.
+
+    Sampling matches Blender / Cycles' equirectangular env-texture mapping
+    (Z-up world space) verbatim. From Cycles source
+    (``direction_to_equirectangular``):
+
+        u = -atan2(d.y, d.x) / (2π) + 0.5    # note the NEGATIVE atan2
+        v =  1 - acos(d.z) / π
+
+    Inverting (texel center (j, i) on a top-down image after flipud):
+
+        theta = (j + 0.5) · π / H            → row 0 (top) = world +Z
+        phi   = π - (i + 0.5) · 2π / W       → col W/2     = world +X
+
+    Direction:    d = (sin θ cos φ, sin θ sin φ, cos θ)
+
+    The SH basis below uses standard math convention (Y_10 ∝ z), so the
+    coefficients can be evaluated against world-space normals directly
+    without any axis swap.
+
+    Earlier versions of this prefilter used ``phi = (i+0.5)·2π/W - π``
+    (Cycles' phi negated), which silently mirrored the y-component of
+    every coefficient. White-sky tests still passed (L00 has no
+    direction), but Cycles vs kernel disagreed by exactly the y-flip
+    on every HDRI scene. See ``proposals/phase-3-sky-env-texture-debug.md``.
+    """
+    H, W = pixels_rgba.shape[:2]
+    rgb = pixels_rgba[..., :3].astype(np.float64) * float(strength)
+
+    j = np.arange(H, dtype=np.float64)
+    i = np.arange(W, dtype=np.float64)
+    theta = (j + 0.5) * math.pi / float(H)
+    phi = math.pi - (i + 0.5) * 2.0 * math.pi / float(W)
+
+    sin_th = np.sin(theta)            # (H,)
+    cos_th = np.cos(theta)            # (H,)
+    cos_ph = np.cos(phi)              # (W,)
+    sin_ph = np.sin(phi)              # (W,)
+
+    # Z-up direction vector per pixel.
+    x = (sin_th[:, None] * cos_ph[None, :])  # (H, W)
+    y = (sin_th[:, None] * sin_ph[None, :])  # (H, W)
+    z = np.broadcast_to(cos_th[:, None], (H, W))
+
+    Y = np.empty((9, H, W), dtype=np.float64)
+    Y[0] = _Y_NORM[0]
+    Y[1] = _Y_NORM[1] * y
+    Y[2] = _Y_NORM[2] * z
+    Y[3] = _Y_NORM[3] * x
+    Y[4] = _Y_NORM[4] * x * y
+    Y[5] = _Y_NORM[5] * y * z
+    Y[6] = _Y_NORM[6] * (3.0 * z * z - 1.0)
+    Y[7] = _Y_NORM[7] * x * z
+    Y[8] = _Y_NORM[8] * (x * x - y * y)
+
+    # Solid angle per pixel: dΩ = sin θ · dθ · dφ
+    dtheta = math.pi / float(H)
+    dphi = 2.0 * math.pi / float(W)
+    dOmega = (sin_th[:, None] * (dtheta * dphi)).astype(np.float64)  # (H, 1)
+    dOmega = np.broadcast_to(dOmega, (H, W))
+
+    coeffs = np.zeros((9, 3), dtype=np.float64)
+    weight = (Y * dOmega[None, :, :])  # (9, H, W)
+    for c in range(3):
+        # einsum gives (9,) per channel
+        coeffs[:, c] = np.einsum("ihw,hw->i", weight, rgb[..., c])
+    return coeffs
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def prefilter_world(world) -> np.ndarray:
+    """Returns (9, 3) RGB SH coefficients describing the world's
+    diffuse irradiance environment. Falls back to ``world.color``
+    when the node graph isn't a recognized pattern."""
+    if world is None:
+        return np.zeros((9, 3), dtype=np.float64)
+
+    bg = _find_background_node(world)
+    if bg is not None:
+        try:
+            strength_input = bg.inputs.get("Strength")
+            strength = float(strength_input.default_value) if strength_input is not None else 1.0
+        except Exception:  # noqa: BLE001
+            strength = 1.0
+
+        env = _find_env_image_node(bg)
+        if env is not None and getattr(env, "image", None) is not None:
+            # Warn (not fail) if the Strength socket is driven by a node —
+            # we read default_value, which is stale in that case.
+            try:
+                strength_input = bg.inputs.get("Strength")
+                if strength_input is not None and strength_input.is_linked:
+                    _log.debug(
+                        "[HeatSim:Kernel] WARNING: world '%s' has "
+                        "a linked Background Strength input; SH9 prefilter "
+                        "uses default_value=%s, which may be stale.",
+                        world.name, strength,
+                    )
+            except Exception:
+                pass
+            pixels = _read_image_pixels(env.image)
+            if pixels is not None:
+                return _prefilter_equirectangular(pixels, strength)
+            # Fall through to color fallback if the image has no data.
+            _log.debug(
+                "[HeatSim:Kernel] WARNING: world '%s' env texture '%s' has no loaded pixel data; "
+                "falling back to solid-color sky. Try image.reload().",
+                world.name, getattr(env.image, "name", "?"),
+            )
+
+        try:
+            color_input = bg.inputs.get("Color")
+            color = (
+                tuple(float(c) for c in color_input.default_value[:3])
+                if color_input is not None and not color_input.is_linked
+                else (0.0, 0.0, 0.0)
+            )
+        except Exception:  # noqa: BLE001
+            color = (0.0, 0.0, 0.0)
+        return _solid_color_sh(np.array(color), strength)
+
+    # No usable node graph: use the legacy world.color (Blender 5.x still
+    # exposes this, defaults to (0.05, 0.05, 0.05)).
+    color = tuple(float(c) for c in (getattr(world, "color", None) or (0.0, 0.0, 0.0)))
+    return _solid_color_sh(np.array(color), 1.0)
+
+
+def eval_per_vertex(
+    normals: np.ndarray,
+    coeffs_rgb: np.ndarray,
+    *,
+    rgb_to_scalar: str = "mean",
+) -> np.ndarray:
+    """Evaluate per-vertex irradiance E(n) from SH9 coefficients.
+
+    Uses the Ramamoorthi-Hanrahan closed-form quadratic. The input
+    ``coeffs_rgb`` is (9, 3) and the output is (N,) scalar W/m² (the
+    thermal solver is monochromatic).
+
+    rgb_to_scalar:
+        "mean"      → average of R/G/B (good neutral default).
+        "luminance" → 0.2126·R + 0.7152·G + 0.0722·B (Rec. 709).
+    """
+    n = np.asarray(normals, dtype=np.float64).reshape(-1, 3)
+    # Normalize defensively — vertex normals from Blender can be slightly
+    # off unit length on degenerate meshes.
+    norms = np.linalg.norm(n, axis=1, keepdims=True)
+    norms = np.where(norms > 1e-12, norms, 1.0)
+    n = n / norms
+
+    # Both the prefilter and this eval use the standard math SH basis
+    # (Y_10 ∝ z), so the world-space (Z-up) normal components feed in
+    # directly: no axis swap required.
+    x = n[:, 0]
+    y = n[:, 1]
+    z = n[:, 2]
+
+    c = np.asarray(coeffs_rgb, dtype=np.float64).reshape(9, 3)
+    L00 = c[0]
+    L1m1 = c[1]; L10 = c[2]; L11 = c[3]
+    L2m2 = c[4]; L2m1 = c[5]; L20 = c[6]; L21 = c[7]; L22 = c[8]
+
+    # E(n) per channel.
+    # E = c1·L22·(x²−y²) + c3·L20·z² + c4·L00 − c5·L20
+    #     + 2·c1·(L2−2·xy + L21·xz + L2−1·yz)
+    #     + 2·c2·(L11·x + L1−1·y + L10·z)
+    irr = (
+        _C1 * L22[None, :] * (x * x - y * y)[:, None]
+        + _C3 * L20[None, :] * (z * z)[:, None]
+        + _C4 * L00[None, :]
+        - _C5 * L20[None, :]
+        + 2.0 * _C1 * (
+            L2m2[None, :] * (x * y)[:, None]
+            + L21[None, :] * (x * z)[:, None]
+            + L2m1[None, :] * (y * z)[:, None]
+        )
+        + 2.0 * _C2 * (
+            L11[None, :] * x[:, None]
+            + L1m1[None, :] * y[:, None]
+            + L10[None, :] * z[:, None]
+        )
+    )
+    irr = np.maximum(irr, 0.0)  # negative reconstruction lobes get clamped.
+
+    if rgb_to_scalar == "luminance":
+        weights = np.array([0.2126, 0.7152, 0.0722], dtype=np.float64)
+        return (irr @ weights).astype(np.float64)
+    # default mean
+    return irr.mean(axis=1).astype(np.float64)
+
+
+def coeffs_have_energy(coeffs_rgb: np.ndarray) -> bool:
+    """Cheap test for whether the prefilter produced a usable sky.
+    Skips per-vertex SH eval when the world contributes nothing."""
+    return bool(np.any(np.abs(coeffs_rgb) > 1e-9))

--- a/visionsim/simulate/heatsim/sky_visibility.py
+++ b/visionsim/simulate/heatsim/sky_visibility.py
@@ -1,0 +1,354 @@
+# Vendored from heat-sim-blender:addon/lib/sky_visibility.py @ e5b4afe
+"""Per-vertex Bent Normal + Sky AO bake for the Direct Kernel sky term.
+
+The SH9 sky prefilter implicitly assumes every vertex sees the full
+upper hemisphere. For receivers tucked under overhangs (indoor scenes,
+the underside of objects, contact regions) this over-feeds flux. This
+module bakes two scalars per vertex that let us approximate the
+visibility cone cheaply:
+
+  - **AO** (scalar in [0, 1]): fraction of hemisphere shadow rays that
+    were unoccluded.
+  - **bent normal** (unit vector): the average direction of the
+    unoccluded rays.
+
+At runtime the kernel evaluates the existing Ramamoorthi-Hanrahan
+quadratic at the *bent normal* (instead of the surface normal) and
+attenuates by AO. This is the Jimenez et al. 2016 / "directional GTAO"
+approximation, the production-game standard for cheap diffuse-IBL
+occlusion. ~3-5× cheaper to bake than full SH9 PRT, ~1 extra scalar
+multiply per evaluation, fixes the indoor over-receiving problem.
+
+Bake cost on a 14k-vertex scene: ~0.1-0.5 s with K=64 rays/vertex via
+Embree. Storage: 4 floats per vertex (3 + 1), persisted as mesh
+attributes ``bent_normal`` (FLOAT_VECTOR, POINT) and ``sky_ao``
+(FLOAT, POINT) and as a disk sidecar mirroring the existing
+albedo-cache layout.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import time
+from typing import Dict, List, Optional, Tuple
+
+import bpy
+import numpy as np
+
+_log = logging.getLogger("rich")
+
+_RAY_EPS_M = 1e-4   # push origin off the surface to avoid self-hits, meters
+
+
+# ---------------------------------------------------------------------------
+# Sampling helpers
+# ---------------------------------------------------------------------------
+
+
+def _stratified_hemisphere_samples(
+    k_rays: int, rng: np.random.Generator
+) -> np.ndarray:
+    """Return (K, 3) unit vectors in the +Z hemisphere using stratified
+    sampling, uniform on the hemisphere (each ray has equal solid-angle
+    weight). The local frame is +Z = surface normal; we transform per-vertex
+    via the orthonormal basis built in ``_build_world_frames``.
+
+    Sampling: jittered stratified ``side × side`` grid in (cos θ, φ). For
+    uniform-on-hemisphere, cos θ ∈ [0, 1] is uniform and φ ∈ [0, 2π) is
+    uniform. We over-sample to side² ≥ K then trim.
+    """
+    side = int(math.ceil(math.sqrt(max(1, k_rays))))
+    total = side * side
+    iu, jv = np.meshgrid(np.arange(side), np.arange(side), indexing="ij")
+    u = (iu.reshape(-1) + rng.random(total)) / float(side)
+    v = (jv.reshape(-1) + rng.random(total)) / float(side)
+    if total > k_rays:
+        # Trim deterministically (no random subset — we already jittered).
+        u = u[:k_rays]
+        v = v[:k_rays]
+    cos_theta = u                              # uniform on hemisphere → cos θ ∈ [0, 1]
+    sin_theta = np.sqrt(np.clip(1.0 - cos_theta * cos_theta, 0.0, 1.0))
+    phi = 2.0 * math.pi * v
+    local = np.column_stack([
+        sin_theta * np.cos(phi),
+        sin_theta * np.sin(phi),
+        cos_theta,
+    ]).astype(np.float64)
+    return local
+
+
+def _build_world_frames(normals: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    """Vectorized orthonormal basis per normal using the Duff et al. 2017
+    "Building an Orthonormal Basis, Revisited" method (branchless, robust).
+    Returns ``(T, B)`` — both (N, 3) — completing a right-handed frame
+    [T, B, N] with the input ``normals`` as the third column."""
+    n = normals.astype(np.float64)
+    sign = np.where(n[:, 2] >= 0.0, 1.0, -1.0)
+    a = -1.0 / (sign + n[:, 2])
+    b = n[:, 0] * n[:, 1] * a
+    T = np.column_stack([
+        1.0 + sign * n[:, 0] * n[:, 0] * a,
+        sign * b,
+        -sign * n[:, 0],
+    ])
+    B = np.column_stack([
+        b,
+        sign + n[:, 1] * n[:, 1] * a,
+        -n[:, 1],
+    ])
+    return T, B
+
+
+def _hemisphere_world_dirs(
+    normals: np.ndarray,
+    local_samples: np.ndarray,
+) -> np.ndarray:
+    """Returns (N, K, 3) world-space directions oriented around per-vertex
+    normals. ``normals`` is (N, 3); ``local_samples`` is (K, 3) in the
+    local +Z-up hemisphere frame."""
+    T, B = _build_world_frames(normals)               # (N, 3), (N, 3)
+    # world_dir[v, k] = T[v]*local[k,0] + B[v]*local[k,1] + N[v]*local[k,2]
+    # Broadcast: (N, 1, 3) * (1, K, 1) → sum
+    nrm = normals.astype(np.float64)
+    out = (
+        T[:, None, :] * local_samples[None, :, 0:1]
+        + B[:, None, :] * local_samples[None, :, 1:2]
+        + nrm[:, None, :] * local_samples[None, :, 2:3]
+    )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Bake core
+# ---------------------------------------------------------------------------
+
+
+def bake_for_object(
+    obj: bpy.types.Object,
+    backend,
+    k_rays: int,
+    rng: np.random.Generator,
+    far_dist_m: float = 1.0e6,
+) -> Optional[Tuple[np.ndarray, np.ndarray]]:
+    """Bake (bent_normal, ao) for one receiver mesh against ``backend``
+    (already built from the scene's occluder set).
+
+    Returns ``(bent_normal (N, 3) float64, ao (N,) float64)`` or None on
+    extraction failure. Bent normals are unit-length; AO is in [0, 1].
+    Fully-occluded vertices (AO ≈ 0) keep the surface normal as fallback.
+    """
+    # Lazy import — irradiance_kernel imports us, avoid circularity.
+    from visionsim.simulate.heatsim import irradiance_kernel
+
+    geom = irradiance_kernel._extract_world_geometry(obj)
+    if geom is None:
+        return None
+    world_verts, world_normals, _faces = geom
+    Nv = int(world_verts.shape[0])
+    if Nv == 0:
+        return None
+
+    local_samples = _stratified_hemisphere_samples(k_rays, rng)  # (K, 3)
+    K = int(local_samples.shape[0])
+
+    world_dirs = _hemisphere_world_dirs(world_normals, local_samples)  # (N, K, 3)
+
+    origins = (
+        world_verts.astype(np.float32)[:, None, :]
+        + _RAY_EPS_M * world_normals.astype(np.float32)[:, None, :]
+    )
+    origins = np.broadcast_to(origins, (Nv, K, 3)).copy()
+    dirs = world_dirs.astype(np.float32)
+    max_dists = np.full((Nv, K), float(far_dist_m), dtype=np.float32)
+
+    flat_o = origins.reshape(Nv * K, 3)
+    flat_d = dirs.reshape(Nv * K, 3)
+    flat_md = max_dists.reshape(Nv * K)
+
+    occluded = backend.shadow_rays(flat_o, flat_d, flat_md)
+    visible = (~occluded).reshape(Nv, K)  # bool (N, K)
+
+    ao = visible.mean(axis=1).astype(np.float64)  # (N,)
+
+    # Bent normal = average of visible directions, then normalize. Fall back
+    # to surface normal where no rays survived.
+    vis_mask = visible[..., None].astype(np.float64)  # (N, K, 1)
+    bent_unnorm = (world_dirs * vis_mask).sum(axis=1)  # (N, 3)
+    norms = np.linalg.norm(bent_unnorm, axis=1, keepdims=True)
+    has_some_visible = (norms > 1e-12).reshape(-1)
+    bent_normal = np.empty_like(world_normals, dtype=np.float64)
+    bent_normal[has_some_visible] = (
+        bent_unnorm[has_some_visible] / norms[has_some_visible]
+    )
+    bent_normal[~has_some_visible] = world_normals[~has_some_visible]
+
+    return bent_normal, ao
+
+
+# ---------------------------------------------------------------------------
+# Mesh-attribute persistence
+# ---------------------------------------------------------------------------
+
+
+_BENT_ATTR = "bent_normal"
+_AO_ATTR = "sky_ao"
+
+
+def _read_bent_ao_attrs(obj: bpy.types.Object) -> Optional[Tuple[np.ndarray, np.ndarray]]:
+    """Read the mesh-attribute cache for one object. Returns
+    ``(bent_normal, ao)`` or None if missing / wrong shape."""
+    mesh = getattr(obj, "data", None)
+    if mesh is None:
+        return None
+    try:
+        bent_attr = mesh.attributes.get(_BENT_ATTR)
+        ao_attr = mesh.attributes.get(_AO_ATTR)
+    except Exception:
+        return None
+    if bent_attr is None or ao_attr is None:
+        return None
+    if (
+        getattr(bent_attr, "domain", None) != "POINT"
+        or getattr(bent_attr, "data_type", None) != "FLOAT_VECTOR"
+    ):
+        return None
+    if (
+        getattr(ao_attr, "domain", None) != "POINT"
+        or getattr(ao_attr, "data_type", None) != "FLOAT"
+    ):
+        return None
+    n = len(mesh.vertices)
+    if n != len(bent_attr.data) or n != len(ao_attr.data):
+        return None
+    bent_flat = np.zeros((n * 3,), dtype=np.float32)
+    ao = np.zeros((n,), dtype=np.float32)
+    try:
+        bent_attr.data.foreach_get("vector", bent_flat)
+        ao_attr.data.foreach_get("value", ao)
+    except Exception:
+        return None
+    return bent_flat.reshape(n, 3).astype(np.float64), ao.astype(np.float64)
+
+
+def _store_bent_ao_attrs(
+    obj: bpy.types.Object,
+    bent_normal: np.ndarray,
+    ao: np.ndarray,
+) -> None:
+    """Persist (bent_normal, ao) as POINT mesh attributes on ``obj``.
+    Skipped silently on vertex-count mismatch (modifier-driven topology)."""
+    mesh = getattr(obj, "data", None)
+    if mesh is None:
+        return
+    n = len(mesh.vertices)
+    if int(bent_normal.shape[0]) != n or int(ao.shape[0]) != n:
+        return
+    for attr_name in (_BENT_ATTR, _AO_ATTR):
+        if attr_name in mesh.attributes:
+            try:
+                mesh.attributes.remove(mesh.attributes[attr_name])
+            except Exception:
+                pass
+    try:
+        bent_attr = mesh.attributes.new(name=_BENT_ATTR, type="FLOAT_VECTOR", domain="POINT")
+        bent_attr.data.foreach_set(
+            "vector", np.asarray(bent_normal, dtype=np.float32).reshape(-1)
+        )
+        ao_attr = mesh.attributes.new(name=_AO_ATTR, type="FLOAT", domain="POINT")
+        ao_attr.data.foreach_set("value", np.asarray(ao, dtype=np.float32))
+        mesh.update()
+    except Exception:
+        pass
+
+
+def remove_bent_ao_attrs(obj: bpy.types.Object) -> None:
+    """Drop the cached mesh attributes. Used by Reset / source switch."""
+    mesh = getattr(obj, "data", None)
+    if mesh is None:
+        return
+    for attr_name in (_BENT_ATTR, _AO_ATTR):
+        if attr_name in mesh.attributes:
+            try:
+                mesh.attributes.remove(mesh.attributes[attr_name])
+            except Exception:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Public entry point — get or bake, with cache resolution
+# ---------------------------------------------------------------------------
+
+
+def get_or_bake_for_objects(
+    scene: bpy.types.Scene,
+    objects: List[bpy.types.Object],
+    backend,
+    settings,
+    *,
+    force_rebake: bool = False,
+) -> Dict[str, Dict[str, np.ndarray]]:
+    """For each object, return ``{"bent_normal", "ao"}``.
+
+    Resolution order per object (skipped when ``force_rebake=True``):
+      1. POINT mesh attributes (``bent_normal``, ``sky_ao``)
+      2. Disk sidecar (``sky_visibility_cache.npz``)
+      3. Bake via Embree, store as attributes + disk cache.
+
+    ``backend`` must be a pre-built BVH for the full scene's occluder set
+    (typically the same backend the kernel built for direct-light visibility).
+    """
+    from visionsim.simulate.heatsim import temperature_io
+
+    k_rays = int(getattr(settings, "sky_ao_rays_per_vertex", 64))
+    k_rays = max(4, min(k_rays, 1024))
+
+    disk_cache = temperature_io.read_sky_visibility_cache(scene) or {}
+    out: Dict[str, Dict[str, np.ndarray]] = {}
+    rng = np.random.default_rng(0)
+    newly_baked: Dict[str, Tuple[np.ndarray, np.ndarray]] = {}
+    t0 = time.perf_counter()
+
+    for obj in objects:
+        if not force_rebake:
+            attr_cached = _read_bent_ao_attrs(obj)
+            if attr_cached is not None:
+                bn, ao = attr_cached
+                out[obj.name] = {"bent_normal": bn, "ao": ao}
+                continue
+            disk_payload = disk_cache.get(obj.name)
+            if disk_payload is not None:
+                bn = np.asarray(disk_payload["bent_normal"], dtype=np.float64)
+                ao = np.asarray(disk_payload["ao"], dtype=np.float64)
+                if int(bn.shape[0]) == len(obj.data.vertices) and int(ao.shape[0]) == bn.shape[0]:
+                    _store_bent_ao_attrs(obj, bn, ao)
+                    out[obj.name] = {"bent_normal": bn, "ao": ao}
+                    continue
+
+        # Bake.
+        _log.debug("[HeatSim:SkyVis] Baking bent normal + AO for '%s' (K=%d rays/vertex).", obj.name, k_rays)
+        result = bake_for_object(obj, backend, k_rays, rng)
+        if result is None:
+            continue
+        bn, ao = result
+        _store_bent_ao_attrs(obj, bn, ao)
+        newly_baked[obj.name] = (bn.astype(np.float32), ao.astype(np.float32))
+        out[obj.name] = {"bent_normal": bn, "ao": ao}
+
+    if newly_baked:
+        merged = dict(disk_cache)
+        for name, (bn, ao) in newly_baked.items():
+            merged[name] = {"bent_normal": bn, "ao": ao}
+        temperature_io.write_sky_visibility_cache(scene, merged)
+        dt = time.perf_counter() - t0
+        try:
+            example = next(iter(newly_baked.values()))
+            n_verts = int(example[0].shape[0])
+        except Exception:
+            n_verts = 0
+        _log.debug(
+            "[HeatSim:SkyVis] Baked sky visibility for %d object(s) (%d+ verts each) in %.2f s.",
+            len(newly_baked), n_verts, dt,
+        )
+
+    return out

--- a/visionsim/simulate/heatsim/solver.py
+++ b/visionsim/simulate/heatsim/solver.py
@@ -1,0 +1,1193 @@
+# Vendored from heat-sim-blender:addon/lib/heatsim_fem.py @ e5b4afe
+import logging
+import numpy as np
+import scipy.sparse as sp
+import warnings
+
+import torch
+
+from visionsim.simulate.heatsim import constants
+from visionsim.simulate.heatsim.laplacian import (
+    HAS_ROBUST_LAPLACIAN,
+    ROBUST_IMPORT_ERROR,
+    mesh_laplacian_and_mass,
+    point_cloud_laplacian_and_mass,
+)
+
+_log = logging.getLogger("rich")
+
+try:
+    import igl  # type: ignore
+
+    HAS_IGL = True
+    IGL_IMPORT_ERROR = None
+except Exception as e:  # pragma: no cover
+    igl = None
+    HAS_IGL = False
+    IGL_IMPORT_ERROR = str(e)
+
+
+# Default per-timestep linear-solver mode. "pcg_jacobi" = Jacobi-preconditioned CG
+# (faster, same result); "cg" = original unpreconditioned CG. Callers may override
+# per-instance via the HeatSimFEM(solver_mode=...) kwarg.
+DEFAULT_SOLVER_MODE = "pcg_jacobi"
+
+
+def scipy_to_torch_sparse(mat, device, dtype=torch.float32):
+    """
+    Convert a SciPy sparse matrix to a torch.sparse_coo_tensor on a given device.
+    """
+    mat = mat.tocoo()
+    indices = np.vstack([mat.row, mat.col]).astype(np.int64)
+    i = torch.from_numpy(indices).to(device)
+    v = torch.from_numpy(mat.data.astype(np.float32)).to(device)
+    return torch.sparse_coo_tensor(i, v, mat.shape, device=device, dtype=dtype).coalesce()
+
+
+@torch.no_grad()
+def cg_solve(mv, b, x0=None, tol=1e-6, max_iter=200):
+    """
+    Simple Conjugate Gradient solver for SPD systems in operator form:
+        A x = b, where mv(x) computes A @ x.
+    """
+    if x0 is None:
+        x = torch.zeros_like(b)
+    else:
+        x = x0.clone()
+
+    r = b - mv(x)
+    p = r.clone()
+    rs_old = torch.dot(r.flatten(), r.flatten())
+
+    if rs_old.sqrt() < tol:
+        return x
+
+    for _ in range(max_iter):
+        Ap = mv(p)
+        denom = torch.dot(p.flatten(), Ap.flatten())
+        # Avoid division by zero
+        if denom.abs() < 1e-20:
+            break
+        alpha = rs_old / denom
+
+        x = x + alpha * p
+        r = r - alpha * Ap
+        rs_new = torch.dot(r.flatten(), r.flatten())
+
+        if rs_new.sqrt() < tol:
+            break
+
+        beta = rs_new / rs_old
+        p = r + beta * p
+        rs_old = rs_new
+
+    return x
+
+
+def sparse_diag(A):
+    """Extract the diagonal of a coalesced torch sparse COO tensor as a dense (N,) vector."""
+    A = A.coalesce()
+    idx = A.indices()
+    val = A.values()
+    n = A.shape[0]
+    d = torch.zeros(n, device=val.device, dtype=val.dtype)
+    mask = idx[0] == idx[1]
+    d[idx[0][mask]] = val[mask]
+    return d
+
+
+@torch.no_grad()
+def pcg_solve(mv, b, Minv, x0=None, tol=1e-6, max_iter=200):
+    """
+    Jacobi (diagonal) preconditioned Conjugate Gradient for SPD systems A x = b,
+    where mv(x) computes A @ x and Minv is the (N,1) inverse-diagonal preconditioner.
+
+    Converges to the SAME solution as cg_solve (identical A, b, stopping tolerance on
+    ||r||_2) but in far fewer iterations, so results match the unpreconditioned solver
+    within the tolerance while running much faster.
+    """
+    if x0 is None:
+        x = torch.zeros_like(b)
+    else:
+        x = x0.clone()
+
+    r = b - mv(x)
+    if torch.dot(r.flatten(), r.flatten()).sqrt() < tol:
+        return x
+
+    z = Minv * r
+    p = z.clone()
+    rz_old = torch.dot(r.flatten(), z.flatten())
+
+    for _ in range(max_iter):
+        Ap = mv(p)
+        denom = torch.dot(p.flatten(), Ap.flatten())
+        if denom.abs() < 1e-20:
+            break
+        alpha = rz_old / denom
+
+        x = x + alpha * p
+        r = r - alpha * Ap
+
+        if torch.dot(r.flatten(), r.flatten()).sqrt() < tol:
+            break
+
+        z = Minv * r
+        rz_new = torch.dot(r.flatten(), z.flatten())
+        beta = rz_new / rz_old
+        p = z + beta * p
+        rz_old = rz_new
+
+    return x
+
+
+class HeatSimFEM:
+    """
+    Memory-efficient heat simulation using torch sparse and CG.
+    Sparse matrices are used and no dense system matrices are formed.
+    """
+
+    def __init__(self, gen_params, sim_params, **kwargs) -> None:
+        self.gen_params = gen_params
+        self.sim_params = sim_params
+
+        if hasattr(gen_params, "device"):
+            self.device = torch.device(gen_params.device)
+        else:
+            self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+        # Mesh + irradiance
+        self.verts_np = kwargs.get("verts_np", None)
+        self.faces_np = kwargs.get("faces_np", None)
+        self.irradiance_map = kwargs.get("irradiance_map", None)
+        # Optional spatially varying material fields (per-vertex):
+        # - thermal_diffusivity_map: mm^2/s
+        # - density_map: kg/mm^3
+        # - specific_heat_map: J/(kg*K)
+        # - emissivity_map: unitless [0,1] (used for radiation boundary term)
+        self.thermal_diffusivity_map = kwargs.get("thermal_diffusivity_map", None)
+        self.density_map = kwargs.get("density_map", None)
+        self.specific_heat_map = kwargs.get("specific_heat_map", None)
+        self.emissivity_map = kwargs.get("emissivity_map", None)
+
+        # Laplacian/mass backend config
+        # - laplacian_domain: "MESH" or "POINTS"
+        # - laplacian_backend: "IGL" or "ROBUST"
+        self.laplacian_domain = kwargs.get("laplacian_domain", "MESH")
+        self.laplacian_backend = kwargs.get("laplacian_backend", "IGL")
+        self.robust_mollify_factor = float(kwargs.get("robust_mollify_factor", 1e-5))
+        self.pointcloud_neighbors = int(kwargs.get("pointcloud_neighbors", 30))
+
+        # Linear-solver mode for the per-timestep SPD solve:
+        #   "pcg_jacobi" (default) -> Jacobi-preconditioned CG (much faster, same result)
+        #   "cg"                   -> original unpreconditioned CG (kept for A/B comparison)
+        self.solver_mode = str(kwargs.get("solver_mode", DEFAULT_SOLVER_MODE))
+
+        if self.irradiance_map is not None:
+            _log.debug("irradiance_map %s", self.irradiance_map.shape)
+
+    # ------------------------------------------------------------------
+    # Core sparse setup + simulation
+    # ------------------------------------------------------------------
+
+    def _build_boundary_and_sources(
+        self,
+        M_boundary_t,
+        boundary_mask_np,
+        irradiance_map_np,
+        rho_np,
+        c_np,
+        eps_np,
+        dt,
+        dtype=torch.float32,
+    ):
+        """
+        Build torch tensors for boundary mask and precompute RHS constants.
+        """
+        # Allow per-vertex rho/c (otherwise fall back to gen_params scalars)
+        if rho_np is None:
+            rho_np = np.full_like(boundary_mask_np, float(self.gen_params.RHO), dtype=np.float64)
+        if c_np is None:
+            c_np = np.full_like(boundary_mask_np, float(self.gen_params.C), dtype=np.float64)
+        if eps_np is None:
+            eps_np = np.full_like(boundary_mask_np, 0.9, dtype=np.float64)
+        eps_np = np.clip(eps_np, 0.0, 1.0)
+
+        rho_t = torch.from_numpy(rho_np.astype(np.float32)).to(self.device)
+        c_t = torch.from_numpy(c_np.astype(np.float32)).to(self.device)
+        rc_t = rho_t * c_t
+        eps_t = torch.from_numpy(eps_np.astype(np.float32)).to(self.device)
+
+        boundary_mask = torch.from_numpy(boundary_mask_np.astype(np.float32)).to(
+            self.device
+        )
+
+        if irradiance_map_np is None:
+            irradiance_map_np = np.zeros_like(boundary_mask_np, dtype=np.float32)
+        irr_t = torch.from_numpy(irradiance_map_np.astype(np.float32)).to(self.device)
+
+        # Constants
+        sigma = constants.SIGMA
+        Tamb = constants.AMBIENT_TEMP
+        h = constants.CONVECTION_COEFF
+
+        # A-side diags (multiplied with u inside mv)
+        vec_rad_A = None
+        vec_conv_A = None
+        if self.sim_params.sim_radiation:
+            vec_rad_A = (
+                boundary_mask
+                * dt
+                * 4.0
+                * sigma
+                * eps_t
+                * (Tamb**3)
+                / rc_t
+            )
+        if self.sim_params.sim_convection:
+            vec_conv_A = (
+                boundary_mask
+                * dt
+                * h
+                / rc_t
+            )
+
+        # RHS source vectors (constants)
+        vec_rad_rhs = torch.zeros_like(boundary_mask)
+        vec_conv_rhs = torch.zeros_like(boundary_mask)
+        vec_light_rhs = torch.zeros_like(boundary_mask)
+
+
+        if self.sim_params.sim_radiation:
+            vec_rad_rhs = (
+                boundary_mask
+                * dt
+                * 4.0
+                * sigma
+                * eps_t
+                * (Tamb**4)
+                / rc_t
+            )
+        if self.sim_params.sim_convection:
+            vec_conv_rhs = boundary_mask * dt * h * Tamb / rc_t
+        # Irradiance term
+        vec_light_rhs = boundary_mask * dt * irr_t / rc_t
+
+        _log.debug("DEBUG: vec_rad_rhs range: %s %s", vec_rad_rhs.min().item(), vec_rad_rhs.max().item())
+        _log.debug("DEBUG: vec_conv_rhs range: %s %s", vec_conv_rhs.min().item(), vec_conv_rhs.max().item())
+        _log.debug("DEBUG: vec_light_rhs range: %s %s", vec_light_rhs.min().item(), vec_light_rhs.max().item())
+
+        # B_const = M_boundary @ (sum of these vectors)
+        total_rhs_vec = vec_rad_rhs + vec_conv_rhs + vec_light_rhs  # (N,)
+        total_rhs_vec = total_rhs_vec.unsqueeze(1)  # (N,1)
+
+        B_const = torch.sparse.mm(M_boundary_t, total_rhs_vec)  # (N,1)
+
+        return boundary_mask, irr_t, vec_rad_A, vec_conv_A, B_const
+
+    def _simulate_heat_torch(
+        self,
+        u0_np,
+        L_t,
+        M_t,
+        M_boundary_t,
+        boundary_mask_np,
+        irradiance_map_np,
+        alpha_np,
+        rho_np,
+        c_np,
+        eps_np,
+        dt,
+        num_steps,
+        steady_state: bool = False,
+        tol_K_per_s: float = 0.0,
+        store_only_final: bool = False,
+    ):
+        """
+        Main implicit Euler heat simulation using CG, in torch.
+        """
+        reg_value = 1e-8 if self.sim_params.add_tikhonov_reg else 0.0
+
+        # Initial condition
+        u_prev = torch.from_numpy(u0_np.reshape(-1).astype(np.float32)).to(
+            self.device
+        )
+        u_prev = u_prev.unsqueeze(1)  # (N,1)
+
+        # ------------------------------------------------------------------
+        # Build constants + (optionally) time-varying lighting source terms
+        # ------------------------------------------------------------------
+
+        # Allow per-vertex rho/c (otherwise fall back to gen_params scalars)
+        if rho_np is None:
+            rho_np = np.full_like(boundary_mask_np, float(self.gen_params.RHO), dtype=np.float64)
+        if c_np is None:
+            c_np = np.full_like(boundary_mask_np, float(self.gen_params.C), dtype=np.float64)
+        if eps_np is None:
+            eps_np = np.full_like(boundary_mask_np, 0.9, dtype=np.float64)
+        eps_np = np.clip(eps_np, 0.0, 1.0)
+
+        rho_t = torch.from_numpy(rho_np.astype(np.float32)).to(self.device)
+        c_t = torch.from_numpy(c_np.astype(np.float32)).to(self.device)
+        rc_t = rho_t * c_t
+        eps_t = torch.from_numpy(eps_np.astype(np.float32)).to(self.device)
+
+        boundary_mask = torch.from_numpy(boundary_mask_np.astype(np.float32)).to(self.device)
+
+        sigma = constants.SIGMA
+        Tamb = constants.AMBIENT_TEMP
+        h = constants.CONVECTION_COEFF
+
+        vec_rad_A = None
+        vec_conv_A = None
+        if self.sim_params.sim_radiation:
+            vec_rad_A = boundary_mask * dt * 4.0 * sigma * eps_t * (Tamb**3) / rc_t
+        if self.sim_params.sim_convection:
+            vec_conv_A = boundary_mask * dt * h / rc_t
+
+        vec_rad_rhs = torch.zeros_like(boundary_mask)
+        vec_conv_rhs = torch.zeros_like(boundary_mask)
+        if self.sim_params.sim_radiation:
+            vec_rad_rhs = boundary_mask * dt * 4.0 * sigma * eps_t * (Tamb**4) / rc_t
+        if self.sim_params.sim_convection:
+            vec_conv_rhs = boundary_mask * dt * h * Tamb / rc_t
+
+        # Constant part of RHS from radiation+convection only
+        rhs_const = (vec_rad_rhs + vec_conv_rhs).unsqueeze(1)  # (N,1)
+        B_rad_conv_const = torch.sparse.mm(M_boundary_t, rhs_const)  # (N,1)
+
+        # Base irradiance term (constant over time)
+        if irradiance_map_np is None:
+            irradiance_map_np = np.zeros_like(boundary_mask_np, dtype=np.float32)
+        irr_base_t = torch.from_numpy(np.asarray(irradiance_map_np, dtype=np.float32)).to(self.device)
+        vec_light_base = (boundary_mask * dt * irr_base_t / rc_t).unsqueeze(1)
+        B_light_base = torch.sparse.mm(M_boundary_t, vec_light_base)  # (N,1)
+
+        # Debug ranges
+        try:
+            _log.debug(
+                "DEBUG: B_rad_conv_const range: [%s, %s]",
+                f"{B_rad_conv_const.min().item():.10f}",
+                f"{B_rad_conv_const.max().item():.10f}",
+            )
+            _log.debug(
+                "DEBUG: B_light_base range: [%s, %s]",
+                f"{B_light_base.min().item():.10f}",
+                f"{B_light_base.max().item():.10f}",
+            )
+        except Exception:
+            pass
+
+        # Pre-define matrix-free operator A(u)
+        def mv(x):
+            # x: (N,1)
+            # M @ x
+            Mx = torch.sparse.mm(M_t, x)
+            # L @ x
+            Lx = torch.sparse.mm(L_t, x)
+            # Basic diffusion term
+            if alpha_np is None:
+                # Backward-compatible scalar diffusivity
+                K = float(self.gen_params.K)
+                out = Mx - K * dt * Lx
+            else:
+                # Spatially varying diffusivity (mm^2/s) as a per-vertex diagonal scaling.
+                # This is an approximation; we build a weighted Laplacian separately in _build_matrices.
+                out = Mx - dt * Lx
+
+            # Radiation / convection on A side
+            if vec_rad_A is not None:
+                tmp = (vec_rad_A.unsqueeze(1) * x)
+                out = out + torch.sparse.mm(M_boundary_t, tmp)
+            if vec_conv_A is not None:
+                tmp = (vec_conv_A.unsqueeze(1) * x)
+                out = out + torch.sparse.mm(M_boundary_t, tmp)
+
+            if reg_value > 0.0:
+                out = out + reg_value * x
+
+            return out
+
+        # Run simulation
+        u0_cpu = u_prev.detach().cpu().numpy().astype(np.float64).reshape(-1)
+        us = []
+        if not store_only_final:
+            us.append(u0_cpu)
+
+        # Steady-state diagnostics
+        WARMUP_STEPS = 5
+        WINDOW = 10
+        PRINT_EVERY = 20
+        recent_changes = []
+        converged = False
+        max_dT = float("inf")
+        nonmonotonic_warned = False
+
+        # Constant RHS across the time loop (no time-varying lighting).
+        B_step = B_rad_conv_const + B_light_base
+
+        # ------------------------------------------------------------------
+        # Jacobi (diagonal) preconditioner for the constant operator A.
+        # A = M - K*dt*L (+ radiation/convection boundary diag + Tikhonov reg).
+        # Computed ONCE since A does not change across timesteps.
+        # ------------------------------------------------------------------
+        Minv = None
+        if self.solver_mode == "pcg_jacobi":
+            diagA = sparse_diag(M_t)
+            dL = sparse_diag(L_t)
+            if alpha_np is None:
+                diagA = diagA - float(self.gen_params.K) * dt * dL
+            else:
+                diagA = diagA - dt * dL
+            if vec_rad_A is not None or vec_conv_A is not None:
+                dMb = sparse_diag(M_boundary_t)
+                if vec_rad_A is not None:
+                    diagA = diagA + dMb * vec_rad_A
+                if vec_conv_A is not None:
+                    diagA = diagA + dMb * vec_conv_A
+            if reg_value > 0.0:
+                diagA = diagA + reg_value
+            Minv = (1.0 / torch.clamp(diagA, min=1e-12)).unsqueeze(1)
+
+        for step in range(num_steps):
+            # b = M @ u_prev + B_step
+            b = torch.sparse.mm(M_t, u_prev) + B_step
+
+            # Use previous solution as initial guess for faster convergence.
+            if Minv is not None:
+                u_next = pcg_solve(mv, b, Minv, x0=u_prev, tol=1e-5, max_iter=200)
+            else:
+                u_next = cg_solve(mv, b, x0=u_prev, tol=1e-5, max_iter=200)
+
+            max_dT = float((u_next - u_prev).abs().max().item())
+            # Discrete approximation to ||dT/dt||_inf in K/s. dt-invariant.
+            rate_K_per_s = max_dT / dt if dt > 0.0 else float("inf")
+            if step < 3 or (step + 1) % PRINT_EVERY == 0:
+                _log.debug(
+                    "FEM step %d: u range [%.4f, %.4f] max_dT=%.6f K  rate=%.6f K/s",
+                    step,
+                    u_next.min().item(),
+                    u_next.max().item(),
+                    max_dT,
+                    rate_K_per_s,
+                )
+
+            if not store_only_final:
+                us.append(u_next.detach().cpu().numpy().astype(np.float64).reshape(-1))
+            u_prev = u_next
+
+            if steady_state and step >= WARMUP_STEPS:
+                recent_changes.append(rate_K_per_s)
+                if len(recent_changes) > WINDOW:
+                    recent_changes.pop(0)
+                # Compare the mean over the window so per-step CG/float-point
+                # wobble doesn't keep us from declaring convergence once the
+                # system has plateaued.
+                if len(recent_changes) >= WINDOW:
+                    mean_rate = float(sum(recent_changes) / len(recent_changes))
+                    if mean_rate < tol_K_per_s:
+                        converged = True
+                        _log.debug(
+                            "[HeatSim:FEM] Steady-state converged at step "
+                            "%d (mean rate over last %d steps "
+                            "= %.6f K/s < tol=%.6f K/s; "
+                            "latest rate=%.6f K/s)",
+                            step + 1,
+                            WINDOW,
+                            mean_rate,
+                            tol_K_per_s,
+                            rate_K_per_s,
+                        )
+                        break
+                if (
+                    not nonmonotonic_warned
+                    and len(recent_changes) == WINDOW
+                    and recent_changes[-1] > recent_changes[0]
+                ):
+                    _log.debug(
+                        "[HeatSim:FEM] WARNING: convergence rate not decreasing over "
+                        "%d steps (latest %.6f K/s, "
+                        "%d ago %.6f K/s). "
+                        "Consider shrinking timestep_size.",
+                        WINDOW,
+                        recent_changes[-1],
+                        WINDOW,
+                        recent_changes[0],
+                    )
+                    nonmonotonic_warned = True
+
+        if steady_state and not converged:
+            final_rate = max_dT / dt if dt > 0.0 else float("inf")
+            _log.debug(
+                "[HeatSim:FEM] WARNING: did not reach tol=%.6f K/s in "
+                "%d steps (final rate=%.6f K/s). "
+                "Returning current state.",
+                tol_K_per_s,
+                num_steps,
+                final_rate,
+            )
+
+        if store_only_final:
+            final_cpu = u_prev.detach().cpu().numpy().astype(np.float64).reshape(-1)
+            return np.stack([final_cpu], axis=0)  # (1, N)
+        return np.stack(us, axis=0)  # (num_steps_taken+1, N)
+
+    def _apply_vertex_weighted_laplacian(self, L: sp.spmatrix, alpha_vec: np.ndarray) -> sp.spmatrix:
+        """
+        Approximate variable-coefficient diffusion by scaling off-diagonal Laplacian entries.
+
+        Assumes L is a (negative semidefinite) Laplacian-like matrix with:
+        - off-diagonals >= 0
+        - diagonal = -row_sum(offdiag)
+        """
+        alpha_vec = np.asarray(alpha_vec, dtype=np.float64).reshape(-1)
+        L_coo = L.tocoo()
+        rows = L_coo.row
+        cols = L_coo.col
+        data = L_coo.data.astype(np.float64)
+
+        off = rows != cols
+        rows_off = rows[off]
+        cols_off = cols[off]
+        data_off = data[off]
+
+        # Scale edge weights by average alpha across the edge
+        scale = 0.5 * (alpha_vec[rows_off] + alpha_vec[cols_off])
+        data_off = data_off * scale
+
+        # Rebuild with recomputed diagonal so rows sum to ~0
+        Lw_off = sp.coo_matrix((data_off, (rows_off, cols_off)), shape=L.shape).tocsr()
+        diag = -np.array(Lw_off.sum(axis=1)).reshape(-1)
+        Lw = Lw_off + sp.diags(diag, format="csr")
+        return Lw
+
+    def _compute_mass_matrix_manual(self, verts_np, faces_np):
+        """
+        Compute lumped mass matrix manually (barycentric).
+        Each vertex gets 1/3 of the area of each adjacent triangle.
+        """
+        n_verts = verts_np.shape[0]
+        mass_diag = np.zeros(n_verts, dtype=np.float64)
+
+        # Vectorized computation
+        v0 = verts_np[faces_np[:, 0]]
+        v1 = verts_np[faces_np[:, 1]]
+        v2 = verts_np[faces_np[:, 2]]
+        cross = np.cross(v1 - v0, v2 - v0)
+        areas = 0.5 * np.linalg.norm(cross, axis=1)
+
+        # Accumulate area/3 to each vertex
+        np.add.at(mass_diag, faces_np[:, 0], areas / 3.0)
+        np.add.at(mass_diag, faces_np[:, 1], areas / 3.0)
+        np.add.at(mass_diag, faces_np[:, 2], areas / 3.0)
+
+        return sp.diags(mass_diag, format='csr')
+
+    def _compute_cotmatrix_manual(self, verts_np, faces_np):
+        """
+        Fast, vectorized computation of cotangent Laplacian.
+        L_ij = -0.5 * (cot(alpha_ij) + cot(beta_ij)) for edge (i,j)
+        L_ii = -sum_j(L_ij)
+        Only works for triangle meshes (faces_np n x 3).
+        """
+        n_verts = verts_np.shape[0]
+        n_faces = faces_np.shape[0]
+        # Indices of triangle corners
+        i0 = faces_np[:, 0]
+        i1 = faces_np[:, 1]
+        i2 = faces_np[:, 2]
+
+        v0 = verts_np[i0]  # (nF, 3)
+        v1 = verts_np[i1]
+        v2 = verts_np[i2]
+
+        # For each triangle, compute cotangent at each corner
+        # Each triangle has 3 corners: at v0, at v1, at v2.
+        # For each corner, we want to compute cot(theta):
+        # cot(theta_i) = (u·v) / norm(u x v) where u/v are the two adjacent triangle sides at that corner.
+        # Layout:
+        # Corner at v0 = angle at v0, sides: (v2-v0), (v1-v0) (from v0 towards v2, v0 towards v1)
+        # Corner at v1 = angle at v1, sides: (v0-v1), (v2-v1)
+        # Corner at v2 = angle at v2, sides: (v1-v2), (v0-v2)
+        u0 = v2 - v0  # (nF, 3)
+        v0v = v1 - v0
+        u1 = v0 - v1
+        v1v = v2 - v1
+        u2 = v1 - v2
+        v2v = v0 - v2
+
+        # Cotangents at corners
+        cot0 = np.einsum('ij,ij->i', u0, v0v) / (np.linalg.norm(np.cross(u0, v0v), axis=1) + 1e-16)
+        cot1 = np.einsum('ij,ij->i', u1, v1v) / (np.linalg.norm(np.cross(u1, v1v), axis=1) + 1e-16)
+        cot2 = np.einsum('ij,ij->i', u2, v2v) / (np.linalg.norm(np.cross(u2, v2v), axis=1) + 1e-16)
+
+        # For each triangle, contribute to edges:
+        # (i1,i2): cot at v0
+        # (i2,i0): cot at v1
+        # (i0,i1): cot at v2
+        # Each cotangent belongs to the edge opposite the current corner.
+        I = np.concatenate([i1, i2, i2, i0, i0, i1])
+        J = np.concatenate([i2, i1, i0, i2, i1, i0])
+        V = 0.5 * np.concatenate([cot0, cot0, cot1, cot1, cot2, cot2])
+
+        # Build sparse matrix
+        L = sp.coo_matrix((V, (I, J)), shape=(n_verts, n_verts))
+        # Set diagonal: L_ii = -sum_j(L_ij)
+        L = L.tocsr()
+        L = L - sp.diags(np.array(L.sum(axis=1)).flatten(), format='csr')
+        return L
+
+    def _build_pointcloud_fallback_matrices(self, points_np, n_neighbors: int):
+        """
+        Fallback point-cloud Laplacian if robust_laplacian isn't available.
+
+        Builds a simple symmetric kNN graph Laplacian:
+            L_psd = D - W  (PSD)
+        We return the NEGATIVE of this matrix to match the solver convention.
+        Mass matrix is identity (lumped).
+        """
+        try:
+            from scipy.spatial import cKDTree
+        except Exception as e:  # pragma: no cover
+            raise RuntimeError(
+                "Point-cloud FEM requires either robust_laplacian or scipy.spatial.cKDTree. "
+                f"Import error: {e}"
+            )
+
+        points_np = np.asarray(points_np, dtype=np.float64)
+        n = int(points_np.shape[0])
+        if n == 0:
+            raise ValueError("Cannot build point-cloud Laplacian for empty point set")
+
+        k = int(max(2, min(n_neighbors, n - 1)))
+        tree = cKDTree(points_np)
+        dists, idxs = tree.query(points_np, k=k + 1)  # include self at [0]
+        dists = dists[:, 1:]
+        idxs = idxs[:, 1:]
+
+        # Simple distance weights. Symmetrize later.
+        eps = 1e-12
+        w = 1.0 / (dists + eps)
+
+        rows = np.repeat(np.arange(n, dtype=np.int64), k)
+        cols = idxs.reshape(-1).astype(np.int64)
+        data = w.reshape(-1).astype(np.float64)
+
+        W = sp.coo_matrix((data, (rows, cols)), shape=(n, n)).tocsr()
+        # Symmetrize
+        W = 0.5 * (W + W.T)
+        d = np.array(W.sum(axis=1)).reshape(-1)
+        L_psd = sp.diags(d, format="csr") - W
+
+        # Match solver convention: negative semidefinite Laplacian.
+        L = -L_psd
+        M = sp.eye(n, format="csr")
+        return L, M
+
+    def _build_matrices(self, verts_np, faces_np, *, alpha_vec: np.ndarray | None = None):
+        """
+        Build Laplacian + mass matrices, then convert to torch sparse.
+
+        Important sign convention:
+        - This solver expects a NEGATIVE semidefinite Laplacian (like `igl.cotmatrix()`).
+        - `robust_laplacian` returns a POSITIVE semidefinite Laplacian, so we flip sign.
+        """
+        verts_np = np.array(verts_np, dtype=np.float64)
+
+        # --------------------------------------------------------------
+        # Point-cloud mode (no faces required)
+        # --------------------------------------------------------------
+        if str(self.laplacian_domain).upper() == "POINTS":
+            if str(self.laplacian_backend).upper() == "ROBUST":
+                if not HAS_ROBUST_LAPLACIAN:
+                    warnings.warn(
+                        "Requested robust_laplacian point-cloud Laplacian, but robust_laplacian "
+                        f"is not available ({ROBUST_IMPORT_ERROR}). Falling back to a simple kNN graph Laplacian.",
+                        RuntimeWarning,
+                    )
+                    L, M = self._build_pointcloud_fallback_matrices(
+                        verts_np, n_neighbors=self.pointcloud_neighbors
+                    )
+                    # Put an info messsage on how the Laplacian is built
+                    _log.debug(
+                        "[DEBUG] Point-cloud Laplacian built using simple kNN graph Laplacian. L shape: %s, M shape: %s",
+                        L.shape,
+                        M.shape,
+                    )
+                else:
+                    L_psd, M = point_cloud_laplacian_and_mass(
+                        verts_np,
+                        mollify_factor=self.robust_mollify_factor,
+                        n_neighbors=self.pointcloud_neighbors,
+                    )
+                    L = -L_psd
+                    _log.debug(
+                        "[DEBUG] Point-cloud Laplacian built using robust_laplacian API. L shape: %s, M shape: %s",
+                        L.shape,
+                        M.shape,
+                    )
+
+            else:
+                warnings.warn(
+                    "Point-cloud FEM requested with non-ROBUST backend; using a simple kNN graph Laplacian.",
+                    RuntimeWarning,
+                )
+                L, M = self._build_pointcloud_fallback_matrices(
+                    verts_np, n_neighbors=self.pointcloud_neighbors
+                )
+                _log.debug(
+                    "[DEBUG] Point-cloud Laplacian built using simple kNN graph Laplacian. L shape: %s, M shape: %s",
+                    L.shape,
+                    M.shape,
+                )
+
+            # Optional: apply spatially varying diffusivity by weighting the Laplacian.
+            if alpha_vec is not None:
+                alpha_vec = np.asarray(alpha_vec, dtype=np.float64).reshape(-1)
+                if alpha_vec.shape[0] == L.shape[0]:
+                    L = self._apply_vertex_weighted_laplacian(L, alpha_vec)
+                else:
+                    warnings.warn(
+                        "alpha_vec length doesn't match point-cloud Laplacian size; ignoring variable diffusion.",
+                        RuntimeWarning,
+                    )
+
+            M_boundary = M.copy()
+            L_t = scipy_to_torch_sparse(L, self.device)
+            M_t = scipy_to_torch_sparse(M, self.device)
+            M_boundary_t = scipy_to_torch_sparse(M_boundary, self.device)
+            return L_t, M_t, M_boundary_t
+
+        # --------------------------------------------------------------
+        # Mesh mode
+        # --------------------------------------------------------------
+        faces_np = np.array(faces_np, dtype=np.int32)
+        assert faces_np.shape[1] == 3, "Only triangle meshes supported."
+
+        if str(self.laplacian_backend).upper() == "ROBUST":
+            if not HAS_ROBUST_LAPLACIAN:
+                warnings.warn(
+                    "Requested robust_laplacian mesh Laplacian, but robust_laplacian is not available "
+                    f"({ROBUST_IMPORT_ERROR}). Falling back to igl cotmatrix/massmatrix.",
+                    RuntimeWarning,
+                )
+            else:
+                L_psd, M = mesh_laplacian_and_mass(
+                    verts_np,
+                    faces_np,
+                    mollify_factor=self.robust_mollify_factor,
+                )
+                L = -L_psd
+                _log.debug(
+                    "[DEBUG] Mesh Laplacian built using robust_laplacian API. L shape: %s, M shape: %s",
+                    L.shape,
+                    M.shape,
+                )
+                M_boundary = M.copy()
+                L_t = scipy_to_torch_sparse(L, self.device)
+                M_t = scipy_to_torch_sparse(M, self.device)
+                M_boundary_t = scipy_to_torch_sparse(M_boundary, self.device)
+                return L_t, M_t, M_boundary_t
+
+        if HAS_IGL:
+            L = igl.cotmatrix(verts_np, faces_np)
+        else:
+            warnings.warn(
+                f"libigl (igl) not available ({IGL_IMPORT_ERROR}); computing cotan Laplacian manually.",
+                RuntimeWarning,
+            )
+            L = sp.csr_matrix((verts_np.shape[0], verts_np.shape[0]))
+            _log.debug("[DEBUG] Mesh Laplacian built using manual computation. L shape: %s", L.shape)
+
+        # Debug: Check Laplacian
+        if L.nnz > 0:
+            _log.debug(
+                "  Laplacian: nnz=%d, data range=[%.6f, %.6f]",
+                L.nnz,
+                L.data.min(),
+                L.data.max(),
+            )
+        else:
+            _log.debug("  WARNING: Laplacian is empty (nnz=0), will compute manually")
+
+        # Try igl mass matrix
+        M = None
+        if HAS_IGL and L.nnz > 0:
+            M = igl.massmatrix(verts_np, faces_np, igl.MASSMATRIX_TYPE_BARYCENTRIC)
+            if M.nnz == 0:
+                M = igl.massmatrix(verts_np, faces_np, igl.MASSMATRIX_TYPE_VORONOI)
+            if M.nnz > 0:
+                _log.debug("  Mass matrix from igl: nnz=%d", M.nnz)
+
+        # Fallback to manual computation if igl failed
+        if M is None or M.nnz == 0:
+            _log.debug("  Computing mass matrix manually (igl failed)...")
+            M = self._compute_mass_matrix_manual(verts_np, faces_np)
+            _log.debug("  Manual mass matrix: nnz=%d, diag sum=%.6f", M.nnz, M.diagonal().sum())
+
+        if L.nnz == 0:
+            _log.debug("  Computing Laplacian manually (igl unavailable or failed)...")
+            L = self._compute_cotmatrix_manual(verts_np, faces_np)
+            _log.debug("  Manual Laplacian: nnz=%d", L.nnz)
+
+        M_boundary = M.copy()
+
+        _log.debug("[DEBUG] Laplacian shape: %s", L.shape)
+        _log.debug("[DEBUG] Mass Matrix shape: %s", M.shape)
+        _log.debug("[DEBUG] Boundary Mass Matrix shape: %s", M_boundary.shape)
+
+        # Print the first 10 diagonal elements of the mass matrix
+        # M can be a sparse matrix; use .diagonal() method instead of np.diag for sparse
+        if hasattr(M, "diagonal"):
+            diag_vals = M.diagonal()
+        else:
+            diag_vals = np.diag(M)
+        _log.debug("[DEBUG] Mass Matrix first 10 diagonal elements: %s", diag_vals[:10].tolist())
+
+        # Optional: apply spatially varying diffusivity by weighting the Laplacian.
+        if alpha_vec is not None:
+            alpha_vec = np.asarray(alpha_vec, dtype=np.float64).reshape(-1)
+            if alpha_vec.shape[0] == L.shape[0]:
+                L = self._apply_vertex_weighted_laplacian(L, alpha_vec)
+            else:
+                warnings.warn(
+                    "alpha_vec length doesn't match mesh Laplacian size; ignoring variable diffusion.",
+                    RuntimeWarning,
+                )
+
+        # Convert to torch sparse on device
+        L_t = scipy_to_torch_sparse(L, self.device)
+        M_t = scipy_to_torch_sparse(M, self.device)
+        M_boundary_t = scipy_to_torch_sparse(M_boundary, self.device)
+
+        return L_t, M_t, M_boundary_t
+
+    def simulate_for_pose(
+        self,
+        verts_np,
+        faces_np,
+        boundary_verts_mask,
+        u_prev,
+        irradiance_map,
+        thermal_diffusivity_map,
+        density_map,
+        specific_heat_map,
+        emissivity_map,
+        num_substeps: int,
+        dt: float,
+        dirichlet_indices=None,
+        dirichlet_values=None,
+    ):
+        """Build (L, M, M_boundary) for a single pose and advance ``num_substeps``
+        implicit-Euler CG solves with ``u_prev`` as the initial state.
+
+        Per-vertex material vectors (alpha, rho, c, eps) and the per-vertex flux
+        ``irradiance_map`` are treated as pose-invariant for Phase 1 animated
+        geometry. The Laplacian / mass matrices are rebuilt because they depend
+        on positions; everything else is a function of constant per-vertex data
+        plus the per-pose mass matrix (which is what couples flux into RHS).
+
+        When ``dirichlet_indices`` is given (with matching ``dirichlet_values``),
+        those vertex indices are pinned to their target temperature on the
+        initial state AND re-pinned after every substep's CG solve -- not just
+        once per frame -- since the FEM/Dirichlet coupling weight in ``mv`` would
+        otherwise let the pinned nodes drift within a frame as substeps advance
+        (this matters most as ``num_substeps`` grows). Callers that don't pass
+        these params (e.g. :meth:`perform_gt_heat_simulation`'s static path) get
+        byte-identical behavior to before.
+
+        Returns: ``(num_substeps, N)`` float64 array of post-step states.
+        """
+        N = int(verts_np.shape[0])
+        u_prev = np.asarray(u_prev, dtype=np.float64).reshape(-1)
+        assert u_prev.shape[0] == N, f"u_prev length {u_prev.shape[0]} != N {N}"
+
+        alpha_np = (
+            np.asarray(thermal_diffusivity_map, dtype=np.float64).reshape(-1)
+            if thermal_diffusivity_map is not None
+            else None
+        )
+        L_t, M_t, M_boundary_t = self._build_matrices(verts_np, faces_np, alpha_vec=alpha_np)
+
+        rho_np = (
+            np.asarray(density_map, dtype=np.float64).reshape(-1)
+            if density_map is not None
+            else np.full(N, float(self.gen_params.RHO), dtype=np.float64)
+        )
+        c_np = (
+            np.asarray(specific_heat_map, dtype=np.float64).reshape(-1)
+            if specific_heat_map is not None
+            else np.full(N, float(self.gen_params.C), dtype=np.float64)
+        )
+        eps_np = (
+            np.asarray(emissivity_map, dtype=np.float64).reshape(-1)
+            if emissivity_map is not None
+            else np.full(N, 0.9, dtype=np.float64)
+        )
+        eps_np = np.clip(eps_np, 0.0, 1.0)
+        boundary_np = np.asarray(boundary_verts_mask).reshape(-1).astype(np.float32)
+        irr_np = (
+            np.asarray(irradiance_map, dtype=np.float32).reshape(-1)
+            if irradiance_map is not None
+            else np.zeros(N, dtype=np.float32)
+        )
+
+        rho_t = torch.from_numpy(rho_np.astype(np.float32)).to(self.device)
+        c_t = torch.from_numpy(c_np.astype(np.float32)).to(self.device)
+        rc_t = rho_t * c_t
+        eps_t = torch.from_numpy(eps_np.astype(np.float32)).to(self.device)
+        boundary_mask = torch.from_numpy(boundary_np).to(self.device)
+        irr_t = torch.from_numpy(irr_np).to(self.device)
+
+        sigma = constants.SIGMA
+        Tamb = constants.AMBIENT_TEMP
+        h = constants.CONVECTION_COEFF
+
+        vec_rad_A = None
+        vec_conv_A = None
+        if self.sim_params.sim_radiation:
+            vec_rad_A = boundary_mask * dt * 4.0 * sigma * eps_t * (Tamb ** 3) / rc_t
+        if self.sim_params.sim_convection:
+            vec_conv_A = boundary_mask * dt * h / rc_t
+
+        vec_rad_rhs = (
+            boundary_mask * dt * 4.0 * sigma * eps_t * (Tamb ** 4) / rc_t
+            if self.sim_params.sim_radiation
+            else torch.zeros_like(boundary_mask)
+        )
+        vec_conv_rhs = (
+            boundary_mask * dt * h * Tamb / rc_t
+            if self.sim_params.sim_convection
+            else torch.zeros_like(boundary_mask)
+        )
+        vec_light_rhs = boundary_mask * dt * irr_t / rc_t
+        rhs_total = (vec_rad_rhs + vec_conv_rhs + vec_light_rhs).unsqueeze(1)
+        B_step = torch.sparse.mm(M_boundary_t, rhs_total)  # (N, 1)
+
+        reg_value = 1e-8 if self.sim_params.add_tikhonov_reg else 0.0
+
+        def mv(x):
+            Mx = torch.sparse.mm(M_t, x)
+            Lx = torch.sparse.mm(L_t, x)
+            if alpha_np is None:
+                K = float(self.gen_params.K)
+                out = Mx - K * dt * Lx
+            else:
+                out = Mx - dt * Lx
+            if vec_rad_A is not None:
+                out = out + torch.sparse.mm(M_boundary_t, vec_rad_A.unsqueeze(1) * x)
+            if vec_conv_A is not None:
+                out = out + torch.sparse.mm(M_boundary_t, vec_conv_A.unsqueeze(1) * x)
+            if reg_value > 0.0:
+                out = out + reg_value * x
+            return out
+
+        u_prev_t = torch.from_numpy(u_prev.astype(np.float32).reshape(-1, 1)).to(self.device)
+
+        di_t = None
+        if dirichlet_indices is not None and len(dirichlet_indices) > 0:
+            di_t = torch.from_numpy(np.asarray(dirichlet_indices, dtype=np.int64)).to(self.device)
+            dv_t = torch.from_numpy(np.asarray(dirichlet_values, dtype=np.float32).reshape(-1, 1)).to(self.device)
+            u_prev_t[di_t] = dv_t
+
+        out_states = np.zeros((num_substeps, N), dtype=np.float64)
+        for s in range(num_substeps):
+            b = torch.sparse.mm(M_t, u_prev_t) + B_step
+            u_next_t = cg_solve(mv, b, x0=u_prev_t, tol=1e-5, max_iter=200)
+            if di_t is not None:
+                u_next_t[di_t] = dv_t
+            out_states[s, :] = u_next_t.detach().cpu().numpy().astype(np.float64).reshape(-1)
+            u_prev_t = u_next_t
+
+        return out_states
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def perform_gt_heat_simulation(
+        self,
+        verts_np,
+        faces_np,
+        boundary_faces_np,
+        boundary_verts_mask_override=None,
+        u0=None,
+        irradiance_map=None,
+        thermal_diffusivity_map=None,
+        density_map=None,
+        specific_heat_map=None,
+        emissivity_map=None,
+        steady_state: bool = False,
+        tol_K_per_s: float = 0.0,
+        store_only_final: bool = False,
+    ):
+        # In point-cloud mode we keep ALL vertices (no face-based filtering/renumbering).
+        if str(self.laplacian_domain).upper() == "POINTS":
+            valid_verts = np.ones(verts_np.shape[0], dtype=bool)
+            verts_np = np.asarray(verts_np, dtype=np.float64)
+        else:
+            # Filter to valid verts (same logic as original; drop unreferenced verts)
+            faces_np_unique = np.unique(faces_np).astype(int)
+            valid_verts = np.zeros(verts_np.shape[0], dtype=bool)
+            valid_verts[faces_np_unique] = True
+            _log.debug(
+                "valid_verts %d Total verts: %d",
+                np.count_nonzero(valid_verts),
+                verts_np.shape[0],
+            )
+
+            renumber_faces = np.full(verts_np.shape[0], -1, dtype=int)
+            renumber_faces[valid_verts] = np.arange(np.count_nonzero(valid_verts))
+            faces_np = renumber_faces[faces_np]
+            boundary_faces_np = renumber_faces[boundary_faces_np]
+            verts_np = verts_np[valid_verts].astype(np.float64)
+
+        if u0 is None:
+            u0 = np.full((verts_np.shape[0],), constants.AMBIENT_TEMP, dtype=np.float64)
+        else:
+            u0 = u0[valid_verts].reshape(-1)
+
+        # Material maps can be passed per-call (override constructor fields)
+        if thermal_diffusivity_map is None:
+            thermal_diffusivity_map = self.thermal_diffusivity_map
+        if density_map is None:
+            density_map = self.density_map
+        if specific_heat_map is None:
+            specific_heat_map = self.specific_heat_map
+        if emissivity_map is None:
+            emissivity_map = self.emissivity_map
+
+        # Filter material vectors to valid verts (mesh mode) so they match u0/L/M.
+        rho_f = c_f = alpha_f = eps_f = None
+        if thermal_diffusivity_map is not None:
+            alpha_f = np.asarray(thermal_diffusivity_map, dtype=np.float64).reshape(-1)[valid_verts]
+        if density_map is not None:
+            rho_f = np.asarray(density_map, dtype=np.float64).reshape(-1)[valid_verts]
+        if specific_heat_map is not None:
+            c_f = np.asarray(specific_heat_map, dtype=np.float64).reshape(-1)[valid_verts]
+        if emissivity_map is not None:
+            eps_f = np.asarray(emissivity_map, dtype=np.float64).reshape(-1)[valid_verts]
+
+        if str(self.laplacian_domain).upper() == "POINTS":
+            if boundary_verts_mask_override is not None:
+                boundary_verts_mask = (
+                    np.asarray(boundary_verts_mask_override).reshape(-1)[valid_verts].astype(bool)
+                )
+            else:
+                # Legacy fallback: in point-cloud mode all points are boundary.
+                boundary_verts_mask = np.ones(verts_np.shape[0], dtype=bool)
+        else:
+            boundary_verts = np.unique(boundary_faces_np)
+            boundary_verts_mask = np.zeros(verts_np.shape[0], dtype=bool)
+            boundary_verts_mask[boundary_verts] = 1.0
+
+        _log.debug(
+            "%s %s %s %s %s",
+            verts_np.shape,
+            faces_np.shape if faces_np is not None else None,
+            u0.shape,
+            np.unique(u0),
+            verts_np.dtype,
+        )
+
+        # Build sparse matrices (optionally variable diffusion via alpha_f)
+        L_t, M_t, M_boundary_t = self._build_matrices(verts_np, faces_np, alpha_vec=alpha_f)
+
+        # Time stepping info
+        dt = self.gen_params.NUM_FRAME_DELTA / 60.0
+        record_attimestep = int(
+            (self.sim_params.sim_time - self.sim_params.record_time) / dt
+        )
+        sim_steps = int(self.sim_params.sim_time / dt)
+
+        timesteps = [0, record_attimestep, sim_steps]
+
+        if irradiance_map is None and self.irradiance_map is not None:
+            irradiance_map = self.irradiance_map
+        if irradiance_map is not None:
+            irradiance_map = irradiance_map[valid_verts].astype(np.float32)
+
+        if record_attimestep == 0 and not store_only_final:
+            # Use proper 2D array shape (1, N) for consistent concatenation
+            u_real_arr = [u0.reshape(1, -1)]
+        else:
+            u_real_arr = []
+
+        u0_local = u0.copy()
+
+        for i in range(len(timesteps) - 1):
+            sim_length = timesteps[i + 1] - timesteps[i]
+            _log.debug("sim_length %d", sim_length)
+            if sim_length == 0:
+                continue
+
+            u_real_np_tmp = self._simulate_heat_torch(
+                u0_local,
+                L_t,
+                M_t,
+                M_boundary_t,
+                boundary_verts_mask,
+                irradiance_map,
+                alpha_f,
+                rho_f,
+                c_f,
+                eps_f,
+                dt,
+                sim_length,
+                steady_state=steady_state,
+                tol_K_per_s=tol_K_per_s,
+                store_only_final=store_only_final,
+            )
+            _log.debug("%s", u_real_np_tmp.shape)
+            u0_local = u_real_np_tmp[-1].copy()
+            # Record if this timestep range ends at or after the recording start time
+            if timesteps[i + 1] > record_attimestep:
+                if store_only_final:
+                    # u_real_np_tmp already has shape (1, N) with only the final state.
+                    u_real_arr.append(u_real_np_tmp)
+                else:
+                    # Determine which results to include
+                    start_offset = max(0, record_attimestep - timesteps[i])
+                    if start_offset == 0:
+                        # Include all results except initial condition (already have it)
+                        u_real_arr.append(u_real_np_tmp[1:])
+                    else:
+                        # Skip some initial results
+                        u_real_arr.append(u_real_np_tmp[start_offset + 1:])
+
+        if len(u_real_arr) == 0:
+            # No timesteps were recorded, just return initial condition
+            u_real_arr = np.array([u0.reshape(-1)]).astype(np.float64)
+        else:
+            u_real_arr = np.concatenate(u_real_arr, axis=0).astype(np.float64)
+        tmp_u_real_np = u_real_arr
+
+        # Scatter back to full vertex set
+        u_real_np = np.full(
+            (tmp_u_real_np.shape[0], valid_verts.shape[0]),
+            constants.AMBIENT_TEMP,
+            dtype=np.float64,
+        )
+        u_real_np[:, valid_verts] = tmp_u_real_np
+
+        return u_real_np
+
+    def run_heat_simulation(self):
+        u0 = np.full((self.verts_np.shape[0],), constants.AMBIENT_TEMP, dtype=np.float64)
+
+        u_real_np = self.perform_gt_heat_simulation(
+            self.verts_np.copy(),
+            self.faces_np.copy(),
+            self.faces_np,
+            u0=u0,
+            irradiance_map=self.irradiance_map,
+        )
+        _log.debug("%s", u_real_np[-1])
+
+        if self.sim_params.add_noise_to_sim:
+            u_real_np += np.random.normal(
+                0, self.sim_params.heat_noise_std, u_real_np.shape
+            )
+
+        self.u_real_np = u_real_np
+        return u_real_np

--- a/visionsim/simulate/heatsim/temperature_io.py
+++ b/visionsim/simulate/heatsim/temperature_io.py
@@ -1,0 +1,1026 @@
+# Vendored from heat-sim-blender:addon/lib/temperature_io.py @ e5b4afe
+"""External `.npz` storage for per-object FEM temperature histories.
+
+The .blend keeps only the live-display `sim_temperature` vertex attribute
+plus small metadata custom properties (heatsim_num_timesteps, heatsim_temp_min,
+heatsim_temp_max, heatsim_run_mode, heatsim_data_uri, heatsim_data_abspath,
+heatsim_data_key).
+
+The full per-vertex history goes to
+`<blend_dir>/<basename>.heatsim/latest/temperatures.npz`, keyed by object name,
+with a sidecar `manifest.json`. The reader resolution order is:
+
+    1. cached open NpzFile for the resolved archive path
+    2. `obj["heatsim_data_uri"]` (Blender //-relative path) -> archive
+    3. `obj["heatsim_data_abspath"]` -> archive
+    4. legacy `obj["heatsim_temperature_data"]` (pre-migration .blend files)
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import logging
+import os
+from typing import Any, Optional
+
+import bpy
+import numpy as np
+
+_log = logging.getLogger("rich")
+
+ARCHIVE_FILENAME = "temperatures.npz"
+MANIFEST_FILENAME = "manifest.json"
+IRRADIANCE_CACHE_FILENAME = "irradiance_cache.npz"
+BAKES_DIRNAME = "bakes"
+BAKES_INDEX_FILENAME = "index.json"
+KERNEL_BAKES_DIRNAME = "kernel_bakes"
+KERNEL_ALBEDO_FILENAME = "albedo_cache.npz"
+SKY_VISIBILITY_FILENAME = "sky_visibility_cache.npz"
+
+
+# Cache of opened NpzFile handles, keyed by absolute archive path.
+# Each entry: {"npz": np.lib.npyio.NpzFile, "path": str}
+_CACHE: dict[str, dict[str, Any]] = {}
+
+
+# ---------------------------------------------------------------------------
+# Path helpers
+# ---------------------------------------------------------------------------
+
+
+def _archive_dir_for_blend() -> Optional[str]:
+    """Absolute path to `<blend>.heatsim/latest/`, or None if .blend is unsaved."""
+    blend = bpy.data.filepath
+    if not blend:
+        return None
+    blend_dir = os.path.dirname(blend)
+    base = os.path.splitext(os.path.basename(blend))[0]
+    return os.path.join(blend_dir, f"{base}.heatsim", "latest")
+
+
+def _archive_dir_fallback(scene_name: str) -> str:
+    """Fallback under bpy.app.tempdir when the .blend is unsaved."""
+    return os.path.join(bpy.app.tempdir, f"heatsim_{scene_name}")
+
+
+def _now_utc_iso() -> str:
+    return datetime.datetime.utcnow().isoformat() + "Z"
+
+
+def _stamp_object_props(obj: bpy.types.Object, archive_abspath: str, key: str) -> None:
+    """Set the lookup custom properties used by the reader."""
+    blend = bpy.data.filepath
+    rel_uri = ""
+    if blend:
+        try:
+            rel_uri = bpy.path.relpath(archive_abspath)
+        except Exception:
+            rel_uri = ""
+    obj["heatsim_data_uri"] = rel_uri
+    obj["heatsim_data_abspath"] = archive_abspath
+    obj["heatsim_data_key"] = key
+    # Drop the legacy custom property if it's still around.
+    if "heatsim_temperature_data" in obj:
+        try:
+            del obj["heatsim_temperature_data"]
+        except Exception:
+            pass
+
+
+def _resolve_archive_path(obj: bpy.types.Object) -> Optional[str]:
+    """Try the relative URI first (handles 'blend was moved with .heatsim/'),
+    then the stored absolute path. Returns None if neither resolves to a file
+    that exists."""
+    uri = obj.get("heatsim_data_uri", "")
+    if uri:
+        try:
+            abspath = bpy.path.abspath(uri)
+            if abspath and os.path.isfile(abspath):
+                return abspath
+        except Exception:
+            pass
+    abspath = obj.get("heatsim_data_abspath", "")
+    if abspath and os.path.isfile(abspath):
+        return abspath
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Cache
+# ---------------------------------------------------------------------------
+
+
+def _open_archive(path: str):
+    """Return a memmap-backed NpzFile, caching by absolute path."""
+    cached = _CACHE.get(path)
+    if cached is not None and cached.get("npz") is not None:
+        return cached["npz"]
+    npz = np.load(path, mmap_mode="r", allow_pickle=False)
+    _CACHE[path] = {"npz": npz, "path": path}
+    return npz
+
+
+def _close_archive(path: str) -> None:
+    entry = _CACHE.pop(path, None)
+    if entry is None:
+        return
+    try:
+        entry["npz"].close()
+    except Exception:
+        pass
+
+
+def invalidate_cache() -> None:
+    """Close all cached handles. Called after writes (so the next read sees
+    the new file) and on `load_post` (so a stale handle doesn't survive a
+    .blend reload)."""
+    for path in list(_CACHE.keys()):
+        _close_archive(path)
+
+
+def delete_archive(scene: bpy.types.Scene) -> bool:
+    """Drop the on-disk temperature archive for this .blend.
+
+    Used by the Reset Simulation operator and by tab-switch auto-reset to
+    abandon accumulated incremental state. Closes any cached mmap handle
+    first so Windows can replace the file. Best-effort — missing archive
+    isn't an error. Returns True iff a file was actually deleted.
+    """
+    archive_dir = _archive_dir_for_blend()
+    if archive_dir is None:
+        archive_dir = _archive_dir_fallback(getattr(scene, "name", "default"))
+    archive_path = os.path.join(archive_dir, ARCHIVE_FILENAME)
+    manifest_path = os.path.join(archive_dir, MANIFEST_FILENAME)
+    _close_archive(archive_path)
+    deleted = False
+    for p in (archive_path, manifest_path):
+        try:
+            if os.path.isfile(p):
+                os.remove(p)
+                deleted = True
+        except Exception as e:
+            _log.debug(f"[HeatSim] WARNING: failed to delete {p}: {e}")
+    return deleted
+
+
+# ---------------------------------------------------------------------------
+# Irradiance cache (sidecar) — used by static + incremental so click 2+
+# can reuse the per-vertex flux from click 1's bake instead of paying the
+# Cycles bake cost every click. The cache stores per-object (N_obj,) flux
+# arrays keyed by obj.name. It is invalidated by Reset Simulation and by
+# tab-switch auto-reset.
+# ---------------------------------------------------------------------------
+
+
+def _irradiance_cache_path(scene: bpy.types.Scene) -> str:
+    """Absolute path to the sidecar irradiance cache for this .blend."""
+    archive_dir = _archive_dir_for_blend()
+    if archive_dir is None:
+        archive_dir = _archive_dir_fallback(getattr(scene, "name", "default"))
+    return os.path.join(archive_dir, IRRADIANCE_CACHE_FILENAME)
+
+
+def write_irradiance_cache(
+    scene: bpy.types.Scene,
+    per_object_irradiance: dict[str, np.ndarray],
+) -> Optional[str]:
+    """Write per-object surface flux arrays (W/mm² per vertex) to the
+    sidecar cache. Called once per fresh static-incremental run so
+    subsequent Run clicks can skip the Cycles bake.
+
+    `per_object_irradiance`: maps `obj.name` -> 1D float32 array of length
+    `num_surface_vertices` for that object. Empty dict is a no-op.
+    """
+    if not per_object_irradiance:
+        return None
+    archive_dir = _archive_dir_for_blend()
+    if archive_dir is None:
+        archive_dir = _archive_dir_fallback(getattr(scene, "name", "default"))
+    try:
+        os.makedirs(archive_dir, exist_ok=True)
+    except Exception as e:
+        _log.debug(f"[HeatSim] WARNING: cannot create archive dir for irradiance cache: {e}")
+        return None
+    path = os.path.join(archive_dir, IRRADIANCE_CACHE_FILENAME)
+    arrays = {
+        name: np.asarray(arr, dtype=np.float32).reshape(-1)
+        for name, arr in per_object_irradiance.items()
+    }
+    tmp_path = path + ".tmp"
+    try:
+        with open(tmp_path, "wb") as fh:
+            np.savez(fh, **arrays)
+        os.replace(tmp_path, path)
+        return path
+    except Exception as e:
+        _log.debug(f"[HeatSim] WARNING: failed to write irradiance cache {path}: {e}")
+        try:
+            if os.path.isfile(tmp_path):
+                os.remove(tmp_path)
+        except Exception:
+            pass
+        return None
+
+
+def read_irradiance_cache(scene: bpy.types.Scene) -> Optional[dict[str, np.ndarray]]:
+    """Load the per-object flux arrays cached by ``write_irradiance_cache``.
+    Returns ``None`` if no cache exists. Returns a fresh dict (not mmap-backed
+    — these arrays are tiny, ~24 KB / 6 k verts / object)."""
+    archive_dir = _archive_dir_for_blend()
+    if archive_dir is None:
+        archive_dir = _archive_dir_fallback(getattr(scene, "name", "default"))
+    path = os.path.join(archive_dir, IRRADIANCE_CACHE_FILENAME)
+    if not os.path.isfile(path):
+        return None
+    try:
+        with np.load(path, allow_pickle=False) as npz:
+            return {k: np.array(npz[k], dtype=np.float32) for k in npz.files}
+    except Exception as e:
+        _log.debug(f"[HeatSim] WARNING: failed to read irradiance cache {path}: {e}")
+        return None
+
+
+def delete_irradiance_cache(scene: bpy.types.Scene) -> bool:
+    """Drop the on-disk irradiance cache. Best-effort."""
+    archive_dir = _archive_dir_for_blend()
+    if archive_dir is None:
+        archive_dir = _archive_dir_fallback(getattr(scene, "name", "default"))
+    path = os.path.join(archive_dir, IRRADIANCE_CACHE_FILENAME)
+    if not os.path.isfile(path):
+        return False
+    try:
+        os.remove(path)
+        return True
+    except Exception as e:
+        _log.debug(f"[HeatSim] WARNING: failed to delete irradiance cache {path}: {e}")
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Per-frame bake cache (Phase 2 disk persistence)
+# ---------------------------------------------------------------------------
+#
+# Animate Scene full-run / animate-incremental bakes are persisted to
+# `<blend>.heatsim/latest/bakes/` so they survive .blend save/reload and
+# can be read back by:
+#   - the next Run with `irradiance_bake_source == USE_CACHED` (skip Cycles)
+#   - the View Flux follow-timeline handler (display the nearest-earlier
+#     cached bake on every frame change)
+#
+# Layout:
+#   bakes/index.json    — sorted list of cached frame numbers + per-bake
+#                         metadata (bake_mode, per-object texture sizes)
+#   bakes/<frame>.npz   — keys: "<obj_name>__irradiance",
+#                         "<obj_name>__albedo" (float32 ndarray (H, W, 3))
+#
+# A per-frame npz is the unit of write/read, atomic via tmp+rename. A
+# partial bake (ADAPTIVE re-bakes only some objects) writes only those
+# objects' keys; reads return whatever keys are present.
+
+
+def _bakes_dir(scene: bpy.types.Scene) -> str:
+    """Absolute path to the bakes/ directory for this .blend (created on demand)."""
+    archive_dir = _archive_dir_for_blend()
+    if archive_dir is None:
+        archive_dir = _archive_dir_fallback(getattr(scene, "name", "default"))
+    return os.path.join(archive_dir, BAKES_DIRNAME)
+
+
+def _bakes_index_path(scene: bpy.types.Scene) -> str:
+    return os.path.join(_bakes_dir(scene), BAKES_INDEX_FILENAME)
+
+
+def _bakes_frame_path(scene: bpy.types.Scene, frame: int) -> str:
+    return os.path.join(_bakes_dir(scene), f"{int(frame)}.npz")
+
+
+def read_bake_index(scene: bpy.types.Scene) -> Optional[dict]:
+    """Load `bakes/index.json`. Returns None if the cache directory doesn't
+    exist or the index is unreadable."""
+    path = _bakes_index_path(scene)
+    if not os.path.isfile(path):
+        return None
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception as e:
+        _log.debug(f"[HeatSim] WARNING: failed to read bake index {path}: {e}")
+        return None
+
+
+def _write_bake_index(scene: bpy.types.Scene, idx: dict) -> bool:
+    """Atomic-write bakes/index.json."""
+    bdir = _bakes_dir(scene)
+    try:
+        os.makedirs(bdir, exist_ok=True)
+    except Exception as e:
+        _log.debug(f"[HeatSim] WARNING: cannot create bakes dir {bdir}: {e}")
+        return False
+    path = _bakes_index_path(scene)
+    tmp_path = path + ".tmp"
+    try:
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            json.dump(idx, f, indent=2)
+        os.replace(tmp_path, path)
+        return True
+    except Exception as e:
+        _log.debug(f"[HeatSim] WARNING: failed to write bake index {path}: {e}")
+        try:
+            if os.path.isfile(tmp_path):
+                os.remove(tmp_path)
+        except Exception:
+            pass
+        return False
+
+
+def write_frame_bake(
+    scene: bpy.types.Scene,
+    frame: int,
+    per_object_textures: dict[str, dict[str, Optional[np.ndarray]]],
+    *,
+    bake_mode: str,
+    texture_sizes: dict[str, int],
+) -> Optional[str]:
+    """Write one frame's per-object bake to disk and update the index.
+
+    `per_object_textures`: ``{obj.name: {"irradiance": (H,W,3) float32,
+    "albedo": (H,W,3) float32 or None}, ...}``. Albedo None is allowed
+    and the key is simply skipped.
+
+    `bake_mode`: PER_OBJECT or SHARED (recorded in the index for
+    read-time mismatch detection).
+
+    `texture_sizes`: per-object pixel size of the bake (recorded in the
+    index for read-time size-mismatch detection).
+
+    Returns the absolute path of the written npz, or None on failure
+    (disk-full, unsaved .blend with fallback unwritable, etc.).
+    """
+    if not per_object_textures:
+        return None
+
+    bdir = _bakes_dir(scene)
+    try:
+        os.makedirs(bdir, exist_ok=True)
+    except Exception as e:
+        _log.debug(f"[HeatSim] WARNING: cannot create bakes dir {bdir}: {e}")
+        return None
+
+    arrays: dict[str, np.ndarray] = {}
+    for obj_name, payload in per_object_textures.items():
+        irr = payload.get("irradiance")
+        if irr is not None:
+            arrays[f"{obj_name}__irradiance"] = np.asarray(irr, dtype=np.float32)
+        alb = payload.get("albedo")
+        if alb is not None:
+            arrays[f"{obj_name}__albedo"] = np.asarray(alb, dtype=np.float32)
+    if not arrays:
+        return None
+
+    frame_path = _bakes_frame_path(scene, frame)
+    tmp_path = frame_path + ".tmp"
+    try:
+        with open(tmp_path, "wb") as fh:
+            np.savez(fh, **arrays)
+        os.replace(tmp_path, frame_path)
+    except Exception as e:
+        _log.debug(f"[HeatSim] WARNING: failed to write frame bake {frame_path}: {e}")
+        try:
+            if os.path.isfile(tmp_path):
+                os.remove(tmp_path)
+        except Exception:
+            pass
+        return None
+
+    # Update / merge index.
+    idx = read_bake_index(scene) or {}
+    frames = sorted(set(int(f) for f in idx.get("frames", [])) | {int(frame)})
+    objects = sorted(set(idx.get("objects", [])) | set(per_object_textures.keys()))
+    sizes = dict(idx.get("texture_sizes", {}))
+    sizes.update({k: int(v) for k, v in texture_sizes.items()})
+    idx_new = {
+        "frames": frames,
+        "objects": objects,
+        "bake_mode": str(bake_mode).upper(),
+        "texture_sizes": sizes,
+        "written_at_utc": _now_utc_iso(),
+    }
+    _write_bake_index(scene, idx_new)
+    return frame_path
+
+
+def read_frame_bake(
+    scene: bpy.types.Scene,
+    frame: int,
+) -> Optional[dict[str, dict[str, np.ndarray]]]:
+    """Load one frame's bake from disk. Returns
+    ``{obj_name: {"irradiance": ndarray, "albedo": ndarray or None}, ...}``
+    or None if the file doesn't exist."""
+    path = _bakes_frame_path(scene, frame)
+    if not os.path.isfile(path):
+        return None
+    try:
+        with np.load(path, allow_pickle=False) as npz:
+            files = list(npz.files)
+            out: dict[str, dict[str, np.ndarray]] = {}
+            for k in files:
+                if "__" not in k:
+                    continue
+                obj_name, _, kind = k.partition("__")
+                if kind not in ("irradiance", "albedo"):
+                    continue
+                arr = np.array(npz[k], dtype=np.float32)
+                out.setdefault(obj_name, {"irradiance": None, "albedo": None})[kind] = arr
+            return out or None
+    except Exception as e:
+        _log.debug(f"[HeatSim] WARNING: failed to read frame bake {path}: {e}")
+        return None
+
+
+def find_nearest_earlier_baked_frame(
+    scene: bpy.types.Scene,
+    frame: int,
+) -> Optional[int]:
+    """Return the largest cached frame ≤ `frame`, or the smallest cached
+    frame if all cached frames are > `frame` (so the viewer never sees
+    blank when scrubbing before the earliest bake). Returns None if the
+    cache is empty or the index is unreadable."""
+    idx = read_bake_index(scene)
+    if not idx:
+        return None
+    frames = sorted(int(f) for f in idx.get("frames", []))
+    if not frames:
+        return None
+    # Filter out frames whose npz is actually missing on disk (e.g. user
+    # manually deleted some) — trust the file system as authoritative.
+    extant = [f for f in frames if os.path.isfile(_bakes_frame_path(scene, f))]
+    if not extant:
+        return None
+    candidates = [f for f in extant if f <= int(frame)]
+    if candidates:
+        return candidates[-1]
+    return extant[0]
+
+
+def delete_bakes(scene: bpy.types.Scene) -> int:
+    """Remove the entire bakes/ directory. Returns the number of files
+    deleted (incl. index.json). Best-effort — missing directory is fine."""
+    bdir = _bakes_dir(scene)
+    if not os.path.isdir(bdir):
+        return 0
+    deleted = 0
+    try:
+        for entry in os.listdir(bdir):
+            p = os.path.join(bdir, entry)
+            try:
+                if os.path.isfile(p):
+                    os.remove(p)
+                    deleted += 1
+            except Exception as e:
+                _log.debug(f"[HeatSim] WARNING: failed to delete {p}: {e}")
+        try:
+            os.rmdir(bdir)
+        except OSError:
+            # Directory not empty (some unexpected file) — leave it.
+            pass
+    except Exception as e:
+        _log.debug(f"[HeatSim] WARNING: failed to clear bakes dir {bdir}: {e}")
+    return deleted
+
+
+# ---------------------------------------------------------------------------
+# Direct-Kernel disk caches
+# ---------------------------------------------------------------------------
+#
+# The Direct-Kernel irradiance source bypasses the Cycles bake but still
+# produces two reusable artifacts per object:
+#
+#   - Per-vertex absorbed flux (W/m²) per simulated frame, stored under
+#     `<blend>.heatsim/latest/kernel_bakes/<frame>.npz`. Used by the
+#     View Flux follow-timeline handler so the user can scrub the
+#     timeline and see the baked direct-kernel flux at each frame
+#     without re-running the kernel.
+#   - Per-vertex grayscale albedo (one-shot Cycles bake reduced to a
+#     scalar), stored under `<blend>.heatsim/latest/albedo_cache.npz`.
+#     Reused on every kernel run; invalidated only by Reset Simulation
+#     or source switch.
+#
+# Both caches are atomically written via tmp+rename and best-effort —
+# disk-full / unsaved-blend failures log and swallow.
+
+
+def _kernel_bakes_dir(scene: bpy.types.Scene) -> str:
+    """Absolute path to the kernel_bakes/ directory for this .blend."""
+    archive_dir = _archive_dir_for_blend()
+    if archive_dir is None:
+        archive_dir = _archive_dir_fallback(getattr(scene, "name", "default"))
+    return os.path.join(archive_dir, KERNEL_BAKES_DIRNAME)
+
+
+def _kernel_bake_frame_path(scene: bpy.types.Scene, frame: int) -> str:
+    return os.path.join(_kernel_bakes_dir(scene), f"{int(frame)}.npz")
+
+
+def _kernel_albedo_path(scene: bpy.types.Scene) -> str:
+    archive_dir = _archive_dir_for_blend()
+    if archive_dir is None:
+        archive_dir = _archive_dir_fallback(getattr(scene, "name", "default"))
+    return os.path.join(archive_dir, KERNEL_ALBEDO_FILENAME)
+
+
+def write_kernel_frame_bake(
+    scene: bpy.types.Scene,
+    frame: int,
+    per_object_flux: dict[str, np.ndarray],
+) -> Optional[str]:
+    """Persist one frame's direct-kernel absorbed flux (W/m² per vertex)
+    to disk. Returns the file path, or None on failure."""
+    if not per_object_flux:
+        return None
+    bdir = _kernel_bakes_dir(scene)
+    try:
+        os.makedirs(bdir, exist_ok=True)
+    except Exception as e:
+        _log.debug(f"[HeatSim] WARNING: cannot create kernel_bakes dir {bdir}: {e}")
+        return None
+    arrays = {
+        name: np.asarray(arr, dtype=np.float32).reshape(-1)
+        for name, arr in per_object_flux.items()
+    }
+    if not arrays:
+        return None
+    path = _kernel_bake_frame_path(scene, frame)
+    tmp_path = path + ".tmp"
+    try:
+        with open(tmp_path, "wb") as fh:
+            np.savez(fh, **arrays)
+        os.replace(tmp_path, path)
+        return path
+    except Exception as e:
+        _log.debug(f"[HeatSim] WARNING: failed to write kernel frame bake {path}: {e}")
+        try:
+            if os.path.isfile(tmp_path):
+                os.remove(tmp_path)
+        except Exception:
+            pass
+        return None
+
+
+def read_kernel_frame_bake(
+    scene: bpy.types.Scene,
+    frame: int,
+) -> Optional[dict[str, np.ndarray]]:
+    """Load one frame's direct-kernel flux from disk, or None if absent."""
+    path = _kernel_bake_frame_path(scene, frame)
+    if not os.path.isfile(path):
+        return None
+    try:
+        with np.load(path, allow_pickle=False) as npz:
+            return {k: np.array(npz[k], dtype=np.float32) for k in npz.files}
+    except Exception as e:
+        _log.debug(f"[HeatSim] WARNING: failed to read kernel frame bake {path}: {e}")
+        return None
+
+
+def find_nearest_earlier_kernel_frame(
+    scene: bpy.types.Scene,
+    frame: int,
+) -> Optional[int]:
+    """Return the largest cached kernel-bake frame ≤ ``frame``, falling
+    back to the smallest cached frame if none precede ``frame``. Returns
+    None if the kernel cache is empty."""
+    bdir = _kernel_bakes_dir(scene)
+    if not os.path.isdir(bdir):
+        return None
+    extant: list[int] = []
+    try:
+        for entry in os.listdir(bdir):
+            if not entry.endswith(".npz"):
+                continue
+            stem = entry[:-4]
+            try:
+                extant.append(int(stem))
+            except ValueError:
+                continue
+    except Exception:
+        return None
+    if not extant:
+        return None
+    extant.sort()
+    candidates = [f for f in extant if f <= int(frame)]
+    return candidates[-1] if candidates else extant[0]
+
+
+def delete_kernel_bakes(scene: bpy.types.Scene) -> int:
+    """Remove the kernel_bakes/ directory. Returns # files deleted."""
+    bdir = _kernel_bakes_dir(scene)
+    if not os.path.isdir(bdir):
+        return 0
+    deleted = 0
+    try:
+        for entry in os.listdir(bdir):
+            p = os.path.join(bdir, entry)
+            try:
+                if os.path.isfile(p):
+                    os.remove(p)
+                    deleted += 1
+            except Exception as e:
+                _log.debug(f"[HeatSim] WARNING: failed to delete {p}: {e}")
+        try:
+            os.rmdir(bdir)
+        except OSError:
+            pass
+    except Exception as e:
+        _log.debug(f"[HeatSim] WARNING: failed to clear kernel_bakes dir {bdir}: {e}")
+    return deleted
+
+
+def write_kernel_albedo_cache(
+    scene: bpy.types.Scene,
+    per_object_albedo: dict[str, np.ndarray],
+) -> Optional[str]:
+    """Write per-vertex grayscale albedo (one-shot Cycles bake) to disk."""
+    if not per_object_albedo:
+        return None
+    archive_dir = _archive_dir_for_blend()
+    if archive_dir is None:
+        archive_dir = _archive_dir_fallback(getattr(scene, "name", "default"))
+    try:
+        os.makedirs(archive_dir, exist_ok=True)
+    except Exception as e:
+        _log.debug(f"[HeatSim] WARNING: cannot create archive dir for albedo cache: {e}")
+        return None
+    path = _kernel_albedo_path(scene)
+    arrays = {
+        name: np.asarray(arr, dtype=np.float32).reshape(-1)
+        for name, arr in per_object_albedo.items()
+    }
+    tmp_path = path + ".tmp"
+    try:
+        with open(tmp_path, "wb") as fh:
+            np.savez(fh, **arrays)
+        os.replace(tmp_path, path)
+        return path
+    except Exception as e:
+        _log.debug(f"[HeatSim] WARNING: failed to write kernel albedo cache {path}: {e}")
+        try:
+            if os.path.isfile(tmp_path):
+                os.remove(tmp_path)
+        except Exception:
+            pass
+        return None
+
+
+def read_kernel_albedo_cache(scene: bpy.types.Scene) -> Optional[dict[str, np.ndarray]]:
+    """Read the per-vertex albedo cache, or None if absent."""
+    path = _kernel_albedo_path(scene)
+    if not os.path.isfile(path):
+        return None
+    try:
+        with np.load(path, allow_pickle=False) as npz:
+            return {k: np.array(npz[k], dtype=np.float32) for k in npz.files}
+    except Exception as e:
+        _log.debug(f"[HeatSim] WARNING: failed to read kernel albedo cache {path}: {e}")
+        return None
+
+
+def delete_kernel_albedo_cache(scene: bpy.types.Scene) -> bool:
+    """Drop the kernel albedo cache. Best-effort."""
+    path = _kernel_albedo_path(scene)
+    if not os.path.isfile(path):
+        return False
+    try:
+        os.remove(path)
+        return True
+    except Exception as e:
+        _log.debug(f"[HeatSim] WARNING: failed to delete kernel albedo cache {path}: {e}")
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Sky-visibility cache (bent normal + AO) for the Direct Kernel
+# ---------------------------------------------------------------------------
+#
+# Per-object per-vertex Bent Normal (3 floats) + Sky AO (1 scalar). Used
+# by the Direct Kernel to attenuate the SH9 sky term against per-vertex
+# hemispherical visibility. Layout: one npz with keys
+# ``<obj_name>__bent_normal`` (N, 3) float32 and ``<obj_name>__sky_ao``
+# (N,) float32. Invalidated by Reset Simulation, source switch, and
+# whenever animated geometry triggers a sky-visibility rebake.
+
+
+def _sky_visibility_path(scene: bpy.types.Scene) -> str:
+    archive_dir = _archive_dir_for_blend()
+    if archive_dir is None:
+        archive_dir = _archive_dir_fallback(getattr(scene, "name", "default"))
+    return os.path.join(archive_dir, SKY_VISIBILITY_FILENAME)
+
+
+def write_sky_visibility_cache(
+    scene: bpy.types.Scene,
+    per_object: dict[str, dict[str, np.ndarray]],
+) -> Optional[str]:
+    """Persist ``{obj_name: {"bent_normal": (N,3), "ao": (N,)}}`` to disk."""
+    if not per_object:
+        return None
+    archive_dir = _archive_dir_for_blend()
+    if archive_dir is None:
+        archive_dir = _archive_dir_fallback(getattr(scene, "name", "default"))
+    try:
+        os.makedirs(archive_dir, exist_ok=True)
+    except Exception as e:
+        _log.debug(f"[HeatSim] WARNING: cannot create archive dir for sky-vis cache: {e}")
+        return None
+    path = _sky_visibility_path(scene)
+    arrays: dict[str, np.ndarray] = {}
+    for name, payload in per_object.items():
+        bn = payload.get("bent_normal")
+        ao = payload.get("ao")
+        if bn is None or ao is None:
+            continue
+        arrays[f"{name}__bent_normal"] = np.asarray(bn, dtype=np.float32).reshape(-1, 3)
+        arrays[f"{name}__sky_ao"] = np.asarray(ao, dtype=np.float32).reshape(-1)
+    if not arrays:
+        return None
+    tmp_path = path + ".tmp"
+    try:
+        with open(tmp_path, "wb") as fh:
+            np.savez(fh, **arrays)
+        os.replace(tmp_path, path)
+        return path
+    except Exception as e:
+        _log.debug(f"[HeatSim] WARNING: failed to write sky-vis cache {path}: {e}")
+        try:
+            if os.path.isfile(tmp_path):
+                os.remove(tmp_path)
+        except Exception:
+            pass
+        return None
+
+
+def read_sky_visibility_cache(
+    scene: bpy.types.Scene,
+) -> Optional[dict[str, dict[str, np.ndarray]]]:
+    """Load the sky-visibility cache, or None if absent."""
+    path = _sky_visibility_path(scene)
+    if not os.path.isfile(path):
+        return None
+    try:
+        with np.load(path, allow_pickle=False) as npz:
+            files = list(npz.files)
+            out: dict[str, dict[str, np.ndarray]] = {}
+            for k in files:
+                if "__" not in k:
+                    continue
+                obj_name, _, kind = k.partition("__")
+                arr = np.array(npz[k], dtype=np.float32)
+                if kind == "bent_normal":
+                    out.setdefault(obj_name, {})["bent_normal"] = arr
+                elif kind == "sky_ao":
+                    out.setdefault(obj_name, {})["ao"] = arr
+            # Keep only entries that have both arrays.
+            return {k: v for k, v in out.items() if "bent_normal" in v and "ao" in v} or None
+    except Exception as e:
+        _log.debug(f"[HeatSim] WARNING: failed to read sky-vis cache {path}: {e}")
+        return None
+
+
+def delete_sky_visibility_cache(scene: bpy.types.Scene) -> bool:
+    """Drop the sky-visibility cache. Best-effort."""
+    path = _sky_visibility_path(scene)
+    if not os.path.isfile(path):
+        return False
+    try:
+        os.remove(path)
+        return True
+    except Exception as e:
+        _log.debug(f"[HeatSim] WARNING: failed to delete sky-vis cache {path}: {e}")
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Writer
+# ---------------------------------------------------------------------------
+
+
+def write_archive(
+    scene: bpy.types.Scene,
+    per_object_temps: dict[str, np.ndarray],
+    metadata: dict[str, Any],
+    *,
+    mode: str = "replace",
+    replace_existing: Optional[bool] = None,
+) -> Optional[str]:
+    """Write `temperatures.npz` + `manifest.json` and stamp lookup custom
+    properties on each named object in `per_object_temps`.
+
+    `per_object_temps`: maps `obj.name` -> 2D ndarray of shape (T, N), where
+    T is timesteps and N is vertex count for that object. 1D arrays are
+    promoted to (1, N).
+
+    `mode`:
+        - "replace"     overwrite the file with `per_object_temps` only
+        - "merge"       per-key replace: new keys replace, missing keys keep
+                        their old values (used by the disabled-objects pass
+                        in full-run mode)
+        - "append_time" per-key concatenate along axis 0 (time): new arrays
+                        are appended after existing ones (used by incremental
+                        runs to grow the cumulative history)
+
+    `replace_existing` is the legacy bool kwarg. `True` -> "replace",
+    `False` -> "merge". Mapped onto `mode` for backward compat.
+
+    Returns the absolute archive path, or None on failure (e.g. disk-full).
+    """
+    if not per_object_temps:
+        return None
+
+    if replace_existing is not None:
+        mode = "replace" if replace_existing else "merge"
+
+    if mode not in ("replace", "merge", "append_time"):
+        raise ValueError(f"write_archive: unknown mode {mode!r}")
+
+    archive_dir = _archive_dir_for_blend()
+    if archive_dir is None:
+        archive_dir = _archive_dir_fallback(getattr(scene, "name", "default"))
+        _log.debug(
+            f"[HeatSim] WARNING: .blend is unsaved; storing temperatures under "
+            f"{archive_dir}. Save the .blend before closing to keep results."
+        )
+
+    try:
+        os.makedirs(archive_dir, exist_ok=True)
+    except Exception as e:
+        _log.debug(f"[HeatSim] ERROR: cannot create archive dir {archive_dir}: {e}")
+        return None
+
+    archive_path = os.path.join(archive_dir, ARCHIVE_FILENAME)
+    manifest_path = os.path.join(archive_dir, MANIFEST_FILENAME)
+
+    # Pre-load existing arrays for merge/append modes.
+    arrays: dict[str, np.ndarray] = {}
+    if mode in ("merge", "append_time") and os.path.isfile(archive_path):
+        try:
+            # Materialize via np.array so we can close the file before we replace it.
+            with np.load(archive_path, allow_pickle=False) as old:
+                for k in old.files:
+                    arrays[k] = np.array(old[k])
+        except Exception as e:
+            _log.debug(f"[HeatSim] WARNING: failed to read existing archive for {mode}: {e}")
+
+    for name, arr in per_object_temps.items():
+        a = np.asarray(arr, dtype=np.float64)
+        if a.ndim == 1:
+            a = a[None, :]
+        if mode == "append_time" and name in arrays:
+            old = arrays[name]
+            if old.ndim == 1:
+                old = old[None, :]
+            if int(old.shape[1]) != int(a.shape[1]):
+                raise ValueError(
+                    f"write_archive(mode='append_time'): vertex count for "
+                    f"{name!r} drifted ({old.shape[1]} -> {a.shape[1]}); "
+                    f"topology must be stable across incremental clicks."
+                )
+            arrays[name] = np.concatenate([old, a], axis=0)
+        else:
+            arrays[name] = a
+
+    # Close any cached handle on the archive path before overwriting (Windows
+    # mmap'd files can't be replaced while open).
+    _close_archive(archive_path)
+
+    # `np.savez(path, ...)` auto-appends `.npz` to a string path, so we open
+    # the tmp file ourselves and hand it the file object — that bypasses the
+    # rewrite and lets `os.replace` atomically rename the exact path we wrote.
+    tmp_path = archive_path + ".tmp"
+    try:
+        with open(tmp_path, "wb") as fh:
+            np.savez(fh, **arrays)
+        os.replace(tmp_path, archive_path)
+    except Exception as e:
+        _log.debug(f"[HeatSim] ERROR: failed to write archive {archive_path}: {e}")
+        try:
+            if os.path.isfile(tmp_path):
+                os.remove(tmp_path)
+        except Exception:
+            pass
+        return None
+
+    # Manifest sidecar (best-effort; not load-bearing).
+    try:
+        sidecar = dict(metadata)
+        sidecar["objects"] = {name: list(arr.shape) for name, arr in arrays.items()}
+        sidecar["written_at_utc"] = _now_utc_iso()
+        sidecar["blend_path"] = bpy.data.filepath or ""
+        with open(manifest_path, "w", encoding="utf-8") as f:
+            json.dump(sidecar, f, indent=2)
+    except Exception as e:
+        _log.debug(f"[HeatSim] WARNING: failed to write manifest: {e}")
+
+    # Stamp lookup props on objects we just wrote (don't touch unrelated objs).
+    for name in per_object_temps.keys():
+        obj = scene.objects.get(name)
+        if obj is not None:
+            _stamp_object_props(obj, archive_path, name)
+
+    return archive_path
+
+
+# ---------------------------------------------------------------------------
+# Reader
+# ---------------------------------------------------------------------------
+
+
+def _read_legacy(obj: bpy.types.Object) -> Optional[np.ndarray]:
+    """Backwards-compat: read from the old in-blend custom property if no
+    archive resolves. Always allocates (legacy values are Python lists)."""
+    legacy = obj.get("heatsim_temperature_data")
+    if legacy is None:
+        return None
+    arr = np.asarray(legacy, dtype=np.float64)
+    if arr.ndim == 1:
+        arr = arr[None, :]
+    return arr
+
+
+def read_object_history(obj: bpy.types.Object) -> Optional[np.ndarray]:
+    """Return (T, N) history for `obj`, mmap-backed when from an archive.
+    Resolution order: archive (URI -> abspath) -> legacy custom property.
+    Returns None if nothing resolves."""
+    path = _resolve_archive_path(obj)
+    if path is not None:
+        try:
+            npz = _open_archive(path)
+            key = obj.get("heatsim_data_key", "") or obj.name
+            if key not in npz.files:
+                if obj.name in npz.files:
+                    key = obj.name
+                else:
+                    return _read_legacy(obj)
+            return np.asarray(npz[key])
+        except Exception as e:
+            _log.debug(
+                f"[HeatSim] WARNING: failed to read archive at {path}: {e}; "
+                f"falling back to legacy property."
+            )
+    return _read_legacy(obj)
+
+
+def read_object_timestep(
+    obj: bpy.types.Object,
+    t: int,
+    *,
+    clamp_past_end: bool = True,
+) -> Optional[np.ndarray]:
+    """Hot path used by the frame-change handler. Returns the (N,) row at
+    timestep `t`.
+
+    `clamp_past_end=True` (default) clamps `t` to `[0, history.shape[0] - 1]`,
+    so timeline scrubbing past the end shows the last simulated state.
+
+    `clamp_past_end=False` returns None when `t >= history.shape[0]`, leaving
+    it to the caller to render an alternative (e.g. the per-vertex initial
+    map for not-yet-simulated frames in animate-mode incremental runs).
+    Negative t is still clamped to 0 either way.
+    """
+    history = read_object_history(obj)
+    if history is None:
+        return None
+    if history.ndim == 1:
+        return np.asarray(history)
+    n = int(history.shape[0])
+    t_int = int(t)
+    if t_int < 0:
+        t_int = 0
+    if t_int >= n:
+        if clamp_past_end:
+            t_int = n - 1
+        else:
+            return None
+    return np.asarray(history[t_int, :])
+
+
+def has_temperature_data(obj: bpy.types.Object) -> bool:
+    """True if either the archive resolves to a file or the legacy custom
+    property is set. Used by visualization code that wants a presence test
+    without paying the cost of actually loading the data."""
+    if _resolve_archive_path(obj) is not None:
+        return True
+    return "heatsim_temperature_data" in obj
+
+
+def get_num_timesteps(obj: bpy.types.Object) -> int:
+    """Read the metadata custom prop; fall back to history.shape[0]."""
+    v = obj.get("heatsim_num_timesteps")
+    if v is not None:
+        try:
+            return int(v)
+        except Exception:
+            pass
+    h = read_object_history(obj)
+    if h is None:
+        return 0
+    return int(h.shape[0]) if h.ndim == 2 else 1

--- a/visionsim/simulate/heatsim/thermal_shader.py
+++ b/visionsim/simulate/heatsim/thermal_shader.py
@@ -1,0 +1,776 @@
+"""Thermal AOV + gray-body radiance shader support for visionsim.
+
+Provides four entry points consumed by the thermal render pipeline:
+
+* :func:`setup_temperature_aov`      — register a ``temperature`` value AOV on a view-layer
+                                       and append ``Attribute → ShaderNodeOutputAOV`` to
+                                       every material; returns the compositor socket name.
+* :func:`enter_thermal_scene`        — swap scene to gray-body emission materials, disable
+                                       lights, set a gray world; returns a restore state dict.
+* :func:`restore_scene`              — undo :func:`enter_thermal_scene` from the state dict.
+* :func:`stamp_default_temperatures` — stamp per-object ``heatsim_default_temperature``
+                                       OBJECT-domain custom properties as a shader fallback.
+
+Port of heat-sim-blender ``addon/lib/visualization.py`` (@ 543ee81) into visionsim
+conventions: guarded ``bpy`` import, rich logger, Google-style docstrings, ruff 121 chars.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from visionsim.simulate.heatsim.constants import ATLAS_COVERAGE_PROP, ATLAS_IMAGE_NAME, ATLAS_UV_LAYER_NAME
+
+try:
+    import bpy  # type: ignore
+except ImportError:
+    bpy = None  # type: ignore
+
+_log = logging.getLogger("rich")
+
+# Stefan-Boltzmann constant (SI, W/m²·K⁴).  Used as a magnitude knob × radiance_scale
+# in the shader.  Do NOT unify with the solver σ (constants.py uses mm-scaled W/mm²·K⁴).
+_SIGMA_SI: float = 5.670374419e-8
+
+# Defaults used when the scene provides no overrides.
+_DEFAULT_EMISSIVITY: float = 0.9
+_AMBIENT_K: float = 295.372
+_THERMAL_WORLD_NAME: str = "HeatSim_Thermal_World"
+
+# Keys inside the opaque state dict returned by enter_thermal_scene.
+# Object types that render geometry and can therefore carry a material patched with the
+# temperature AOV chain. Only MESH supports the per-vertex `sim_temperature` attribute; the
+# rest rely entirely on the stamped object-level default (see stamp_default_temperatures).
+_RENDERABLE_GEOMETRY_TYPES: frozenset[str] = frozenset({"MESH", "CURVE", "SURFACE", "META", "FONT"})
+
+_KEY_WORLD: str = "orig_world"
+_KEY_MATERIALS: str = "orig_materials"
+_KEY_LIGHT_HIDE_RENDER: str = "light_hide_render"
+_KEY_LIGHT_HIDE_VIEWPORT: str = "light_hide_viewport"
+_KEY_CLAMP: str = "orig_sample_clamp"
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_temperature_source_chain(nodes: Any, links: Any, new_node: Any = None, x0: float = -800.0, y0: float = 300.0) -> Any:
+    """Build the shared temperature-source node chain: today's per-vertex
+    ``sim_temperature`` -> ``heatsim_default_temperature`` fallback chain, extended with an
+    optional texture-atlas sample mixed in by validity.
+
+    This is the single place both the gray-body radiance shader (:func:`_build_gray_body_material`)
+    and the ``temperature`` AOV (:func:`_append_temperature_aov_nodes`) read ``T_effective``
+    from, per the design spec's "extend at the source" requirement -- both consumers benefit
+    from the atlas without duplicating the mix logic.
+
+    Vertex-path chain (unchanged from before the atlas existed)::
+
+        T_vertex = default_T + (sim_temperature > 1) * (sim_temperature - default_T)
+
+    Atlas extension::
+
+        UVMap("HeatSim_Atlas_UV") -> ImageTexture(HeatSim_Temperature_Atlas, Non-Color,
+            Linear, CLIP) -> SeparateColor.Red = atlas temperature (Kelvin)
+        gate = ImageTexture.Alpha * Attribute(OBJECT, ATLAS_COVERAGE_PROP).Fac
+        T_effective = Mix(Factor=gate, A=T_vertex, B=atlas temperature)
+
+    ``gate`` is an explicit product of two independent zero-by-default signals: the atlas's
+    own per-texel validity (its alpha channel) AND an OBJECT-domain custom property this
+    module's callers stamp 1.0/0.0 on atlas-participant/non-participant meshes
+    (``adapter.write_frame_attributes``). Multiplying both in is deliberate belt-and-suspenders:
+    an object with no ``HeatSim_Atlas_UV`` UV layer at all makes the Attribute node fall back to
+    its type default ``(0, 0, 0)``, which samples the atlas image's origin texel -- if that
+    happened to be valid (alpha=1, real coverage for some OTHER object's tile), gating on alpha
+    alone would leak that neighbour's temperature onto this unrelated object. Gating on the
+    object-level property too keeps the mix factor exactly 0 for any non-participant regardless
+    of what pixel (0, 0) contains, and it is exactly 0 for every mesh whenever ``render_domain``
+    is ``"VERTEX"`` (the atlas is never built, so the property is never stamped and defaults to
+    0), which is what keeps that mode byte-identical to before the atlas existed.
+
+    Args:
+        nodes: The material node tree's ``.nodes`` collection.
+        links: The material node tree's ``.links`` collection.
+        new_node: Node-creation callable (``nodes.new`` by default); callers that need to
+            track newly-added nodes for rollback (see :func:`_append_temperature_aov_nodes`)
+            pass their own wrapper.
+        x0: X location of the leftmost (vertex-path) nodes.
+        y0: Y location of the vertex-path attribute nodes; the atlas extension is laid out
+            below it (more negative Y) so the two chains don't visually overlap.
+
+    Returns:
+        The output socket (float ``Value``) carrying the final, per-pixel ``T_effective``.
+    """
+    _new = new_node or nodes.new
+
+    # -- Per-vertex temperature (zero when attribute absent) --------------------
+    temp_attr = _new("ShaderNodeAttribute")
+    temp_attr.attribute_name = "sim_temperature"
+    temp_attr.attribute_type = "GEOMETRY"
+    temp_attr.location = (x0, y0)
+
+    # -- Per-object fallback temperature (stamped by stamp_default_temperatures) -
+    default_temp_attr = _new("ShaderNodeAttribute")
+    default_temp_attr.attribute_name = "heatsim_default_temperature"
+    default_temp_attr.attribute_type = "OBJECT"
+    default_temp_attr.location = (x0, y0 + 200.0)
+
+    # is_valid = sim_temperature > 1.0  (a real physical Kelvin value)
+    temp_is_valid = _new("ShaderNodeMath")
+    temp_is_valid.operation = "GREATER_THAN"
+    temp_is_valid.location = (x0 + 200.0, y0 + 100.0)
+    temp_is_valid.inputs[1].default_value = 1.0
+    links.new(temp_attr.outputs["Fac"], temp_is_valid.inputs[0])
+
+    # delta = sim_temperature - default_T
+    temp_delta = _new("ShaderNodeMath")
+    temp_delta.operation = "SUBTRACT"
+    temp_delta.location = (x0 + 200.0, y0 - 40.0)
+    links.new(temp_attr.outputs["Fac"], temp_delta.inputs[0])
+    links.new(default_temp_attr.outputs["Fac"], temp_delta.inputs[1])
+
+    # scaled = is_valid × delta  (zero when the per-vertex attr is absent)
+    temp_scaled = _new("ShaderNodeMath")
+    temp_scaled.operation = "MULTIPLY"
+    temp_scaled.location = (x0 + 360.0, y0 + 30.0)
+    links.new(temp_is_valid.outputs["Value"], temp_scaled.inputs[0])
+    links.new(temp_delta.outputs["Value"], temp_scaled.inputs[1])
+
+    # T_vertex = default_T + scaled  (= sim_temperature when valid, else default_T)
+    temp_vertex = _new("ShaderNodeMath")
+    temp_vertex.operation = "ADD"
+    temp_vertex.location = (x0 + 520.0, y0 + 130.0)
+    links.new(default_temp_attr.outputs["Fac"], temp_vertex.inputs[0])
+    links.new(temp_scaled.outputs["Value"], temp_vertex.inputs[1])
+
+    # -- Atlas extension: UV -> Image Texture -> (Red, Alpha) --------------------
+    atlas_uv_attr = _new("ShaderNodeAttribute")
+    atlas_uv_attr.attribute_name = ATLAS_UV_LAYER_NAME
+    atlas_uv_attr.attribute_type = "GEOMETRY"
+    atlas_uv_attr.location = (x0, y0 - 260.0)
+
+    atlas_tex = _new("ShaderNodeTexImage")
+    atlas_tex.image = bpy.data.images.get(ATLAS_IMAGE_NAME) if bpy is not None else None
+    atlas_tex.interpolation = "Linear"
+    atlas_tex.extension = "CLIP"
+    if atlas_tex.image is not None:
+        try:
+            atlas_tex.image.colorspace_settings.name = "Non-Color"
+        except Exception:  # pragma: no cover - defensive, mirrors irradiance.py's style
+            pass
+    atlas_tex.location = (x0 + 200.0, y0 - 260.0)
+    links.new(atlas_uv_attr.outputs["Vector"], atlas_tex.inputs["Vector"])
+
+    atlas_red = _new("ShaderNodeSeparateColor")
+    atlas_red.location = (x0 + 420.0, y0 - 200.0)
+    links.new(atlas_tex.outputs["Color"], atlas_red.inputs["Color"])
+
+    # gate = atlas alpha (this texel's own validity) × object-level atlas-participant flag
+    atlas_gate_attr = _new("ShaderNodeAttribute")
+    atlas_gate_attr.attribute_name = ATLAS_COVERAGE_PROP
+    atlas_gate_attr.attribute_type = "OBJECT"
+    atlas_gate_attr.location = (x0 + 200.0, y0 - 420.0)
+
+    # The atlas alpha is a hard {0, 1} validity mask, but the image is sampled with Linear
+    # interpolation (and CLIP, which returns (0,0,0,0) outside a tile), so at a valid ->
+    # invalid boundary BOTH the colour and the alpha blend toward zero at the same rate.
+    # A half-blended texel then yields a half-open gate over a half-darkened temperature:
+    #
+    #     T_valid = 296.2 K (a=1) beside an invalid texel (T=0, a=0)
+    #       -> sampled Red = 148.1 K, sampled alpha = 0.50
+    #       -> Mix(Factor=0.50, A=295.37, B=148.1) = 221.7 K
+    #
+    # which is below the 295 K solve floor. Measured on visionsim50/kitchen1: 2665 such
+    # pixels in one frame (they vanish entirely under render_domain=VERTEX). Thresholding
+    # the alpha back to {0, 1} keeps the gate categorical: a texel is either valid --
+    # sample the atlas -- or it is not, and we fall back to the object-level vertex path
+    # rather than blending a partially-zeroed colour into the result.
+    atlas_alpha_valid = _new("ShaderNodeMath")
+    atlas_alpha_valid.operation = "GREATER_THAN"
+    atlas_alpha_valid.location = (x0 + 300.0, y0 - 340.0)
+    atlas_alpha_valid.inputs[1].default_value = 0.5
+    links.new(atlas_tex.outputs["Alpha"], atlas_alpha_valid.inputs[0])
+
+    atlas_gate = _new("ShaderNodeMath")
+    atlas_gate.operation = "MULTIPLY"
+    atlas_gate.location = (x0 + 420.0, y0 - 380.0)
+    links.new(atlas_alpha_valid.outputs["Value"], atlas_gate.inputs[0])
+    links.new(atlas_gate_attr.outputs["Fac"], atlas_gate.inputs[1])
+
+    # T_effective = Mix(Factor=gate, A=T_vertex, B=atlas temperature)
+    mix = _new("ShaderNodeMix")
+    mix.data_type = "FLOAT"
+    mix.location = (x0 + 680.0, y0 - 100.0)
+    links.new(atlas_gate.outputs["Value"], mix.inputs["Factor"])
+    links.new(temp_vertex.outputs["Value"], mix.inputs["A"])
+    links.new(atlas_red.outputs["Red"], mix.inputs["B"])
+
+    return mix.outputs["Result"]
+
+
+def _build_emissivity_source_chain(nodes: Any, links: Any, x0: float, y0: float) -> Any:
+    """Per-vertex emissivity socket, falling back to ``_DEFAULT_EMISSIVITY``.
+
+    ``adapter._write_emissivity_attr`` stamps an ``emissivity`` POINT attribute on every
+    object it writes back (both the per-vertex path and the constant-fill fallback), from
+    the sidecar's per-slot presets where one is supplied. A mesh that never went through
+    the solve has no such attribute, and Blender returns 0.0 for a missing float
+    attribute -- which would mean "perfect mirror, emits nothing". So a value of exactly
+    0 is treated as absent and replaced by the default.
+
+    Emissivity is what an LWIR camera actually distinguishes: the preset library spans
+    0.05 (polished aluminium) to 0.98 (skin), and at 350 K that is the difference between
+    42 and 750 W/m^2 emitted from surfaces at the same physical temperature. Baking one
+    constant into the mix factor made every material in the scene radiate identically.
+
+    Returns:
+        The output socket (float ``Value``) carrying the effective per-pixel emissivity.
+    """
+    eps_attr = nodes.new("ShaderNodeAttribute")
+    eps_attr.attribute_name = "emissivity"
+    eps_attr.attribute_type = "GEOMETRY"
+    eps_attr.location = (x0, y0)
+
+    # is_valid = emissivity > 0  (a missing attribute reads as 0.0)
+    eps_valid = nodes.new("ShaderNodeMath")
+    eps_valid.operation = "GREATER_THAN"
+    eps_valid.location = (x0 + 200.0, y0 + 100.0)
+    eps_valid.inputs[1].default_value = 0.0
+    links.new(eps_attr.outputs["Fac"], eps_valid.inputs[0])
+
+    # delta = emissivity - default
+    eps_delta = nodes.new("ShaderNodeMath")
+    eps_delta.operation = "SUBTRACT"
+    eps_delta.location = (x0 + 200.0, y0 - 40.0)
+    links.new(eps_attr.outputs["Fac"], eps_delta.inputs[0])
+    eps_delta.inputs[1].default_value = _DEFAULT_EMISSIVITY
+
+    # effective = default + is_valid * delta   (branch-free select)
+    eps_eff = nodes.new("ShaderNodeMath")
+    eps_eff.operation = "MULTIPLY_ADD"
+    eps_eff.location = (x0 + 400.0, y0)
+    links.new(eps_delta.outputs["Value"], eps_eff.inputs[0])
+    links.new(eps_valid.outputs["Value"], eps_eff.inputs[1])
+    eps_eff.inputs[2].default_value = _DEFAULT_EMISSIVITY
+
+    # Clamp to [0, 1]; a sidecar cannot produce an out-of-range value, but a hand-edited
+    # attribute could, and a negative mix factor is meaningless.
+    eps_clamped = nodes.new("ShaderNodeClamp")
+    eps_clamped.location = (x0 + 600.0, y0)
+    eps_clamped.inputs["Min"].default_value = 0.0
+    eps_clamped.inputs["Max"].default_value = 1.0
+    links.new(eps_eff.outputs["Value"], eps_clamped.inputs["Value"])
+    return eps_clamped.outputs["Result"]
+
+
+def _build_gray_body_material(radiance_scale: float) -> Any:
+    """Create (or return a cached) gray-body emission material for thermal rendering.
+
+    Shader graph — gray-body Kirchhoff (ε + ρ = 1) with Stefan-Boltzmann T⁴ emission:
+
+        T_eff ─→ POWER(4) ─→ MUL(σ) ─→ MUL(radiance_scale) ─→ Emission(Color=1, Str)─┐
+                                                                                        ├─ Mix(Fac=1-ε) ─→ Out
+                                                               Diffuse(Color=1, R=0) ──┘
+
+    ``T_eff`` is read from per-vertex ``sim_temperature`` (falling back to the per-object
+    ``heatsim_default_temperature`` custom property when the attribute is absent).
+    Emissivity is read per-vertex from the ``emissivity`` attribute, falling back to
+    ``_DEFAULT_EMISSIVITY`` where that attribute is absent.
+
+    Args:
+        radiance_scale: Scalar multiplier after σ·T⁴ — tune this to adjust rendered
+            radiance brightness relative to physical W/m² magnitudes.
+
+    Returns:
+        A ``bpy.types.Material`` configured for gray-body thermal rendering.
+    """
+    mat_name = f"HeatSim_ThermalShader_vs_{radiance_scale:.6g}"
+    existing = bpy.data.materials.get(mat_name)
+    if existing is not None:
+        return existing
+
+    mat = bpy.data.materials.new(name=mat_name)
+    mat.use_nodes = True
+    nodes = mat.node_tree.nodes
+    links = mat.node_tree.links
+    nodes.clear()
+
+    # -- Temperature source: vertex path + atlas mix (see _build_temperature_source_chain) --
+    temp_effective_socket = _build_temperature_source_chain(nodes, links, x0=-800.0, y0=300.0)
+
+    # -- Stefan-Boltzmann T⁴ chain ---------------------------------------------
+    temp_pow4 = nodes.new("ShaderNodeMath")
+    temp_pow4.operation = "POWER"
+    temp_pow4.location = (-100.0, 430.0)
+    temp_pow4.inputs[1].default_value = 4.0
+    links.new(temp_effective_socket, temp_pow4.inputs[0])
+
+    sigma_mul = nodes.new("ShaderNodeMath")
+    sigma_mul.operation = "MULTIPLY"
+    sigma_mul.location = (80.0, 430.0)
+    sigma_mul.inputs[1].default_value = _SIGMA_SI
+    links.new(temp_pow4.outputs["Value"], sigma_mul.inputs[0])
+
+    scale_mul = nodes.new("ShaderNodeMath")
+    scale_mul.operation = "MULTIPLY"
+    scale_mul.location = (260.0, 430.0)
+    scale_mul.inputs[1].default_value = float(radiance_scale)
+    links.new(sigma_mul.outputs["Value"], scale_mul.inputs[0])
+
+    # -- Gray-body shader: Mix(Fac=1-ε, Emission, Diffuse) ----------------------
+    # Cycles Mix Shader: out = (1-Fac)·A + Fac·B
+    # With Fac=1-ε, A=Emission, B=Diffuse: out = ε·σT⁴·scale + (1-ε)·L_in  ✓
+    emission = nodes.new("ShaderNodeEmission")
+    emission.location = (440.0, 430.0)
+    emission.inputs["Color"].default_value = (1.0, 1.0, 1.0, 1.0)
+    links.new(scale_mul.outputs["Value"], emission.inputs["Strength"])
+
+    diffuse = nodes.new("ShaderNodeBsdfDiffuse")
+    diffuse.location = (440.0, 200.0)
+    diffuse.inputs["Color"].default_value = (1.0, 1.0, 1.0, 1.0)
+    diffuse.inputs["Roughness"].default_value = 0.0  # Lambertian
+
+    # Fac = 1 - ε so the Emission slot gets weight ε and Diffuse gets weight 1-ε.
+    # ε is per-vertex, not a scene-wide constant -- see _build_emissivity_source_chain.
+    eps_socket = _build_emissivity_source_chain(nodes, links, x0=-800.0, y0=-260.0)
+    one_minus_eps = nodes.new("ShaderNodeMath")
+    one_minus_eps.operation = "SUBTRACT"
+    one_minus_eps.location = (440.0, 60.0)
+    one_minus_eps.inputs[0].default_value = 1.0
+    links.new(eps_socket, one_minus_eps.inputs[1])
+
+    mix_shader = nodes.new("ShaderNodeMixShader")
+    mix_shader.location = (640.0, 340.0)
+    mix_shader.inputs["Fac"].default_value = 1.0 - _DEFAULT_EMISSIVITY
+    links.new(one_minus_eps.outputs["Value"], mix_shader.inputs["Fac"])
+    links.new(emission.outputs["Emission"], mix_shader.inputs[1])
+    links.new(diffuse.outputs["BSDF"], mix_shader.inputs[2])
+
+    out = nodes.new("ShaderNodeOutputMaterial")
+    out.location = (840.0, 340.0)
+    links.new(mix_shader.outputs["Shader"], out.inputs["Surface"])
+
+    mat["heatsim_thermal_radiance_scale"] = float(radiance_scale)
+    mat["heatsim_thermal_default_emissivity"] = _DEFAULT_EMISSIVITY
+    return mat
+
+
+def _append_temperature_aov_nodes(mat: Any, aov_name: str) -> None:
+    """Append a temperature value chain → ``ShaderNodeOutputAOV(aov_name)`` to *mat*.
+
+    The AOV mirrors the gray-body shader's is-valid/default blend rather than wiring
+    ``sim_temperature`` straight through: where the per-vertex ``sim_temperature``
+    attribute is missing/invalid (≤ 1 K) the AOV reports the per-object
+    ``heatsim_default_temperature`` instead of 0 K, so ``temperature/`` and
+    ``thermal_radiance/`` agree for un-simulated meshes.
+
+        T_eff = default_T + (sim_temperature > 1) · (sim_temperature − default_T)
+
+    Idempotent: skips materials that already have an OutputAOV node with the same name.
+    """
+    nodes = mat.node_tree.nodes
+    links = mat.node_tree.links
+
+    # Skip if already wired.
+    for node in nodes:
+        if node.type == "OUTPUT_AOV" and (getattr(node, "aov_name", None) == aov_name or node.name == aov_name):
+            return
+
+    # Track nodes we add so we can clean up on a mid-build failure.
+    added: list[Any] = []
+
+    def _new(node_type: str) -> Any:
+        node = nodes.new(node_type)
+        added.append(node)
+        return node
+
+    try:
+        # -- Temperature source: vertex path + atlas mix (see _build_temperature_source_chain) --
+        temp_effective_socket = _build_temperature_source_chain(nodes, links, new_node=_new, x0=-600.0, y0=-400.0)
+
+        # -- First-hit gate -----------------------------------------------------
+        # Cycles accumulates a value AOV at *every* shading event along the path,
+        # weighted by throughput. A Transparent BSDF has throughput 1, so alpha-cut
+        # foliage (e.g. kitchen1's `hojas`, a MixShader over a TransparentBSDF) makes
+        # a camera ray shade one leaf after another and the AOV SUMS their
+        # temperatures: measured 2103 K on a scene whose hottest source is 350 K,
+        # with the pixel values landing on integer multiples of the leaf temperature
+        # (254 px at 2x, 57 at 3x, 16 at 4x ...). Gate on Transparent Depth == 0 so
+        # only the first surface contributes and the AOV stays a *surface*
+        # temperature, bounded by the solve.
+        #
+        # Trade-off: where a ray passes through the transparent part of a cut-out
+        # texture, the AOV reports that surface rather than the geometry behind it.
+        # That is the documented meaning of the pass ("per-pixel surface
+        # temperature") and is strictly better than an unbounded sum.
+        light_path = _new("ShaderNodeLightPath")
+        light_path.location = (-600.0, -700.0)
+
+        first_hit = _new("ShaderNodeMath")
+        first_hit.operation = "LESS_THAN"
+        first_hit.location = (-400.0, -700.0)
+        first_hit.inputs[1].default_value = 0.5
+        links.new(light_path.outputs["Transparent Depth"], first_hit.inputs[0])
+
+        gated = _new("ShaderNodeMath")
+        gated.operation = "MULTIPLY"
+        gated.location = (700.0, -400.0)
+        links.new(temp_effective_socket, gated.inputs[0])
+        links.new(first_hit.outputs["Value"], gated.inputs[1])
+        temp_effective_socket = gated.outputs["Value"]
+
+        aov_node = _new("ShaderNodeOutputAOV")
+    except Exception as exc:
+        _log.debug("Could not build temperature AOV chain on %r: %s", mat.name, exc)
+        for node in added:
+            try:
+                nodes.remove(node)
+            except Exception:
+                pass
+        return
+
+    aov_node.name = aov_name
+    if hasattr(aov_node, "aov_name"):
+        try:
+            aov_node.aov_name = aov_name
+        except Exception:
+            pass
+    aov_node.location = (940.0, -400.0)
+
+    sock = aov_node.inputs.get("Value") or (aov_node.inputs[0] if aov_node.inputs else None)
+    if sock is not None:
+        try:
+            links.new(temp_effective_socket, sock)
+        except Exception as exc:
+            _log.debug("Could not link AOV socket on %r: %s", mat.name, exc)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+_DEFAULT_SURFACE_MATERIAL_NAME = "HeatSim_Default_Surface"
+
+
+def _get_default_surface_material() -> Any:
+    """A stand-in for Blender's implicit default surface, shared across the scene.
+
+    A freshly created node-based material is already Blender's default look — a
+    Principled BSDF at 0.8 grey, roughness 0.5 — which is exactly what Cycles draws
+    for a mesh with no material. Assigning it therefore leaves the RGB pass looking
+    the same while giving the surface a node tree the temperature AOV can hang off.
+    """
+    mat = bpy.data.materials.get(_DEFAULT_SURFACE_MATERIAL_NAME)
+    if mat is None:
+        mat = bpy.data.materials.new(_DEFAULT_SURFACE_MATERIAL_NAME)
+        mat.use_nodes = True
+    return mat
+
+
+def _ensure_temperature_material_slots(obj: Any) -> int:
+    """Give ``obj`` a material wherever it has none, returning how many were filled.
+
+    A value AOV is emitted by shader nodes, so a mesh with no material — or with an
+    empty slot — has nothing to write the ``temperature`` pass and renders as 0 K even
+    though the solver produced a temperature for it. kitchen1's ``Vert.005`` is exactly
+    this: 36 vertices, a valid ``sim_temperature`` attribute, and no material slot at
+    all, so it came out solid black.
+
+    Faces on an empty slot render with the default surface too, so those are filled in
+    place rather than only handling the zero-slot case.
+    """
+    mesh = getattr(obj, "data", None)
+    if mesh is None or not hasattr(mesh, "materials"):
+        return 0
+    try:
+        if len(obj.material_slots) == 0:
+            mesh.materials.append(_get_default_surface_material())
+            return 1
+        filled = 0
+        for slot in obj.material_slots:
+            if slot.material is None:
+                slot.material = _get_default_surface_material()
+                filled += 1
+        return filled
+    except Exception as exc:  # pragma: no cover - library-linked / non-editable meshes
+        _log.warning("thermal: could not assign a default surface to %r: %s", obj.name, exc)
+        return 0
+
+
+def setup_temperature_aov(scene: Any, view_layer: Any) -> str:
+    """Register a ``temperature`` value AOV on *view_layer* and wire it into scene materials.
+
+    For every mesh material in the scene, appends an
+    ``Attribute("sim_temperature") → ShaderNodeOutputAOV("temperature")`` chain so that
+    Cycles writes raw temperature values into the AOV render pass.
+
+    Args:
+        scene: The Blender scene (``bpy.types.Scene``).
+        view_layer: The view layer on which to register the AOV (``bpy.types.ViewLayer``).
+
+    Returns:
+        The compositor socket name ``"temperature"`` — wire this to the
+        ``CompositorNodeOutputFile`` input for the temperature render pass.
+    """
+    aov_name = "temperature"
+
+    # 1. Register the AOV on the view layer (idempotent).
+    existing_names: set[str] = set()
+    try:
+        existing_names = {a.name for a in view_layer.aovs}
+    except Exception:
+        pass
+
+    if aov_name not in existing_names:
+        try:
+            aov = view_layer.aovs.add()
+            aov.name = aov_name
+            if hasattr(aov, "type"):
+                try:
+                    aov.type = "VALUE"
+                except Exception:
+                    try:
+                        aov.type = "FLOAT"
+                    except Exception:
+                        pass
+        except Exception as exc:
+            _log.warning("Could not register temperature AOV on view layer: %s", exc)
+
+    # 2. Append Attribute → OutputAOV chain to every material-using mesh in the scene.
+    #    Meshes with no usable material get one first, else they have no shader to carry
+    #    the AOV and Cycles renders them as 0 K (see _ensure_temperature_material_slots).
+    patched = 0
+    filled = 0
+    for obj in scene.objects:
+        if obj.type != "MESH":
+            continue
+        filled += _ensure_temperature_material_slots(obj)
+        for slot in obj.material_slots:
+            mat = slot.material
+            if mat is None or not mat.use_nodes:
+                continue
+            _append_temperature_aov_nodes(mat, aov_name)
+            patched += 1
+
+    _log.debug(
+        "setup_temperature_aov: AOV %r registered; %d material slot(s) patched, %d filled with the default surface",
+        aov_name, patched, filled,
+    )
+    return aov_name
+
+
+def enter_thermal_scene(scene: Any, *, radiance_scale: float) -> dict:
+    """Swap *scene* into thermal rendering state for a gray-body radiance pass.
+
+    Replaces every mesh object's materials with the gray-body emission material,
+    hides all light objects from render, and sets a uniform-background thermal world.
+    Returns an opaque state dict; pass it to :func:`restore_scene` to undo all changes.
+
+    Args:
+        scene: The Blender scene.
+        radiance_scale: Multiplier applied after σ·T⁴; controls the brightness of the
+            rendered radiance image relative to physical W/m² values.
+
+    Returns:
+        An opaque state dict for passing to :func:`restore_scene`.
+
+    Note:
+        Self-restoring: the ``state`` dict is populated *as* the scene is mutated,
+        and any exception mid-swap (e.g. ``materials.clear()`` raising on
+        library-linked/overridden mesh data) triggers a full :func:`restore_scene`
+        rollback before the error is re-raised.  This guarantees the scene is never
+        left half-swapped even though the caller has not yet received ``state``.
+    """
+    state: dict[str, Any] = {}
+
+    # Bind the (mutable) record containers into ``state`` up-front so a rollback
+    # during the loops below sees everything recorded so far.
+    orig_materials: dict[str, list[Any]] = {}
+    hide_render: dict[str, bool] = {}
+    hide_viewport: dict[str, bool] = {}
+    state[_KEY_MATERIALS] = orig_materials
+    state[_KEY_LIGHT_HIDE_RENDER] = hide_render
+    state[_KEY_LIGHT_HIDE_VIEWPORT] = hide_viewport
+
+    try:
+        thermal_mat = _build_gray_body_material(radiance_scale)
+
+        # -- Save per-object material assignments and swap to thermal material --
+        # Record AFTER clear() succeeds: if clear() raises on a non-editable mesh
+        # the object is left untouched and is (correctly) not in the restore map,
+        # so the rollback never double-clears it.
+        for obj in scene.objects:
+            if obj.type != "MESH":
+                continue
+            mat_names = [slot.material.name if slot.material else None for slot in obj.material_slots]
+            obj.data.materials.clear()
+            orig_materials[obj.name] = mat_names
+            obj.data.materials.append(thermal_mat)
+
+        # -- Save and disable all lights (hide from render + viewport) ----------
+        for obj in scene.objects:
+            if obj.type == "LIGHT":
+                hide_render[obj.name] = bool(obj.hide_render)
+                hide_viewport[obj.name] = bool(obj.hide_viewport)
+                obj.hide_render = True
+                obj.hide_viewport = True
+
+
+        # -- Disable sample clamping for the gray-body pass ---------------------
+        # The scene's Cycles clamps were authored for its RGB render, where pixel
+        # values are O(1). This pass is radiometric: it renders eps*sigma*T^4, which
+        # for a 300 K surface is ~500 and for a 450 K surface ~2300. A clamp tuned for
+        # the beauty render therefore truncates the physics.
+        #
+        # Measured on visionsim50/classroom (sample_clamp_direct = 5.5): every pixel
+        # collapsed to ~15 regardless of its solved temperature -- pixels at 350 K+ read
+        # 15.58 where sigma*T^4 demands 1170, a 75x shortfall, and the image went flat
+        # (p1-p99 of 14.86-15.84 across a field spanning 295-384 K). kitchen1 is correct
+        # only by luck: its sample_clamp_direct is already 0.
+        #
+        # Emission seen straight down the camera ray is a DIRECT sample, so the direct
+        # clamp is the damaging one; the indirect clamp is disabled too because the
+        # (1-eps)*L_in reflection term is genuinely indirect and equally out of scale.
+        # Both are saved and restored by restore_scene().
+        cy = getattr(scene, "cycles", None)
+        if cy is not None:
+            saved_clamp: dict[str, Any] = {}
+            for attr in ("sample_clamp_direct", "sample_clamp_indirect"):
+                if hasattr(cy, attr):
+                    saved_clamp[attr] = getattr(cy, attr)
+                    try:
+                        setattr(cy, attr, 0.0)  # 0 == disabled in Cycles
+                    except Exception as exc:  # pragma: no cover - read-only build
+                        _log.debug("Could not clear cycles.%s: %s", attr, exc)
+                        saved_clamp.pop(attr, None)
+            if saved_clamp:
+                _log.info("thermal: cleared Cycles sample clamps for the radiance pass (%s)",
+                          ", ".join(f"{k}={v}" for k, v in saved_clamp.items()))
+            state[_KEY_CLAMP] = saved_clamp
+
+        # -- Save world and replace with a uniform gray thermal world -----------
+        orig_world = scene.world
+        state[_KEY_WORLD] = orig_world.name if orig_world is not None else None
+
+        # The world is what the gray body's (1 - eps) term reflects, so it must be a
+        # RADIANCE in the same units the emission term produces -- sigma*T_amb^4 scaled by
+        # radiance_scale -- not the ambient temperature itself. Emitting `_AMBIENT_K`
+        # (295.372) directly mixed a Kelvin value into a radiance image. That was a ~4%
+        # error while emissivity was pinned at 0.9, and dominates once a low-emissivity
+        # surface is rendered: at eps=0.05 the reflected term is 95% of the pixel.
+        #
+        # The name carries radiance_scale for the same reason the material's does: the
+        # world is cached by name, so two scales must not share one datablock.
+        _ambient_radiance = _SIGMA_SI * (_AMBIENT_K**4) * float(radiance_scale)
+        world_name = f"{_THERMAL_WORLD_NAME}_vs_{radiance_scale:.6g}"
+        thermal_world = bpy.data.worlds.get(world_name)
+        if thermal_world is None:
+            thermal_world = bpy.data.worlds.new(world_name)
+            thermal_world.use_nodes = True
+            wnodes = thermal_world.node_tree.nodes
+            wlinks = thermal_world.node_tree.links
+            wnodes.clear()
+            bg = wnodes.new("ShaderNodeBackground")
+            bg.inputs["Color"].default_value = (1.0, 1.0, 1.0, 1.0)
+            bg.inputs["Strength"].default_value = _ambient_radiance
+            wout = wnodes.new("ShaderNodeOutputWorld")
+            wlinks.new(bg.outputs["Background"], wout.inputs["Surface"])
+        scene.world = thermal_world
+    except Exception:
+        # Roll back every change recorded so far, then re-raise so the caller sees
+        # the original failure (with the scene already restored, not half-swapped).
+        restore_scene(scene, state)
+        raise
+
+    return state
+
+
+def restore_scene(scene: Any, state: dict) -> None:
+    """Restore *scene* to the state captured by :func:`enter_thermal_scene`.
+
+    Args:
+        scene: The Blender scene (must be the same scene passed to
+            :func:`enter_thermal_scene`).
+        state: The opaque dict returned by :func:`enter_thermal_scene`.
+    """
+    # -- Restore per-object materials ------------------------------------------
+    orig_materials: dict[str, list[Any]] = state.get(_KEY_MATERIALS, {})
+    for obj in scene.objects:
+        if obj.type != "MESH":
+            continue
+        saved = orig_materials.get(obj.name)
+        if saved is None:
+            continue
+        obj.data.materials.clear()
+        for mat_name in saved:
+            mat = bpy.data.materials.get(mat_name) if mat_name else None
+            obj.data.materials.append(mat)
+
+    # -- Restore Cycles sample clamps -------------------------------------------
+    cy = getattr(scene, "cycles", None)
+    if cy is not None:
+        for attr, value in (state.get(_KEY_CLAMP, {}) or {}).items():
+            try:
+                setattr(cy, attr, value)
+            except Exception as exc:  # pragma: no cover
+                _log.debug("Could not restore cycles.%s: %s", attr, exc)
+
+    # -- Restore light visibility -----------------------------------------------
+    hide_render: dict[str, bool] = state.get(_KEY_LIGHT_HIDE_RENDER, {})
+    hide_viewport: dict[str, bool] = state.get(_KEY_LIGHT_HIDE_VIEWPORT, {})
+    for obj in scene.objects:
+        if obj.type == "LIGHT":
+            if obj.name in hide_render:
+                obj.hide_render = hide_render[obj.name]
+            if obj.name in hide_viewport:
+                obj.hide_viewport = hide_viewport[obj.name]
+
+    # -- Restore world ----------------------------------------------------------
+    orig_world_name = state.get(_KEY_WORLD)
+    if orig_world_name is not None:
+        w = bpy.data.worlds.get(orig_world_name)
+        if w is not None:
+            scene.world = w
+    elif _KEY_WORLD in state:
+        # World was None before enter_thermal_scene.
+        scene.world = None  # type: ignore[assignment]
+
+
+def stamp_default_temperatures(scene: Any, *, default_K: float) -> None:
+    """Stamp the ``heatsim_default_temperature`` custom property on every mesh object.
+
+    The gray-body emission shader reads this as a fallback temperature wherever the
+    per-vertex ``sim_temperature`` attribute is absent (objects not participating in
+    the FEM solve, or fluid meshes regenerated each frame by Mantaflow).  Cheap to
+    call every frame.
+
+    Args:
+        scene: The Blender scene.
+        default_K: Fallback temperature in Kelvin to stamp on all mesh objects.
+    """
+    t = float(default_K)
+    for obj in scene.objects:
+        # Stamp every object that can RENDER with a patched material, not just meshes.
+        # Materials are shared datablocks: a CURVE/SURFACE/META/FONT object sharing a
+        # material with a mesh gets the temperature AOV chain patched into it by
+        # setup_temperature_aov, but a MESH-only guard here left it with neither
+        # `sim_temperature` (per-vertex, meshes only) nor this default, so BOTH
+        # ShaderNodeAttribute reads fell back to their type default 0 and the object
+        # rendered as T_effective = 0 K.
+        #
+        # Measured on visionsim50/kitchen1: `IVY_Curve` (type CURVE, visible, sharing
+        # material "MADERA BANQUETAS" with real meshes) rendered at 0 K. Being thin, almost
+        # none of its footprint is interior, so Cycles' reconstruction filter smeared those
+        # zeros into neighbouring fully-covered pixels -- 729 of the frame's 3394 sub-295 K
+        # pixels, including every extreme value (hiding the curve raised the frame minimum
+        # from 31.3 K to 224.4 K).
+        #
+        # Non-meshes cannot carry the per-vertex attribute, so the default is all they get:
+        # they render at ambient instead of absolute zero, which is correct for geometry
+        # that never took part in the solve.
+        if obj.type not in _RENDERABLE_GEOMETRY_TYPES:
+            continue
+        obj["heatsim_default_temperature"] = t

--- a/visionsim/simulate/heatsim/uv_utils.py
+++ b/visionsim/simulate/heatsim/uv_utils.py
@@ -1,0 +1,102 @@
+"""UV state snapshot/restore.
+
+Extracted from heat-sim-blender's ``addon/lib/irradiance.py`` @ e5b4afe and trimmed to the
+helpers visionsim uses. Not a verbatim copy, so it is linted and type-checked like the
+rest of the package rather than carrying the vendored exemption.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Optional
+
+import bpy
+
+UVState = tuple[Optional[str], Optional[str]]  # (active_uv_name, active_render_uv_name)
+UVSnapshot = list[tuple["bpy.types.Object", UVState]]
+
+
+def get_uv_state(obj: bpy.types.Object) -> UVState:
+    """Return (active_uv_name, active_render_uv_name) for a mesh object."""
+    if obj is None or obj.type != "MESH":
+        return (None, None)
+    mesh = getattr(obj, "data", None)
+    if mesh is None or not getattr(mesh, "uv_layers", None):
+        return (None, None)
+
+    active = mesh.uv_layers.active.name if mesh.uv_layers.active else None
+    render = None
+    for uv in mesh.uv_layers:
+        if getattr(uv, "active_render", False):
+            render = uv.name
+            break
+    if render is None:
+        render = active
+    return (active, render)
+
+
+def _set_active_uv(mesh: bpy.types.Mesh, uv_name: str | None) -> None:
+    if not mesh or not getattr(mesh, "uv_layers", None) or not uv_name:
+        return
+    if uv_name not in mesh.uv_layers:
+        return
+    try:
+        mesh.uv_layers[uv_name].active = True
+    except Exception:
+        # Some Blender versions are finicky; fall back to active_index.
+        try:
+            mesh.uv_layers.active_index = list(mesh.uv_layers).index(mesh.uv_layers[uv_name])
+        except Exception:
+            pass
+
+
+def _set_render_uv(mesh: bpy.types.Mesh, uv_name: str | None) -> None:
+    if not mesh or not getattr(mesh, "uv_layers", None) or not uv_name:
+        return
+    if uv_name not in mesh.uv_layers:
+        return
+    try:
+        for uv in mesh.uv_layers:
+            if getattr(uv, "active_render", None) is not None:
+                uv.active_render = False
+        mesh.uv_layers[uv_name].active_render = True
+    except Exception:
+        # If active_render isn't supported, ignore.
+        pass
+
+
+def set_uv_state(obj: bpy.types.Object, state: UVState) -> None:
+    """Set active/render UV for a mesh object, if the UV names exist."""
+    if obj is None or obj.type != "MESH":
+        return
+    mesh = getattr(obj, "data", None)
+    if mesh is None or not getattr(mesh, "uv_layers", None):
+        return
+    active_name, render_name = state
+    if active_name:
+        _set_active_uv(mesh, active_name)
+    if render_name:
+        _set_render_uv(mesh, render_name)
+
+
+def snapshot_uv_states(objects: Iterable[bpy.types.Object]) -> UVSnapshot:
+    """Capture UV state for objects (only MESH objects with UV layers)."""
+    snap: UVSnapshot = []
+    for obj in objects:
+        if obj is None or obj.type != "MESH":
+            continue
+        mesh = getattr(obj, "data", None)
+        if mesh is None or not getattr(mesh, "uv_layers", None) or len(mesh.uv_layers) == 0:
+            continue
+        snap.append((obj, get_uv_state(obj)))
+    return snap
+
+
+def restore_uv_states(snapshot: UVSnapshot) -> None:
+    """Restore a previously-captured UV snapshot."""
+    for obj, state in snapshot:
+        try:
+            set_uv_state(obj, state)
+        except Exception:
+            # Never crash callers for a best-effort restore.
+            pass

--- a/visionsim/simulate/install.py
+++ b/visionsim/simulate/install.py
@@ -48,6 +48,19 @@ if __name__ == "__main__":
     print(f"Blender Python executable: {sys.executable}", flush=True)
     print(f"Blender Python path: {sys.path}", flush=True)
 
+    # torch wheel source is platform-specific.  On Linux/Windows we pull the GPU
+    # build from the cu124 index (matches NVIDIA driver >=520 / CUDA 12.x; adjust the
+    # index URL for other drivers, e.g. cu118 for older cards).  macOS has no cu124
+    # wheels, so we install the default wheel there (MPS/CPU) - otherwise pip would
+    # fail to resolve and (with check=True) abort the whole post-install.
+    if sys.platform == "darwin":
+        torch_cmd = base_cmd + ["pip", "install", "torch"]
+    else:
+        torch_cmd = base_cmd + ["pip", "install", "torch", "--index-url", "https://download.pytorch.org/whl/cu124"]
+
+    # NOTE: the core visionsim install precedes the torch/scipy/robust_laplacian
+    # step so that a torch/index hiccup can never block the base package setup
+    # (scipy/robust_laplacian are not on the PyTorch index, so they go via PyPI).
     commands = [
         base_cmd + ["ensurepip"],
         base_cmd + ["pip", "install", "-U", "pip"],
@@ -55,6 +68,8 @@ if __name__ == "__main__":
         base_cmd
         + ["pip", "install", "--no-warn-script-location", "--force-reinstall", "--no-dependencies", "--verbose"]
         + module_spec,
+        torch_cmd,
+        base_cmd + ["pip", "install", "scipy", "robust_laplacian"],
     ]
 
     try:

--- a/visionsim/simulate/job.py
+++ b/visionsim/simulate/job.py
@@ -77,6 +77,9 @@ def render_job(
         client.include_specular_pass(**asdict(config.specular_pass))
     if config.include_points:
         client.include_points(**asdict(config.points))
+    if config.include_thermal:
+        client.prepare_thermal(**asdict(config.thermal))
+        client.include_thermal(**asdict(config.thermal))
 
     if config.unbind_camera:
         client.unbind_camera()

--- a/visionsim/simulate/nodes/__init__.py
+++ b/visionsim/simulate/nodes/__init__.py
@@ -2,3 +2,4 @@ from .colorize import colorize_indices_node_group  # noqa: F401
 from .flow import flow_preview_node_group, vec2rgba_node_group  # noqa: F401
 from .normals import normal_preview_node_group  # noqa: F401
 from .points import point_preview_node_group  # noqa: F401
+from .thermal import thermal_preview_node_group  # noqa: F401

--- a/visionsim/simulate/nodes/thermal.py
+++ b/visionsim/simulate/nodes/thermal.py
@@ -1,0 +1,101 @@
+# NOTE: This needs to be imported by blender to work properly.
+
+# Inferno colormap stop data sourced verbatim from heat-sim-blender's
+# scripts/post/_exr_io.py ``_INFERNO_STOPS`` (matplotlib inferno sampled at 11
+# even t values), so the preview matches heat-sim's rendered To/thermal PNGs.
+
+from __future__ import annotations
+
+import bpy  # type: ignore
+
+from .common import MAPRANGE_NODE, new_socket, set_clamp
+
+
+def thermal_preview_node_group(tmin: float = 295.0, tmax: float = 400.0) -> bpy.types.NodeTree:
+    """Compositor node group mapping a scalar temperature (K) to an inferno-coloured RGB image.
+
+    Structure: ``Temperature`` float INPUT → MapRange([tmin, tmax] → [0, 1]) →
+    ``ShaderNodeValToRGB`` with inferno colour stops → ``Image`` colour OUTPUT.
+
+    The inferno stops match heat-sim-blender's colormap. heat-sim treats the LUT
+    output as scene-linear and sRGB-encodes it before writing the PNG; the caller
+    (``include_thermal``) reproduces that by rendering this group's output through
+    the ``Standard`` (sRGB) view transform rather than the preview default ``Raw``.
+
+    Args:
+        tmin: Minimum temperature in Kelvin — maps to the cool (near-black) end of inferno.
+        tmax: Maximum temperature in Kelvin — maps to the hot (bright yellow) end of inferno.
+
+    Returns:
+        A ``CompositorNodeTree`` named ``"ThermalPreview"``.
+    """
+    ng = bpy.data.node_groups.new(type="CompositorNodeTree", name="ThermalPreview")
+
+    if bpy.app.version >= (4, 3, 0):
+        ng.default_group_node_width = 140
+
+    # -- Sockets -----------------------------------------------------------------
+    # Output first so the interface order matches the socket panel.
+    new_socket(ng, name="Image", in_out="OUTPUT", socket_type="NodeSocketColor")
+    new_socket(ng, name="Temperature", in_out="INPUT", socket_type="NodeSocketFloat")
+
+    # -- Nodes -------------------------------------------------------------------
+    group_input = ng.nodes.new("NodeGroupInput")
+    group_input.name = "Group Input"
+
+    group_output = ng.nodes.new("NodeGroupOutput")
+    group_output.name = "Group Output"
+    group_output.is_active_output = True
+
+    # MapRange: Temperature (K) → [0, 1]
+    map_range = ng.nodes.new(MAPRANGE_NODE)
+    map_range.name = "TempNormalize"
+    set_clamp(map_range, True)
+    map_range.inputs[1].default_value = float(tmin)   # From Min
+    map_range.inputs[2].default_value = float(tmax)   # From Max
+    map_range.inputs[3].default_value = 0.0           # To Min
+    map_range.inputs[4].default_value = 1.0           # To Max
+
+    # Inferno colour ramp (ShaderNodeValToRGB is correct for the Blender ≥5.0 compositor).
+    color_ramp = ng.nodes.new("ShaderNodeValToRGB")
+    color_ramp.name = "InfernoRamp"
+    ramp = color_ramp.color_ramp
+    ramp.interpolation = "LINEAR"
+
+    # Inferno colormap stops — verbatim from heat-sim-blender _exr_io._INFERNO_STOPS
+    # (matplotlib inferno at 11 even positions 0.0, 0.1, …, 1.0).
+    _inferno_stops = [
+        (0.00, (0.00146, 0.00047, 0.01387, 1.0)),  # near-black
+        (0.10, (0.08741, 0.04456, 0.22481, 1.0)),  # deep purple
+        (0.20, (0.25823, 0.03857, 0.40648, 1.0)),  # purple
+        (0.30, (0.41633, 0.09020, 0.43294, 1.0)),  # magenta
+        (0.40, (0.57830, 0.14804, 0.40441, 1.0)),  # red-magenta
+        (0.50, (0.73568, 0.21591, 0.33025, 1.0)),  # red
+        (0.60, (0.86501, 0.31682, 0.22606, 1.0)),  # red-orange
+        (0.70, (0.95451, 0.46874, 0.09987, 1.0)),  # orange
+        (0.80, (0.98762, 0.64532, 0.03989, 1.0)),  # amber
+        (0.90, (0.96439, 0.84385, 0.27339, 1.0)),  # yellow
+        (1.00, (0.98836, 0.99836, 0.64492, 1.0)),  # pale yellow
+    ]
+
+    # Mirror colorize_indices_node_group: clear existing, resize, then fill.
+    while len(ramp.elements) < len(_inferno_stops):
+        ramp.elements.new(0.5)
+    while len(ramp.elements) > len(_inferno_stops):
+        ramp.elements.remove(ramp.elements[-1])
+    for i, (pos, color) in enumerate(_inferno_stops):
+        ramp.elements[i].position = pos
+        ramp.elements[i].color = color
+
+    # -- Locations ---------------------------------------------------------------
+    group_input.location = (-300.0, 0.0)
+    map_range.location = (-100.0, 0.0)
+    color_ramp.location = (150.0, 0.0)
+    group_output.location = (500.0, 0.0)
+
+    # -- Links -------------------------------------------------------------------
+    ng.links.new(group_input.outputs[0], map_range.inputs[0])
+    ng.links.new(map_range.outputs[0], color_ramp.inputs[0])
+    ng.links.new(color_ramp.outputs[0], group_output.inputs[0])
+
+    return ng


### PR DESCRIPTION
## Summary

Adds a **thermal simulation modality**: a finite-element heat solver over Blender scene
geometry, plus two new render passes that expose its result to the dataset pipeline.

Enabled with `--config.include-thermal`, a render now emits, alongside the existing `frames/`:

| pass | units | contents |
|---|---|---|
| `temperature/` | Kelvin | per-pixel surface temperature, 32-bit EXR |
| `thermal_radiance/` | W·m⁻²·sr⁻¹ | gray-body exitance, 32-bit EXR |

The solver assigns per-object material properties (conductivity, density, specific heat,
emissivity) from a per-scene JSON sidecar, builds a Laplacian over the mesh, and integrates
the heat equation with cross-object conduction. Radiance is then rendered from the solved
temperature field.

This is additive: **47 files added, 14 modified, 0 deleted**. Nothing outside the thermal
path changes behaviour when `--config.include-thermal` is off (the default).

## What's included

- **Solver** (`visionsim/simulate/heatsim/`) — cotangent and point-cloud Laplacians, FEM
  assembly, PCG solve, material assignment from sidecars.
- **Two render domains** — `VERTEX` (per-vertex attribute, default) and `TEXEL` (temperature
  atlas, for meshes too coarse to resolve gradients per-vertex).
- **Two irradiance sources** — `DIRECT_KERNEL` (analytic; lights + SH9 sky, default) and
  `CYCLES_BAKE` (bakes diffuse direct+indirect, higher fidelity, slower).
- **Gray-body radiance shader** — each surface emits `ε·σT⁴` and reflects `(1−ε)` of the
  path-traced incident radiance, so a cool surface facing a hot one picks it up.
- **Five scene sidecars** for visionsim50 (`bathroom1`, `classroom`, `diningroom`,
  `kitchen1`, `officebuilding`) and a helper to draft new ones.
- **Docs** — `docs/source/sections/blender/thermal.rst` covers the domains, irradiance
  sources, sidecar schema and material preset library.

Solver code is vendored from the `heat-sim-blender` addon @ `e5b4afe` and adapted.


**178 thermal tests**, all passing, including regression cover for three bugs found during
development (evaluated-mesh divergence, albedo lookup, ambient radiance).

## New dependencies

`torch` (cu124 on Linux/Windows), `scipy` and `robust_laplacian` are installed into
Blender's bundled Python by `visionsim/simulate/install.py`. The torch index is handled
separately so a failure there cannot block base package setup.

## Known limitations

- **Only exercised on Blender 5.2.1 / Linux.** The code uses version-tolerant socket lookups
  rather than `bpy.app.version` guards, but has not been run against 3.6 or 4.5, or on
  Windows. This PR is a draft partly so CI can establish that.
- The `(1−ε)` reflection is **Lambertian, not specular** — correct energy from a hot
  neighbour, but no mirror image. Fine for diffuse surfaces, wrong for polished metal.
- Ray bounce counts are inherited from the `.blend` rather than set by the thermal pass.
- **Transient only.** The solver time-marches from an initial condition; there is no
  direct equilibrium solve. A scene that should start already settled has to be warmed up
  by simulating it, rather than solved for in one shot.
- `adapter.py` is 2051 lines and wants splitting. Deliberately deferred to keep this PR's
  diff reviewable.
- `TEXEL` domain shows ~2.3 K of mottling on some meshes, under investigation.

## Review notes

Seven commits, ordered so each is independently readable. 

<!-- readthedocs-preview visionsim start -->
----
📚 Documentation preview 📚: https://visionsim--32.org.readthedocs.build/en/32/

<!-- readthedocs-preview visionsim end -->